### PR TITLE
feat: database schema and migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,38 @@ jobs:
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run build
+
+  migrations:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: smartscrape
+          POSTGRES_PASSWORD: smartscrape
+          POSTGRES_DB: smartscrape
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U smartscrape -d smartscrape"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      DATABASE_URL: postgresql://smartscrape:smartscrape@localhost:5432/smartscrape
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Run migrations up
+        run: npm run migrate:up --workspace server
+      - name: Migrations down (reverse each migration)
+        run: |
+          for _ in 1 2 3 4; do
+            npm run migrate:down --workspace server
+          done
+      - name: Re-apply migrations
+        run: npm run migrate:up --workspace server

--- a/package-lock.json
+++ b/package-lock.json
@@ -1116,6 +1116,15 @@
       "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
       "license": "MIT"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1685,7 +1694,7 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1695,7 +1704,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -2073,11 +2082,19 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2184,7 +2201,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2259,7 +2275,6 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2449,6 +2464,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -2462,7 +2491,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2475,7 +2503,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -2542,7 +2569,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2678,6 +2704,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -2763,7 +2795,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3268,6 +3299,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3334,6 +3381,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3382,6 +3438,30 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -3603,6 +3683,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3630,8 +3719,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/jiti": {
       "version": "1.21.7",
@@ -3939,7 +4042,6 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -3949,6 +4051,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -4002,6 +4113,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-pg-migrate": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/node-pg-migrate/-/node-pg-migrate-8.0.4.tgz",
+      "integrity": "sha512-HTlJ6fOT/2xHhAUtsqSN85PGMAqSbfGJNRwQF8+ZwQ1+sVGNUTl/ZGEshPsOI3yV22tPIyHXrKXr3S0JxeYLrg==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "~11.1.0",
+        "yargs": "~17.7.0"
+      },
+      "bin": {
+        "node-pg-migrate": "bin/node-pg-migrate.js"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      },
+      "peerDependencies": {
+        "@types/pg": ">=6.0.0 <9.0.0",
+        "pg": ">=4.3.0 <9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/pg": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {
@@ -4224,6 +4360,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4260,7 +4402,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4272,6 +4413,31 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
@@ -4838,6 +5004,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -5072,7 +5247,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5085,7 +5259,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5176,6 +5349,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5208,6 +5393,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -5480,7 +5691,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -6121,7 +6332,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6143,6 +6353,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -6152,12 +6379,48 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -6179,6 +6442,7 @@
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "ioredis": "^5.4.2",
+        "node-pg-migrate": "^8.0.4",
         "pg": "^8.13.1"
       },
       "devDependencies": {

--- a/server/migrations/20260424000001_users_and_auth.js
+++ b/server/migrations/20260424000001_users_and_auth.js
@@ -1,0 +1,65 @@
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+
+export const up = (pgm) => {
+  pgm.sql(`
+    CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+    -- Generic trigger that keeps updated_at current on row updates.
+    CREATE OR REPLACE FUNCTION set_updated_at()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      NEW.updated_at = now();
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+
+    CREATE TABLE users (
+      id                   UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      email                TEXT        UNIQUE NOT NULL,
+      password_hash        TEXT        NOT NULL,
+      name                 TEXT,
+      email_verified       BOOLEAN     NOT NULL DEFAULT false,
+      verification_token   TEXT,
+      reset_token          TEXT,
+      reset_token_expires  TIMESTAMPTZ,
+      telegram_chat_id     TEXT,
+      created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE INDEX users_verification_token_idx
+      ON users (verification_token)
+      WHERE verification_token IS NOT NULL;
+
+    CREATE INDEX users_reset_token_idx
+      ON users (reset_token)
+      WHERE reset_token IS NOT NULL;
+
+    CREATE TRIGGER users_set_updated_at
+      BEFORE UPDATE ON users
+      FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+    CREATE TABLE refresh_tokens (
+      id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id     UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      token_hash  TEXT        NOT NULL,
+      expires_at  TIMESTAMPTZ NOT NULL,
+      revoked     BOOLEAN     NOT NULL DEFAULT false,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE UNIQUE INDEX refresh_tokens_token_hash_uidx ON refresh_tokens (token_hash);
+    CREATE INDEX refresh_tokens_user_id_idx ON refresh_tokens (user_id);
+    CREATE INDEX refresh_tokens_expires_at_idx ON refresh_tokens (expires_at);
+  `);
+};
+
+export const down = (pgm) => {
+  pgm.sql(`
+    DROP TABLE IF EXISTS refresh_tokens;
+    DROP TRIGGER IF EXISTS users_set_updated_at ON users;
+    DROP TABLE IF EXISTS users;
+    DROP FUNCTION IF EXISTS set_updated_at();
+    -- pgcrypto is left installed; other migrations may rely on it.
+  `);
+};

--- a/server/migrations/20260424000002_api_keys.js
+++ b/server/migrations/20260424000002_api_keys.js
@@ -1,0 +1,21 @@
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+
+export const up = (pgm) => {
+  pgm.sql(`
+    CREATE TABLE api_keys (
+      id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id            UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      provider           TEXT        NOT NULL CHECK (provider IN ('openai', 'anthropic', 'openrouter')),
+      api_key_encrypted  TEXT        NOT NULL,
+      is_active          BOOLEAN     NOT NULL DEFAULT true,
+      created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+      UNIQUE (user_id, provider)
+    );
+
+    CREATE INDEX api_keys_user_id_idx ON api_keys (user_id);
+  `);
+};
+
+export const down = (pgm) => {
+  pgm.sql(`DROP TABLE IF EXISTS api_keys;`);
+};

--- a/server/migrations/20260424000003_jobs_runs_and_data.js
+++ b/server/migrations/20260424000003_jobs_runs_and_data.js
@@ -1,0 +1,89 @@
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+
+export const up = (pgm) => {
+  pgm.sql(`
+    CREATE TABLE scrape_jobs (
+      id                   UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id              UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      name                 TEXT        NOT NULL,
+      urls                 JSONB       NOT NULL,
+      extraction_prompt    TEXT        NOT NULL,
+      extraction_schema    JSONB,
+      scrape_method        TEXT        NOT NULL DEFAULT 'auto'
+                             CHECK (scrape_method IN ('auto', 'playwright', 'cheerio')),
+      schedule             TEXT,
+      enabled              BOOLEAN     NOT NULL DEFAULT true,
+      notification_rules   JSONB       NOT NULL DEFAULT '[]'::jsonb,
+      notify_channels      JSONB       NOT NULL DEFAULT '[]'::jsonb,
+      comparison_key       TEXT,
+      ai_provider          TEXT        NOT NULL DEFAULT 'openrouter',
+      ai_model             TEXT        NOT NULL DEFAULT 'gpt-4o-mini',
+      google_sheet_id      TEXT,
+      sheet_tab_name       TEXT,
+      setup_method         TEXT        NOT NULL DEFAULT 'ai'
+                             CHECK (setup_method IN ('ai', 'manual')),
+      last_run_at          TIMESTAMPTZ,
+      created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE INDEX scrape_jobs_user_id_enabled_idx ON scrape_jobs (user_id, enabled);
+    CREATE INDEX scrape_jobs_schedule_idx ON scrape_jobs (schedule) WHERE schedule IS NOT NULL;
+    CREATE INDEX scrape_jobs_last_run_at_idx ON scrape_jobs (last_run_at DESC NULLS LAST);
+
+    CREATE TRIGGER scrape_jobs_set_updated_at
+      BEFORE UPDATE ON scrape_jobs
+      FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+    CREATE TABLE scrape_runs (
+      id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      job_id            UUID        NOT NULL REFERENCES scrape_jobs(id) ON DELETE CASCADE,
+      status            TEXT        NOT NULL
+                          CHECK (status IN ('pending', 'scraping', 'extracting', 'exporting', 'completed', 'failed')),
+      urls_scraped      INTEGER     NOT NULL DEFAULT 0,
+      items_extracted   INTEGER     NOT NULL DEFAULT 0,
+      tokens_used       INTEGER     NOT NULL DEFAULT 0,
+      error_message     TEXT,
+      started_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+      completed_at      TIMESTAMPTZ
+    );
+
+    CREATE INDEX scrape_runs_job_id_started_at_idx ON scrape_runs (job_id, started_at DESC);
+    CREATE INDEX scrape_runs_status_idx ON scrape_runs (status);
+
+    CREATE TABLE extracted_data (
+      id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      run_id      UUID        NOT NULL REFERENCES scrape_runs(id) ON DELETE CASCADE,
+      job_id      UUID        NOT NULL REFERENCES scrape_jobs(id) ON DELETE CASCADE,
+      source_url  TEXT        NOT NULL,
+      data        JSONB       NOT NULL,
+      data_hash   TEXT        NOT NULL,
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE INDEX extracted_data_run_id_idx ON extracted_data (run_id);
+    CREATE INDEX extracted_data_job_id_created_at_idx ON extracted_data (job_id, created_at DESC);
+    CREATE INDEX extracted_data_data_hash_idx ON extracted_data (data_hash);
+
+    CREATE TABLE job_setup_logs (
+      id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      job_id          UUID        NOT NULL REFERENCES scrape_jobs(id) ON DELETE CASCADE,
+      user_goal       TEXT        NOT NULL,
+      ai_suggestion   JSONB       NOT NULL,
+      accepted        BOOLEAN     NOT NULL DEFAULT false,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE INDEX job_setup_logs_job_id_idx ON job_setup_logs (job_id);
+  `);
+};
+
+export const down = (pgm) => {
+  pgm.sql(`
+    DROP TABLE IF EXISTS job_setup_logs;
+    DROP TABLE IF EXISTS extracted_data;
+    DROP TABLE IF EXISTS scrape_runs;
+    DROP TRIGGER IF EXISTS scrape_jobs_set_updated_at ON scrape_jobs;
+    DROP TABLE IF EXISTS scrape_jobs;
+  `);
+};

--- a/server/migrations/20260424000004_integrations.js
+++ b/server/migrations/20260424000004_integrations.js
@@ -1,0 +1,54 @@
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+
+export const up = (pgm) => {
+  pgm.sql(`
+    CREATE TABLE google_connections (
+      id                        UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id                   UUID        NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+      access_token_encrypted    TEXT        NOT NULL,
+      refresh_token_encrypted   TEXT        NOT NULL,
+      token_expires_at          TIMESTAMPTZ,
+      connected_email           TEXT,
+      created_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at                TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE TRIGGER google_connections_set_updated_at
+      BEFORE UPDATE ON google_connections
+      FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+    CREATE TABLE notification_log (
+      id        UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id   UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      job_id    UUID        NOT NULL REFERENCES scrape_jobs(id) ON DELETE CASCADE,
+      run_id    UUID        NOT NULL REFERENCES scrape_runs(id) ON DELETE CASCADE,
+      channel   TEXT        NOT NULL CHECK (channel IN ('email', 'telegram')),
+      type      TEXT        NOT NULL CHECK (type IN ('change_detected', 'job_failed', 'job_completed')),
+      message   TEXT,
+      sent_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE INDEX notification_log_user_id_sent_at_idx ON notification_log (user_id, sent_at DESC);
+    CREATE INDEX notification_log_job_id_idx ON notification_log (job_id);
+    CREATE INDEX notification_log_run_id_idx ON notification_log (run_id);
+
+    CREATE TABLE settings (
+      id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id  UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      key      TEXT NOT NULL,
+      value    TEXT NOT NULL,
+      UNIQUE (user_id, key)
+    );
+
+    CREATE INDEX settings_user_id_idx ON settings (user_id);
+  `);
+};
+
+export const down = (pgm) => {
+  pgm.sql(`
+    DROP TABLE IF EXISTS settings;
+    DROP TABLE IF EXISTS notification_log;
+    DROP TRIGGER IF EXISTS google_connections_set_updated_at ON google_connections;
+    DROP TABLE IF EXISTS google_connections;
+  `);
+};

--- a/server/package.json
+++ b/server/package.json
@@ -8,12 +8,18 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.scripts.json",
+    "migrate": "node --import tsx/esm scripts/migrate.ts",
+    "migrate:up": "npm run migrate -- up",
+    "migrate:down": "npm run migrate -- down",
+    "migrate:redo": "npm run migrate -- redo",
+    "migrate:create": "node --import tsx/esm scripts/migrate.ts create"
   },
   "dependencies": {
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "ioredis": "^5.4.2",
+    "node-pg-migrate": "^8.0.4",
     "pg": "^8.13.1"
   },
   "devDependencies": {

--- a/server/scripts/migrate.ts
+++ b/server/scripts/migrate.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { runner } from 'node-pg-migrate';
+import { env } from '../src/config/env.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = resolve(__dirname, '..', 'migrations');
+
+if (!existsSync(migrationsDir)) {
+  mkdirSync(migrationsDir, { recursive: true });
+}
+
+type Direction = 'up' | 'down' | 'redo';
+
+const [rawCommand, rawArg] = process.argv.slice(2);
+const command = rawCommand ?? 'up';
+
+function usage(): never {
+  console.error('usage: migrate <up|down|redo|create> [name]');
+  process.exit(1);
+}
+
+if (command === 'create') {
+  const name = rawArg;
+  if (!name) usage();
+  const stamp = new Date()
+    .toISOString()
+    .replace(/[-:TZ.]/g, '')
+    .slice(0, 14);
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
+  const file = resolve(migrationsDir, `${stamp}_${slug}.js`);
+  writeFileSync(
+    file,
+    `/** @type {import('node-pg-migrate').MigrationBuilder} */\n\nexport const up = (pgm) => {\n  pgm.sql(\`\n    -- write SQL here\n  \`);\n};\n\nexport const down = (pgm) => {\n  pgm.sql(\`\n    -- reverse SQL here\n  \`);\n};\n`,
+  );
+  console.log(`created ${file}`);
+  process.exit(0);
+}
+
+if (!['up', 'down', 'redo'].includes(command)) usage();
+
+if (!env.databaseUrl) {
+  console.error('DATABASE_URL is not set');
+  process.exit(1);
+}
+
+const direction = command as Direction;
+
+try {
+  if (direction === 'redo') {
+    await runner({
+      databaseUrl: env.databaseUrl,
+      dir: migrationsDir,
+      migrationsTable: 'pgmigrations',
+      direction: 'down',
+      count: 1,
+      verbose: true,
+      singleTransaction: true,
+    });
+    await runner({
+      databaseUrl: env.databaseUrl,
+      dir: migrationsDir,
+      migrationsTable: 'pgmigrations',
+      direction: 'up',
+      count: 1,
+      verbose: true,
+      singleTransaction: true,
+    });
+  } else {
+    await runner({
+      databaseUrl: env.databaseUrl,
+      dir: migrationsDir,
+      migrationsTable: 'pgmigrations',
+      direction,
+      count: direction === 'down' ? 1 : Infinity,
+      verbose: true,
+      singleTransaction: true,
+    });
+  }
+  process.exit(0);
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -11,5 +11,5 @@
     "declaration": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "migrations", "scripts"]
 }

--- a/server/tsconfig.scripts.json
+++ b/server/tsconfig.scripts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["scripts/**/*.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "migrations"]
+}


### PR DESCRIPTION
## Summary

Build Order step 2 from [HANDOFF-smartscrape.md](HANDOFF-smartscrape.md): the full Postgres schema every later feature targets, plus a migration runner.

## Changes

- **Tooling** — `node-pg-migrate` v8 with a thin `scripts/migrate.ts` wrapper. npm scripts: `migrate:up`, `migrate:down`, `migrate:redo`, `migrate:create`. Split server tsconfig (`tsconfig.json` for build, `tsconfig.scripts.json` for typechecking `scripts/`).
- **Schema** — 4 migrations, 10 tables:
  - `001_users_and_auth` — `pgcrypto`, `set_updated_at()` trigger function, `users` (with email verification + reset token columns), `refresh_tokens` (revocable, hashed).
  - `002_api_keys` — per-user AI provider keys (encrypted), `UNIQUE(user_id, provider)`, provider `CHECK` constraint.
  - `003_jobs_runs_and_data` — `scrape_jobs` (config: urls, prompt, schema, cron, notification rules, AI model, sheet link), `scrape_runs` (lifecycle: pending → scraping → extracting → exporting → completed/failed), `extracted_data` (with `data_hash` for change detection), `job_setup_logs` (AI wizard history).
  - `004_integrations` — `google_connections` (encrypted OAuth tokens, unique per user), `notification_log` (channel/type CHECKed), `settings` (per-user key/value).
- **Indexes** — every FK, plus hot paths: partial indexes on verification/reset tokens, `(user_id, enabled)` and `schedule` on jobs, `(job_id, started_at DESC)` on runs, `data_hash` on extracted_data, `(user_id, sent_at DESC)` on notifications.
- **CI** — new `migrations` job spins up Postgres 16, runs `migrate:up`, reverses each migration one at a time, then re-applies. Catches non-idempotent `down()` and missing `DROP IF EXISTS`.

## Design notes

- All IDs `UUID DEFAULT gen_random_uuid()`, all timestamps `TIMESTAMPTZ` with `DEFAULT now()`.
- `set_updated_at()` trigger applied to tables with an `updated_at` column.
- SQL-centric migrations (`pgm.sql()` wrappers) — explicit CHECK constraints, partial indexes, and index shape are easier to audit inline than via the `node-pg-migrate` DSL.
- `refresh_tokens.token_hash` gets a unique index so session lookup is an index hit, not a scan.

## Out of scope

Route handlers, auth logic, AI extraction, BullMQ job running, notification dispatch — queued for later issues per Build Order steps 3+.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck` (src + scripts)
- [x] `npm run build`
- [x] `migrate:create` generates a valid template
- [x] CI migrations job: `up → down×4 → up` on Postgres 16 (pending CI)

Closes #3