### PR TITLE
feat: backend auth (registration, login, email verification, password reset)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1623,6 +1623,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
+      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -1690,6 +1700,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -1698,6 +1726,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.23",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.23.tgz",
+      "integrity": "sha512-aFV3/NsYFLSx9mbb5gtirBSXJnAlrusoKNuPbxsASWc7vrKLmIrTQRpdcxNcSFL3VW2A2XpeLEavwb2qMi6nlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -2219,6 +2257,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2329,6 +2381,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2689,6 +2747,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -3106,6 +3173,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -3822,6 +3904,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3888,10 +4013,46 @@
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -3899,6 +4060,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -4115,6 +4282,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-pg-migrate": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/node-pg-migrate/-/node-pg-migrate-8.0.4.tgz",
@@ -4146,6 +4333,15 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.6.tgz",
+      "integrity": "sha512-Nm2XeuDwwy2wi5A+8jPWwQwNzcjNjhWdE3pVLoXEusxJqCnAPAgnBGkSmiLknbnWuOF9qraRpYZjfxqtKZ4tPw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -5174,7 +5370,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6435,19 +6630,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "server": {
       "name": "@smartscrape/server",
       "version": "0.0.1",
       "dependencies": {
+        "bcrypt": "^6.0.0",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.0",
         "ioredis": "^5.4.2",
+        "jsonwebtoken": "^9.0.2",
         "node-pg-migrate": "^8.0.4",
-        "pg": "^8.13.1"
+        "nodemailer": "^8.0.6",
+        "pg": "^8.13.1",
+        "zod": "^3.24.1"
       },
       "devDependencies": {
+        "@types/bcrypt": "^5.0.2",
         "@types/express": "^5.0.0",
+        "@types/jsonwebtoken": "^9.0.7",
         "@types/node": "^22.10.5",
+        "@types/nodemailer": "^6.4.17",
         "@types/pg": "^8.11.10",
         "tsx": "^4.19.2",
         "typescript": "^5.7.3"

--- a/server/package.json
+++ b/server/package.json
@@ -16,15 +16,23 @@
     "migrate:create": "node --import tsx/esm scripts/migrate.ts create"
   },
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "express-rate-limit": "^7.5.0",
     "ioredis": "^5.4.2",
+    "jsonwebtoken": "^9.0.2",
     "node-pg-migrate": "^8.0.4",
-    "pg": "^8.13.1"
+    "nodemailer": "^8.0.6",
+    "pg": "^8.13.1",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@types/bcrypt": "^5.0.2",
     "@types/express": "^5.0.0",
+    "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^22.10.5",
+    "@types/nodemailer": "^6.4.17",
     "@types/pg": "^8.11.10",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3"

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -23,7 +23,7 @@ if (envPath) {
 
 function required(name: string): string {
   const value = process.env[name];
-  if (!value) {
+  if (!value || value.startsWith('replace-me')) {
     throw new Error(`Missing required env var: ${name}`);
   }
   return value;
@@ -39,11 +39,41 @@ export const env = {
   databaseUrl: optional('DATABASE_URL'),
   redisUrl: optional('REDIS_URL'),
   appUrl: optional('APP_URL', 'http://localhost:5173'),
+  apiUrl: optional('API_URL', 'http://localhost:3000'),
+  smtp: {
+    host: optional('SMTP_HOST'),
+    port: Number.parseInt(optional('SMTP_PORT', '587'), 10),
+    user: optional('SMTP_USER'),
+    pass: optional('SMTP_PASS'),
+    from: optional('EMAIL_FROM', 'noreply@smartscrape.local'),
+  },
+  resend: {
+    apiKey: optional('RESEND_API_KEY'),
+  },
 };
 
-export function requireSecrets(): void {
-  // Called from places that need them; the health check route stays tolerant.
-  required('JWT_SECRET');
-  required('JWT_REFRESH_SECRET');
-  required('ENCRYPTION_KEY');
+type Secrets = {
+  jwtAccessSecret: string;
+  jwtRefreshSecret: string;
+  encryptionKey: string;
+};
+
+let cachedSecrets: Secrets | null = null;
+
+/**
+ * Read and validate all runtime secrets. Throws if any are missing or still
+ * placeholder values. Cache so subsequent calls are free.
+ */
+export function requireSecrets(): Secrets {
+  if (cachedSecrets) return cachedSecrets;
+  const encryptionKeyHex = required('ENCRYPTION_KEY');
+  if (!/^[0-9a-fA-F]{64}$/.test(encryptionKeyHex)) {
+    throw new Error('ENCRYPTION_KEY must be 32 bytes hex-encoded (64 hex chars)');
+  }
+  cachedSecrets = {
+    jwtAccessSecret: required('JWT_SECRET'),
+    jwtRefreshSecret: required('JWT_REFRESH_SECRET'),
+    encryptionKey: encryptionKeyHex,
+  };
+  return cachedSecrets;
 }

--- a/server/src/db/refreshTokens.ts
+++ b/server/src/db/refreshTokens.ts
@@ -1,0 +1,47 @@
+import { getPool } from '../config/database.js';
+
+export type RefreshTokenRow = {
+  id: string;
+  user_id: string;
+  token_hash: string;
+  expires_at: Date;
+  revoked: boolean;
+  created_at: Date;
+};
+
+export async function createRefreshToken(args: {
+  userId: string;
+  tokenHash: string;
+  expiresAt: Date;
+}): Promise<RefreshTokenRow> {
+  const { rows } = await getPool().query<RefreshTokenRow>(
+    `INSERT INTO refresh_tokens (user_id, token_hash, expires_at)
+     VALUES ($1, $2, $3)
+     RETURNING *`,
+    [args.userId, args.tokenHash, args.expiresAt],
+  );
+  return rows[0]!;
+}
+
+export async function findActiveByHash(tokenHash: string): Promise<RefreshTokenRow | null> {
+  const { rows } = await getPool().query<RefreshTokenRow>(
+    `SELECT * FROM refresh_tokens
+      WHERE token_hash = $1
+        AND revoked = false
+        AND expires_at > now()
+      LIMIT 1`,
+    [tokenHash],
+  );
+  return rows[0] ?? null;
+}
+
+export async function revokeById(id: string): Promise<void> {
+  await getPool().query(`UPDATE refresh_tokens SET revoked = true WHERE id = $1`, [id]);
+}
+
+export async function revokeAllForUser(userId: string): Promise<void> {
+  await getPool().query(
+    `UPDATE refresh_tokens SET revoked = true WHERE user_id = $1 AND revoked = false`,
+    [userId],
+  );
+}

--- a/server/src/db/users.ts
+++ b/server/src/db/users.ts
@@ -1,0 +1,154 @@
+import { getPool } from '../config/database.js';
+
+export type UserRow = {
+  id: string;
+  email: string;
+  password_hash: string;
+  name: string | null;
+  email_verified: boolean;
+  verification_token: string | null;
+  reset_token: string | null;
+  reset_token_expires: Date | null;
+  telegram_chat_id: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export type PublicUser = {
+  id: string;
+  email: string;
+  name: string | null;
+  email_verified: boolean;
+  telegram_chat_id: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export function toPublic(u: UserRow): PublicUser {
+  return {
+    id: u.id,
+    email: u.email,
+    name: u.name,
+    email_verified: u.email_verified,
+    telegram_chat_id: u.telegram_chat_id,
+    created_at: u.created_at.toISOString(),
+    updated_at: u.updated_at.toISOString(),
+  };
+}
+
+export async function findUserByEmail(email: string): Promise<UserRow | null> {
+  const { rows } = await getPool().query<UserRow>(
+    `SELECT * FROM users WHERE email = $1 LIMIT 1`,
+    [email.toLowerCase()],
+  );
+  return rows[0] ?? null;
+}
+
+export async function findUserById(id: string): Promise<UserRow | null> {
+  const { rows } = await getPool().query<UserRow>(
+    `SELECT * FROM users WHERE id = $1 LIMIT 1`,
+    [id],
+  );
+  return rows[0] ?? null;
+}
+
+export async function findUserByVerificationToken(tokenHash: string): Promise<UserRow | null> {
+  const { rows } = await getPool().query<UserRow>(
+    `SELECT * FROM users WHERE verification_token = $1 LIMIT 1`,
+    [tokenHash],
+  );
+  return rows[0] ?? null;
+}
+
+export async function findUserByResetToken(tokenHash: string): Promise<UserRow | null> {
+  const { rows } = await getPool().query<UserRow>(
+    `SELECT * FROM users
+     WHERE reset_token = $1 AND reset_token_expires > now()
+     LIMIT 1`,
+    [tokenHash],
+  );
+  return rows[0] ?? null;
+}
+
+export async function createUser(args: {
+  email: string;
+  passwordHash: string;
+  name: string | null;
+  verificationTokenHash: string;
+}): Promise<UserRow> {
+  const { rows } = await getPool().query<UserRow>(
+    `INSERT INTO users (email, password_hash, name, verification_token)
+     VALUES ($1, $2, $3, $4)
+     RETURNING *`,
+    [args.email.toLowerCase(), args.passwordHash, args.name, args.verificationTokenHash],
+  );
+  return rows[0]!;
+}
+
+export async function markEmailVerified(userId: string): Promise<void> {
+  await getPool().query(
+    `UPDATE users SET email_verified = true, verification_token = NULL WHERE id = $1`,
+    [userId],
+  );
+}
+
+export async function setResetToken(
+  userId: string,
+  tokenHash: string,
+  expiresAt: Date,
+): Promise<void> {
+  await getPool().query(
+    `UPDATE users SET reset_token = $1, reset_token_expires = $2 WHERE id = $3`,
+    [tokenHash, expiresAt, userId],
+  );
+}
+
+export async function clearResetToken(userId: string): Promise<void> {
+  await getPool().query(
+    `UPDATE users SET reset_token = NULL, reset_token_expires = NULL WHERE id = $1`,
+    [userId],
+  );
+}
+
+export async function updatePassword(userId: string, passwordHash: string): Promise<void> {
+  await getPool().query(
+    `UPDATE users
+       SET password_hash = $1, reset_token = NULL, reset_token_expires = NULL
+     WHERE id = $2`,
+    [passwordHash, userId],
+  );
+}
+
+export type UpdateProfileArgs = {
+  name?: string | null;
+  telegramChatId?: string | null;
+};
+
+export async function updateProfile(userId: string, args: UpdateProfileArgs): Promise<UserRow> {
+  // Build dynamic UPDATE from only provided keys.
+  const sets: string[] = [];
+  const vals: unknown[] = [];
+  if (args.name !== undefined) {
+    sets.push(`name = $${sets.length + 1}`);
+    vals.push(args.name);
+  }
+  if (args.telegramChatId !== undefined) {
+    sets.push(`telegram_chat_id = $${sets.length + 1}`);
+    vals.push(args.telegramChatId);
+  }
+  if (sets.length === 0) {
+    const existing = await findUserById(userId);
+    if (!existing) throw new Error('User not found');
+    return existing;
+  }
+  vals.push(userId);
+  const { rows } = await getPool().query<UserRow>(
+    `UPDATE users SET ${sets.join(', ')} WHERE id = $${vals.length} RETURNING *`,
+    vals,
+  );
+  return rows[0]!;
+}
+
+export async function deleteUser(userId: string): Promise<void> {
+  await getPool().query(`DELETE FROM users WHERE id = $1`, [userId]);
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,19 +1,45 @@
 import express from 'express';
-import { env } from './config/env.js';
+import { env, requireSecrets } from './config/env.js';
 import { closeDatabase } from './config/database.js';
 import { closeRedis } from './config/redis.js';
+import { authRouter } from './routes/auth.js';
 import { healthRouter } from './routes/health.js';
+import { generalLimiter } from './middleware/rateLimit.js';
 import { fail } from './lib/response.js';
+
+// Fail fast if any runtime secret is missing or a placeholder.
+requireSecrets();
 
 const app = express();
 
+app.set('trust proxy', 1);
 app.use(express.json({ limit: '1mb' }));
 
+// Health stays outside the rate limiter so uptime probes never 429.
 app.use('/api/health', healthRouter);
+
+app.use('/api', generalLimiter);
+app.use('/api/auth', authRouter);
 
 app.use((_req, res) => {
   res.status(404).json(fail('NOT_FOUND', 'Route not found'));
 });
+
+// Centralised error handler so uncaught promise rejections in async handlers
+// still return the consistent envelope instead of Express's default HTML.
+app.use(
+  (
+    err: Error,
+    _req: express.Request,
+    res: express.Response,
+    _next: express.NextFunction,
+  ) => {
+    console.error('[server] unhandled error', err);
+    res
+      .status(500)
+      .json(fail('INTERNAL_ERROR', env.nodeEnv === 'production' ? 'Internal server error' : err.message));
+  },
+);
 
 const server = app.listen(env.port, () => {
   console.log(`[server] listening on http://localhost:${env.port}`);

--- a/server/src/lib/jwt.ts
+++ b/server/src/lib/jwt.ts
@@ -1,0 +1,36 @@
+import jwt from 'jsonwebtoken';
+import { requireSecrets } from '../config/env.js';
+
+export type AccessTokenPayload = {
+  sub: string; // user id
+  email: string;
+};
+
+const ACCESS_TTL = '15m';
+const REFRESH_TTL = '7d';
+export const REFRESH_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function signAccessToken(payload: AccessTokenPayload): string {
+  const { jwtAccessSecret } = requireSecrets();
+  return jwt.sign(payload, jwtAccessSecret, { expiresIn: ACCESS_TTL });
+}
+
+export function verifyAccessToken(token: string): AccessTokenPayload {
+  const { jwtAccessSecret } = requireSecrets();
+  const decoded = jwt.verify(token, jwtAccessSecret);
+  if (typeof decoded === 'string') {
+    throw new Error('Invalid access token payload');
+  }
+  return decoded as AccessTokenPayload;
+}
+
+/**
+ * Refresh tokens are opaque random strings (not JWTs) stored hashed in the DB.
+ * We use jsonwebtoken only for access tokens. See lib/tokens.ts for opaque-token helpers.
+ * This signed variant is kept for possible future short-lived refresh verification,
+ * but the canonical refresh token is opaque.
+ */
+export function signRefreshJwt(payload: { sub: string; jti: string }): string {
+  const { jwtRefreshSecret } = requireSecrets();
+  return jwt.sign(payload, jwtRefreshSecret, { expiresIn: REFRESH_TTL });
+}

--- a/server/src/lib/password.ts
+++ b/server/src/lib/password.ts
@@ -1,0 +1,11 @@
+import bcrypt from 'bcrypt';
+
+const BCRYPT_ROUNDS = 12;
+
+export function hashPassword(plain: string): Promise<string> {
+  return bcrypt.hash(plain, BCRYPT_ROUNDS);
+}
+
+export function verifyPassword(plain: string, hash: string): Promise<boolean> {
+  return bcrypt.compare(plain, hash);
+}

--- a/server/src/lib/tokens.ts
+++ b/server/src/lib/tokens.ts
@@ -1,0 +1,15 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+/**
+ * Generate a URL-safe random token and its SHA-256 hash.
+ * Store the hash; return the plaintext once so it can be emailed/returned to the user.
+ */
+export function generateToken(bytes = 32): { token: string; hash: string } {
+  const token = randomBytes(bytes).toString('base64url');
+  const hash = createHash('sha256').update(token).digest('hex');
+  return { token, hash };
+}
+
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,33 @@
+import type { Request, Response, NextFunction } from 'express';
+import { verifyAccessToken } from '../lib/jwt.js';
+import { fail } from '../lib/response.js';
+
+export type AuthenticatedUser = {
+  id: string;
+  email: string;
+};
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      user?: AuthenticatedUser;
+    }
+  }
+}
+
+export function requireAuth(req: Request, res: Response, next: NextFunction): void {
+  const header = req.header('authorization') ?? '';
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  if (!match) {
+    res.status(401).json(fail('UNAUTHORIZED', 'Missing or malformed Authorization header'));
+    return;
+  }
+  try {
+    const payload = verifyAccessToken(match[1]!);
+    req.user = { id: payload.sub, email: payload.email };
+    next();
+  } catch {
+    res.status(401).json(fail('UNAUTHORIZED', 'Invalid or expired access token'));
+  }
+}

--- a/server/src/middleware/rateLimit.ts
+++ b/server/src/middleware/rateLimit.ts
@@ -1,0 +1,25 @@
+import rateLimit from 'express-rate-limit';
+import type { Request, Response } from 'express';
+import { fail } from '../lib/response.js';
+
+function handler(_req: Request, res: Response): void {
+  res.status(429).json(fail('RATE_LIMITED', 'Too many requests, please try again later.'));
+}
+
+/** 5 requests per minute per IP. Auth-entry routes (login, register, forgot-password). */
+export const authEntryLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 5,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  handler,
+});
+
+/** 100 requests per minute per IP. Default for other API routes. */
+export const generalLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 100,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  handler,
+});

--- a/server/src/middleware/validate.ts
+++ b/server/src/middleware/validate.ts
@@ -1,0 +1,26 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { ZodType, ZodError } from 'zod';
+import { fail } from '../lib/response.js';
+
+type Source = 'body' | 'query' | 'params';
+
+function formatZodError(err: ZodError): { path: string; message: string }[] {
+  return err.issues.map((issue) => ({
+    path: issue.path.join('.') || '(root)',
+    message: issue.message,
+  }));
+}
+
+export function validate<T>(schema: ZodType<T>, source: Source = 'body') {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const input = req[source];
+    const result = schema.safeParse(input);
+    if (!result.success) {
+      res.status(400).json(fail('VALIDATION_ERROR', 'Invalid request', formatZodError(result.error)));
+      return;
+    }
+    // Replace the source with parsed+coerced data so handlers get typed values.
+    (req as unknown as Record<Source, unknown>)[source] = result.data;
+    next();
+  };
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,0 +1,242 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { env } from '../config/env.js';
+import {
+  createUser,
+  clearResetToken,
+  deleteUser,
+  findUserByEmail,
+  findUserById,
+  findUserByResetToken,
+  findUserByVerificationToken,
+  markEmailVerified,
+  setResetToken,
+  toPublic,
+  updatePassword,
+  updateProfile,
+} from '../db/users.js';
+import {
+  createRefreshToken,
+  findActiveByHash,
+  revokeAllForUser,
+  revokeById,
+} from '../db/refreshTokens.js';
+import { hashPassword, verifyPassword } from '../lib/password.js';
+import { signAccessToken, REFRESH_TTL_MS } from '../lib/jwt.js';
+import { generateToken, hashToken } from '../lib/tokens.js';
+import { fail, ok } from '../lib/response.js';
+import { validate } from '../middleware/validate.js';
+import { authEntryLimiter } from '../middleware/rateLimit.js';
+import { requireAuth } from '../middleware/auth.js';
+import { sendEmail } from '../services/email.js';
+
+export const authRouter = Router();
+
+// ---------- schemas ----------
+
+const passwordSchema = z
+  .string()
+  .min(8, 'Password must be at least 8 characters')
+  .max(200, 'Password too long');
+
+const registerSchema = z.object({
+  email: z.string().email().max(254).transform((e) => e.toLowerCase()),
+  password: passwordSchema,
+  name: z.string().trim().min(1).max(120).optional(),
+});
+
+const loginSchema = z.object({
+  email: z.string().email().transform((e) => e.toLowerCase()),
+  password: z.string().min(1).max(200),
+});
+
+const refreshSchema = z.object({
+  refreshToken: z.string().min(10),
+});
+
+const verifyEmailSchema = z.object({
+  token: z.string().min(10),
+});
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email().transform((e) => e.toLowerCase()),
+});
+
+const resetPasswordSchema = z.object({
+  token: z.string().min(10),
+  password: passwordSchema,
+});
+
+const updateProfileSchema = z.object({
+  name: z.string().trim().min(1).max(120).nullable().optional(),
+  telegram_chat_id: z.string().trim().max(64).nullable().optional(),
+});
+
+// ---------- helpers ----------
+
+async function issueSession(user: { id: string; email: string }): Promise<{
+  accessToken: string;
+  refreshToken: string;
+  refreshExpiresAt: string;
+}> {
+  const accessToken = signAccessToken({ sub: user.id, email: user.email });
+  const { token, hash } = generateToken(48);
+  const expiresAt = new Date(Date.now() + REFRESH_TTL_MS);
+  await createRefreshToken({ userId: user.id, tokenHash: hash, expiresAt });
+  return {
+    accessToken,
+    refreshToken: token,
+    refreshExpiresAt: expiresAt.toISOString(),
+  };
+}
+
+function verificationUrl(token: string): string {
+  return `${env.appUrl.replace(/\/$/, '')}/verify-email?token=${encodeURIComponent(token)}`;
+}
+
+function resetUrl(token: string): string {
+  return `${env.appUrl.replace(/\/$/, '')}/reset-password?token=${encodeURIComponent(token)}`;
+}
+
+// ---------- routes ----------
+
+authRouter.post('/register', authEntryLimiter, validate(registerSchema), async (req, res) => {
+  const { email, password, name } = req.body as z.infer<typeof registerSchema>;
+
+  const existing = await findUserByEmail(email);
+  if (existing) {
+    res.status(409).json(fail('EMAIL_TAKEN', 'Email is already registered'));
+    return;
+  }
+
+  const passwordHash = await hashPassword(password);
+  const { token, hash } = generateToken(32);
+  const user = await createUser({
+    email,
+    passwordHash,
+    name: name ?? null,
+    verificationTokenHash: hash,
+  });
+
+  const link = verificationUrl(token);
+  await sendEmail({
+    to: user.email,
+    subject: 'Verify your SmartScrape email',
+    text: `Welcome to SmartScrape. Verify your email by opening: ${link}`,
+  });
+
+  res.status(201).json(
+    ok({
+      user: toPublic(user),
+      // In dev (console email transport) we surface the token so flows are testable.
+      devToken: env.nodeEnv === 'development' ? token : undefined,
+    }),
+  );
+});
+
+authRouter.post('/verify-email', validate(verifyEmailSchema), async (req, res) => {
+  const { token } = req.body as z.infer<typeof verifyEmailSchema>;
+  const user = await findUserByVerificationToken(hashToken(token));
+  if (!user) {
+    res.status(400).json(fail('INVALID_TOKEN', 'Invalid or expired verification token'));
+    return;
+  }
+  if (user.email_verified) {
+    res.status(200).json(ok({ user: toPublic(user) }));
+    return;
+  }
+  await markEmailVerified(user.id);
+  const refreshed = await findUserById(user.id);
+  res.status(200).json(ok({ user: toPublic(refreshed!) }));
+});
+
+authRouter.post('/login', authEntryLimiter, validate(loginSchema), async (req, res) => {
+  const { email, password } = req.body as z.infer<typeof loginSchema>;
+  const user = await findUserByEmail(email);
+  if (!user || !(await verifyPassword(password, user.password_hash))) {
+    // Uniform error to avoid user-existence disclosure.
+    res.status(401).json(fail('INVALID_CREDENTIALS', 'Invalid email or password'));
+    return;
+  }
+  const session = await issueSession({ id: user.id, email: user.email });
+  res.status(200).json(ok({ user: toPublic(user), ...session }));
+});
+
+authRouter.post('/refresh', validate(refreshSchema), async (req, res) => {
+  const { refreshToken } = req.body as z.infer<typeof refreshSchema>;
+  const row = await findActiveByHash(hashToken(refreshToken));
+  if (!row) {
+    res.status(401).json(fail('INVALID_REFRESH', 'Refresh token is invalid or expired'));
+    return;
+  }
+  const user = await findUserById(row.user_id);
+  if (!user) {
+    res.status(401).json(fail('INVALID_REFRESH', 'Refresh token is invalid or expired'));
+    return;
+  }
+  // Rotate: revoke the presented token, issue a fresh pair.
+  await revokeById(row.id);
+  const session = await issueSession({ id: user.id, email: user.email });
+  res.status(200).json(ok(session));
+});
+
+authRouter.post(
+  '/forgot-password',
+  authEntryLimiter,
+  validate(forgotPasswordSchema),
+  async (req, res) => {
+    const { email } = req.body as z.infer<typeof forgotPasswordSchema>;
+    const user = await findUserByEmail(email);
+    if (user) {
+      const { token, hash } = generateToken(32);
+      const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+      await setResetToken(user.id, hash, expiresAt);
+      await sendEmail({
+        to: user.email,
+        subject: 'Reset your SmartScrape password',
+        text: `Reset your password: ${resetUrl(token)}\nThis link expires in 1 hour.`,
+      });
+    }
+    // Always return success to avoid disclosing which emails are registered.
+    res.status(200).json(ok({ sent: true }));
+  },
+);
+
+authRouter.post('/reset-password', validate(resetPasswordSchema), async (req, res) => {
+  const { token, password } = req.body as z.infer<typeof resetPasswordSchema>;
+  const user = await findUserByResetToken(hashToken(token));
+  if (!user) {
+    res.status(400).json(fail('INVALID_TOKEN', 'Invalid or expired reset token'));
+    return;
+  }
+  const passwordHash = await hashPassword(password);
+  await updatePassword(user.id, passwordHash);
+  await clearResetToken(user.id);
+  // Invalidate all existing sessions after a password change.
+  await revokeAllForUser(user.id);
+  res.status(200).json(ok({ reset: true }));
+});
+
+authRouter.get('/me', requireAuth, async (req, res) => {
+  const user = await findUserById(req.user!.id);
+  if (!user) {
+    res.status(404).json(fail('NOT_FOUND', 'User not found'));
+    return;
+  }
+  res.status(200).json(ok({ user: toPublic(user) }));
+});
+
+authRouter.patch('/me', requireAuth, validate(updateProfileSchema), async (req, res) => {
+  const input = req.body as z.infer<typeof updateProfileSchema>;
+  const updated = await updateProfile(req.user!.id, {
+    name: input.name,
+    telegramChatId: input.telegram_chat_id,
+  });
+  res.status(200).json(ok({ user: toPublic(updated) }));
+});
+
+authRouter.delete('/me', requireAuth, async (req, res) => {
+  await revokeAllForUser(req.user!.id);
+  await deleteUser(req.user!.id);
+  res.status(200).json(ok({ deleted: true }));
+});

--- a/server/src/services/email.ts
+++ b/server/src/services/email.ts
@@ -1,0 +1,45 @@
+import nodemailer, { type Transporter } from 'nodemailer';
+import { env } from '../config/env.js';
+
+type SendArgs = {
+  to: string;
+  subject: string;
+  text: string;
+  html?: string;
+};
+
+let cached: Transporter | null = null;
+
+function transporter(): Transporter | null {
+  if (cached) return cached;
+  if (!env.smtp.host) return null;
+  cached = nodemailer.createTransport({
+    host: env.smtp.host,
+    port: env.smtp.port,
+    secure: env.smtp.port === 465,
+    auth:
+      env.smtp.user && env.smtp.pass
+        ? { user: env.smtp.user, pass: env.smtp.pass }
+        : undefined,
+  });
+  return cached;
+}
+
+/**
+ * Send an email via SMTP when configured; otherwise log it. The console
+ * fallback keeps dev flows (verify email, password reset) working without
+ * forcing SMTP setup.
+ */
+export async function sendEmail({ to, subject, text, html }: SendArgs): Promise<void> {
+  const tx = transporter();
+  if (!tx) {
+    console.log('[email:dev-console]', {
+      from: env.smtp.from,
+      to,
+      subject,
+      text,
+    });
+    return;
+  }
+  await tx.sendMail({ from: env.smtp.from, to, subject, text, html });
+}


### PR DESCRIPTION
## Summary

Build Order step 3 from [HANDOFF-smartscrape.md](HANDOFF-smartscrape.md), backend half. Frontend auth pages follow in a separate issue.

## Changes

### Crypto + secrets
- `requireSecrets()` runs at app boot; throws on missing or placeholder `JWT_SECRET` / `JWT_REFRESH_SECRET` / `ENCRYPTION_KEY`, and enforces `ENCRYPTION_KEY` is 32 bytes hex (64 chars).
- Passwords hashed with bcrypt, 12 rounds.
- Access tokens: signed JWT, `sub = user.id`, 15-min TTL.
- Refresh tokens: opaque random (48 bytes base64url) + SHA-256 hash stored in `refresh_tokens`, 7-day TTL. Rotated on every refresh — replaying a used token returns `INVALID_REFRESH`.
- Verification + reset tokens: same opaque-plus-hash pattern. Reset tokens expire in 1 hour.

### Middleware
- `validate` — generic Zod wrapper that replaces `req.body|query|params` with parsed data so handlers see typed values.
- `rateLimit` — 5/min/IP on `/login`, `/register`, `/forgot-password`; 100/min/IP on general `/api/*`. Health stays unlimited.
- `requireAuth` — Bearer JWT verification; attaches `req.user = { id, email }`.

### Routes
| Method | Route | Notes |
|---|---|---|
| POST | `/api/auth/register` | Creates user, sends verification email. In `NODE_ENV=development` returns `devToken` so CLI flows work without SMTP. |
| POST | `/api/auth/verify-email` | Marks email verified. Idempotent. |
| POST | `/api/auth/login` | Returns `accessToken` + `refreshToken` + `refreshExpiresAt`. Uniform `INVALID_CREDENTIALS` error. |
| POST | `/api/auth/refresh` | Rotates refresh token. |
| POST | `/api/auth/forgot-password` | Always returns `{sent:true}` to prevent user-enumeration. |
| POST | `/api/auth/reset-password` | Updates password, revokes all refresh tokens. |
| GET | `/api/auth/me` | Requires auth. |
| PATCH | `/api/auth/me` | Updates name, telegram_chat_id. |
| DELETE | `/api/auth/me` | Cascade-deletes user + revokes refresh tokens. |

### Other
- Email service: Nodemailer SMTP when `SMTP_HOST` is set; console fallback in dev so verify/reset flows work without an SMTP account.
- Centralized error handler preserves `{success, data, error}` envelope on uncaught exceptions.
- Bumped bcrypt to 6 and nodemailer to 8 to clear npm audit highs.

## Security checklist

- [x] bcrypt \u2265 12 rounds
- [x] Refresh tokens hashed at rest, rotated on use
- [x] Password change / delete revokes all refresh tokens
- [x] No user-enumeration on login, forgot-password, or register's rate-limit response
- [x] Zod validation on every route that takes input
- [x] Rate limits per handoff (5/min auth-entry, 100/min general)
- [x] Parameterised queries throughout
- [x] Consistent error envelope, machine-readable codes

## Manual smoke test (all green on docker compose + migrated DB)

- Register \u2192 verify-email \u2192 login \u2192 GET /me \u2192 refresh \u2192 replay old refresh (rejected)
- Duplicate register \u2192 `EMAIL_TAKEN`
- Validation: short password \u2192 `VALIDATION_ERROR` with field path
- Wrong password \u2192 `INVALID_CREDENTIALS`
- forgot-password (known + unknown email) \u2192 both `{sent:true}`
- reset-password \u2192 old password rejected, new accepted
- PATCH /me updates fields and bumps `updated_at`
- DELETE /me removes user + refresh_tokens cascade
- Auth-entry rate limit triggers at 6th request within 60s
- 404 route uses the envelope

## Out of scope

- Frontend auth pages (follow-up issue: React Router, pages, Zustand store, fetch wrapper with auto-refresh)
- Integration tests (follow-up issue)
- 2FA / OAuth login (per handoff v1 exclusions)

Closes #5