### PR TITLE
feat: frontend auth pages (login, register, verify, forgot/reset)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.1.1",
+    "zustand": "^5.0.2"
   },
   "devDependencies": {
     "@types/react": "^18.3.18",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,67 +1,47 @@
-import { useEffect, useState } from 'react';
-
-type HealthCheck = { ok: boolean; error?: string };
-type HealthResponse = {
-  success: boolean;
-  data: {
-    status: 'healthy' | 'degraded';
-    checks: { database: HealthCheck; redis: HealthCheck };
-    uptime: number;
-    timestamp: string;
-  } | null;
-  error: { code: string; message: string } | null;
-};
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { RedirectIfAuthed, RequireAuth } from './components/RequireAuth';
+import ForgotPassword from './pages/ForgotPassword';
+import Home from './pages/Home';
+import Login from './pages/Login';
+import Register from './pages/Register';
+import ResetPassword from './pages/ResetPassword';
+import VerifyEmail from './pages/VerifyEmail';
 
 export default function App() {
-  const [health, setHealth] = useState<HealthResponse | null>(null);
-  const [loadError, setLoadError] = useState<string | null>(null);
-
-  useEffect(() => {
-    fetch('/api/health')
-      .then((r) => r.json() as Promise<HealthResponse>)
-      .then(setHealth)
-      .catch((err: unknown) => setLoadError(err instanceof Error ? err.message : String(err)));
-  }, []);
-
   return (
-    <main className="mx-auto max-w-2xl px-6 py-16">
-      <h1 className="text-3xl font-semibold tracking-tight">SmartScrape</h1>
-      <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
-        AI-powered web scraping with structured extraction, change detection, and notifications.
-      </p>
+    <BrowserRouter>
+      <Routes>
+        <Route
+          path="/login"
+          element={
+            <RedirectIfAuthed>
+              <Login />
+            </RedirectIfAuthed>
+          }
+        />
+        <Route
+          path="/register"
+          element={
+            <RedirectIfAuthed>
+              <Register />
+            </RedirectIfAuthed>
+          }
+        />
+        <Route path="/forgot-password" element={<ForgotPassword />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
+        <Route path="/verify-email" element={<VerifyEmail />} />
 
-      <section className="mt-10 rounded-lg border border-gray-200 p-5 dark:border-gray-800">
-        <h2 className="text-sm font-medium uppercase tracking-wide text-gray-500">Backend status</h2>
-        {loadError && (
-          <p className="mt-3 font-mono text-sm text-red-600">Failed to reach /api/health: {loadError}</p>
-        )}
-        {!loadError && !health && <p className="mt-3 text-sm text-gray-500">Loading&hellip;</p>}
-        {health?.data && (
-          <dl className="mt-3 space-y-2 font-mono text-sm">
-            <Row label="status" value={health.data.status} tone={health.data.status === 'healthy' ? 'good' : 'warn'} />
-            <Row label="database" value={health.data.checks.database.ok ? 'ok' : `down${health.data.checks.database.error ? ` \u2014 ${health.data.checks.database.error}` : ''}`} tone={health.data.checks.database.ok ? 'good' : 'bad'} />
-            <Row label="redis" value={health.data.checks.redis.ok ? 'ok' : `down${health.data.checks.redis.error ? ` \u2014 ${health.data.checks.redis.error}` : ''}`} tone={health.data.checks.redis.ok ? 'good' : 'bad'} />
-            <Row label="uptime" value={`${health.data.uptime.toFixed(1)}s`} />
-          </dl>
-        )}
-      </section>
-    </main>
-  );
-}
+        <Route
+          path="/"
+          element={
+            <RequireAuth>
+              <Home />
+            </RequireAuth>
+          }
+        />
 
-function Row({ label, value, tone }: { label: string; value: string; tone?: 'good' | 'warn' | 'bad' }) {
-  const toneClass =
-    tone === 'good'
-      ? 'text-emerald-600 dark:text-emerald-400'
-      : tone === 'warn'
-        ? 'text-amber-600 dark:text-amber-400'
-        : tone === 'bad'
-          ? 'text-red-600 dark:text-red-400'
-          : 'text-gray-900 dark:text-gray-100';
-  return (
-    <div className="flex justify-between">
-      <dt className="text-gray-500">{label}</dt>
-      <dd className={toneClass}>{value}</dd>
-    </div>
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </BrowserRouter>
   );
 }

--- a/client/src/components/RequireAuth.tsx
+++ b/client/src/components/RequireAuth.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../stores/auth';
+
+export function RequireAuth({ children }: { children: ReactNode }) {
+  const accessToken = useAuth((s) => s.accessToken);
+  const location = useLocation();
+  if (!accessToken) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+  return <>{children}</>;
+}
+
+export function RedirectIfAuthed({ children }: { children: ReactNode }) {
+  const accessToken = useAuth((s) => s.accessToken);
+  if (accessToken) return <Navigate to="/" replace />;
+  return <>{children}</>;
+}

--- a/client/src/components/layout/AuthLayout.tsx
+++ b/client/src/components/layout/AuthLayout.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react';
+
+type Props = {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+};
+
+export function AuthLayout({ title, subtitle, children, footer }: Props) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 dark:bg-gray-950">
+      <div className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <h1 className="text-xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">SmartScrape</h1>
+          <p className="mt-1 text-xs uppercase tracking-widest text-gray-500">AI web scraping</p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{title}</h2>
+          {subtitle && <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{subtitle}</p>}
+          <div className="mt-5">{children}</div>
+        </div>
+        {footer && <div className="mt-4 text-center text-sm text-gray-600 dark:text-gray-400">{footer}</div>}
+      </div>
+    </main>
+  );
+}

--- a/client/src/components/layout/TopNav.tsx
+++ b/client/src/components/layout/TopNav.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../stores/auth';
+
+export function TopNav() {
+  const user = useAuth((s) => s.user);
+  const clear = useAuth((s) => s.clear);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className="border-b border-gray-200 bg-white/70 backdrop-blur dark:border-gray-800 dark:bg-gray-950/70">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-3">
+        <Link to="/" className="text-sm font-semibold tracking-tight text-gray-900 dark:text-gray-100">
+          SmartScrape
+        </Link>
+        <div className="relative">
+          <button
+            onClick={() => setOpen((v) => !v)}
+            className="flex items-center gap-2 rounded-md px-2 py-1 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+          >
+            <span
+              className="flex h-7 w-7 items-center justify-center rounded-full bg-indigo-600 text-xs font-medium uppercase text-white"
+              aria-hidden
+            >
+              {(user?.name ?? user?.email ?? '?').slice(0, 1)}
+            </span>
+            <span className="hidden sm:inline">{user?.name ?? user?.email}</span>
+          </button>
+          {open && (
+            <div
+              className="absolute right-0 mt-2 w-56 overflow-hidden rounded-md border border-gray-200 bg-white shadow-lg dark:border-gray-800 dark:bg-gray-900"
+              onMouseLeave={() => setOpen(false)}
+            >
+              <div className="border-b border-gray-100 px-3 py-2 text-xs text-gray-500 dark:border-gray-800">
+                {user?.email}
+              </div>
+              <button
+                onClick={() => {
+                  setOpen(false);
+                  clear();
+                }}
+                className="block w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+              >
+                Log out
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/client/src/components/ui/Alert.tsx
+++ b/client/src/components/ui/Alert.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+type Props = {
+  tone: 'info' | 'success' | 'error';
+  children: ReactNode;
+  className?: string;
+};
+
+const tones: Record<Props['tone'], string> = {
+  info: 'border-indigo-200 bg-indigo-50 text-indigo-900 dark:border-indigo-900/60 dark:bg-indigo-950/40 dark:text-indigo-200',
+  success:
+    'border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-200',
+  error:
+    'border-red-200 bg-red-50 text-red-900 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-200',
+};
+
+export function Alert({ tone, children, className = '' }: Props) {
+  return (
+    <div className={`rounded-md border px-3 py-2 text-sm ${tones[tone]} ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/client/src/components/ui/Button.tsx
+++ b/client/src/components/ui/Button.tsx
@@ -1,0 +1,40 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+type Variant = 'primary' | 'secondary' | 'ghost' | 'danger';
+
+type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: Variant;
+  loading?: boolean;
+};
+
+const base =
+  'inline-flex items-center justify-center gap-2 rounded-md px-3.5 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-950 disabled:cursor-not-allowed disabled:opacity-60';
+
+const variants: Record<Variant, string> = {
+  primary:
+    'bg-indigo-600 text-white hover:bg-indigo-500 focus-visible:ring-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400',
+  secondary:
+    'bg-gray-100 text-gray-900 hover:bg-gray-200 focus-visible:ring-gray-400 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700',
+  ghost:
+    'text-gray-700 hover:bg-gray-100 focus-visible:ring-gray-400 dark:text-gray-200 dark:hover:bg-gray-800',
+  danger:
+    'bg-red-600 text-white hover:bg-red-500 focus-visible:ring-red-500',
+};
+
+export function Button({ variant = 'primary', loading, disabled, children, className = '', ...rest }: Props) {
+  return (
+    <button
+      {...rest}
+      disabled={disabled || loading}
+      className={`${base} ${variants[variant]} ${className}`}
+    >
+      {loading && (
+        <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+          <circle cx="12" cy="12" r="10" stroke="currentColor" strokeOpacity="0.25" strokeWidth="3" />
+          <path d="M22 12a10 10 0 0 1-10 10" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+        </svg>
+      )}
+      {children}
+    </button>
+  );
+}

--- a/client/src/components/ui/FormField.tsx
+++ b/client/src/components/ui/FormField.tsx
@@ -1,0 +1,32 @@
+import type { InputHTMLAttributes, ReactNode } from 'react';
+
+type Props = InputHTMLAttributes<HTMLInputElement> & {
+  label: string;
+  error?: string | null;
+  hint?: ReactNode;
+};
+
+export function FormField({ label, error, hint, id, className = '', ...rest }: Props) {
+  const inputId = id ?? `f-${label.toLowerCase().replace(/\s+/g, '-')}`;
+  return (
+    <div className={className}>
+      <label
+        htmlFor={inputId}
+        className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300"
+      >
+        {label}
+      </label>
+      <input
+        id={inputId}
+        {...rest}
+        className={`block w-full rounded-md border bg-white px-3 py-2 text-sm text-gray-900 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-100 ${
+          error
+            ? 'border-red-400 focus:border-red-500 focus:ring-red-500 dark:border-red-500'
+            : 'border-gray-300 dark:border-gray-700'
+        }`}
+      />
+      {error && <p className="mt-1 text-xs text-red-600 dark:text-red-400">{error}</p>}
+      {!error && hint && <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{hint}</p>}
+    </div>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,92 @@
+import { useAuth } from '../stores/auth';
+import type { ApiResponse, RefreshResponse } from '../types/api';
+
+const NO_AUTO_REFRESH: RegExp[] = [/^\/api\/auth\/(login|register|refresh|forgot-password|reset-password|verify-email)/];
+
+type RequestOptions = {
+  method?: string;
+  body?: unknown;
+  signal?: AbortSignal;
+  skipAuth?: boolean;
+};
+
+// Coalesce concurrent refreshes so one rotation serves every in-flight caller.
+let refreshPromise: Promise<boolean> | null = null;
+
+async function refreshSession(): Promise<boolean> {
+  if (refreshPromise) return refreshPromise;
+  const { refreshToken } = useAuth.getState();
+  if (!refreshToken) return false;
+
+  refreshPromise = (async () => {
+    try {
+      const res = await fetch('/api/auth/refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refreshToken }),
+      });
+      const json = (await res.json()) as ApiResponse<RefreshResponse>;
+      if (!json.success) {
+        useAuth.getState().clear();
+        return false;
+      }
+      useAuth.getState().setSession(json.data);
+      return true;
+    } catch {
+      useAuth.getState().clear();
+      return false;
+    }
+  })();
+
+  try {
+    return await refreshPromise;
+  } finally {
+    refreshPromise = null;
+  }
+}
+
+async function doFetch(path: string, opts: RequestOptions): Promise<Response> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (!opts.skipAuth) {
+    const { accessToken } = useAuth.getState();
+    if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
+  }
+  return fetch(path, {
+    method: opts.method ?? 'GET',
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+    signal: opts.signal,
+  });
+}
+
+export async function api<T>(path: string, opts: RequestOptions = {}): Promise<ApiResponse<T>> {
+  let res = await doFetch(path, opts);
+
+  if (res.status === 401 && !NO_AUTO_REFRESH.some((re) => re.test(path)) && !opts.skipAuth) {
+    const refreshed = await refreshSession();
+    if (refreshed) {
+      res = await doFetch(path, opts);
+    }
+  }
+
+  try {
+    return (await res.json()) as ApiResponse<T>;
+  } catch {
+    return {
+      success: false,
+      data: null,
+      error: { code: 'NETWORK_ERROR', message: `Unexpected response (${res.status})` },
+    };
+  }
+}
+
+/** Convenience: throws if the envelope reports failure. Use when you don't need to branch on the error. */
+export async function apiOrThrow<T>(path: string, opts: RequestOptions = {}): Promise<T> {
+  const result = await api<T>(path, opts);
+  if (!result.success) {
+    const err = new Error(result.error.message);
+    (err as Error & { code?: string }).code = result.error.code;
+    throw err;
+  }
+  return result.data;
+}

--- a/client/src/pages/ForgotPassword.tsx
+++ b/client/src/pages/ForgotPassword.tsx
@@ -1,0 +1,65 @@
+import { type FormEvent, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AuthLayout } from '../components/layout/AuthLayout';
+import { Button } from '../components/ui/Button';
+import { FormField } from '../components/ui/FormField';
+import { Alert } from '../components/ui/Alert';
+import { api } from '../lib/api';
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [sent, setSent] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    const res = await api<{ sent: boolean }>('/api/auth/forgot-password', {
+      method: 'POST',
+      body: { email },
+      skipAuth: true,
+    });
+    setLoading(false);
+    if (!res.success) {
+      setError(res.error.message);
+      return;
+    }
+    setSent(true);
+  }
+
+  return (
+    <AuthLayout
+      title="Reset password"
+      subtitle="We'll send a reset link if an account exists for this email."
+      footer={
+        <Link to="/login" className="font-medium text-indigo-600 hover:underline dark:text-indigo-400">
+          Back to sign in
+        </Link>
+      }
+    >
+      {sent ? (
+        <Alert tone="success">
+          If an account matches <span className="font-mono">{email}</span>, a reset link is on its way.
+          The link expires in 1 hour.
+        </Alert>
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-4">
+          {error && <Alert tone="error">{error}</Alert>}
+          <FormField
+            label="Email"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Button type="submit" loading={loading} className="w-full">
+            Send reset link
+          </Button>
+        </form>
+      )}
+    </AuthLayout>
+  );
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+import { TopNav } from '../components/layout/TopNav';
+import { api } from '../lib/api';
+import { useAuth } from '../stores/auth';
+import type { HealthStatus, PublicUser } from '../types/api';
+
+export default function Home() {
+  const user = useAuth((s) => s.user);
+  const setUser = useAuth((s) => s.setUser);
+  const [health, setHealth] = useState<HealthStatus | null>(null);
+  const [healthError, setHealthError] = useState<string | null>(null);
+
+  // Refresh the user on mount in case the persisted profile is stale.
+  useEffect(() => {
+    void (async () => {
+      const res = await api<{ user: PublicUser }>('/api/auth/me');
+      if (res.success) setUser(res.data.user);
+    })();
+  }, [setUser]);
+
+  useEffect(() => {
+    void (async () => {
+      const res = await api<HealthStatus>('/api/health', { skipAuth: true });
+      if (res.success) setHealth(res.data);
+      else setHealthError(res.error.message);
+    })();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+      <TopNav />
+      <main className="mx-auto max-w-5xl px-6 py-10">
+        <div className="mb-8">
+          <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
+            Welcome{user?.name ? `, ${user.name}` : ''}
+          </h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Dashboard, Jobs, and Notifications land in upcoming releases. For now, backend wiring.
+          </p>
+        </div>
+
+        <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-gray-500">Account</h2>
+          <dl className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2 font-mono text-sm">
+            <Row label="email" value={user?.email ?? '\u2014'} />
+            <Row
+              label="verified"
+              value={user?.email_verified ? 'yes' : 'no'}
+              tone={user?.email_verified ? 'good' : 'warn'}
+            />
+            <Row label="name" value={user?.name ?? '\u2014'} />
+            <Row label="telegram" value={user?.telegram_chat_id ?? '\u2014'} />
+          </dl>
+        </section>
+
+        <section className="mt-6 rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-gray-500">Backend status</h2>
+          {healthError && <p className="mt-3 font-mono text-sm text-red-600">{healthError}</p>}
+          {!healthError && !health && <p className="mt-3 text-sm text-gray-500">Loading&hellip;</p>}
+          {health && (
+            <dl className="mt-3 space-y-2 font-mono text-sm">
+              <Row
+                label="status"
+                value={health.status}
+                tone={health.status === 'healthy' ? 'good' : 'warn'}
+              />
+              <Row
+                label="database"
+                value={
+                  health.checks.database.ok
+                    ? 'ok'
+                    : `down${health.checks.database.error ? ` \u2014 ${health.checks.database.error}` : ''}`
+                }
+                tone={health.checks.database.ok ? 'good' : 'bad'}
+              />
+              <Row
+                label="redis"
+                value={
+                  health.checks.redis.ok
+                    ? 'ok'
+                    : `down${health.checks.redis.error ? ` \u2014 ${health.checks.redis.error}` : ''}`
+                }
+                tone={health.checks.redis.ok ? 'good' : 'bad'}
+              />
+              <Row label="uptime" value={`${health.uptime.toFixed(1)}s`} />
+            </dl>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+function Row({ label, value, tone }: { label: string; value: string; tone?: 'good' | 'warn' | 'bad' }) {
+  const toneClass =
+    tone === 'good'
+      ? 'text-emerald-600 dark:text-emerald-400'
+      : tone === 'warn'
+        ? 'text-amber-600 dark:text-amber-400'
+        : tone === 'bad'
+          ? 'text-red-600 dark:text-red-400'
+          : 'text-gray-900 dark:text-gray-100';
+  return (
+    <div className="flex justify-between">
+      <dt className="text-gray-500">{label}</dt>
+      <dd className={toneClass}>{value}</dd>
+    </div>
+  );
+}

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,0 +1,90 @@
+import { type FormEvent, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { AuthLayout } from '../components/layout/AuthLayout';
+import { Button } from '../components/ui/Button';
+import { FormField } from '../components/ui/FormField';
+import { Alert } from '../components/ui/Alert';
+import { api } from '../lib/api';
+import { useAuth } from '../stores/auth';
+import type { LoginResponse } from '../types/api';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const setSession = useAuth((s) => s.setSession);
+  const setUser = useAuth((s) => s.setUser);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    const res = await api<LoginResponse>('/api/auth/login', {
+      method: 'POST',
+      body: { email, password },
+      skipAuth: true,
+    });
+    setLoading(false);
+    if (!res.success) {
+      setError(res.error.message);
+      return;
+    }
+    setSession({
+      accessToken: res.data.accessToken,
+      refreshToken: res.data.refreshToken,
+      refreshExpiresAt: res.data.refreshExpiresAt,
+    });
+    setUser(res.data.user);
+    const from = (location.state as { from?: { pathname?: string } } | null)?.from?.pathname ?? '/';
+    navigate(from, { replace: true });
+  }
+
+  return (
+    <AuthLayout
+      title="Sign in"
+      subtitle="Welcome back."
+      footer={
+        <>
+          New here?{' '}
+          <Link to="/register" className="font-medium text-indigo-600 hover:underline dark:text-indigo-400">
+            Create an account
+          </Link>
+        </>
+      }
+    >
+      <form onSubmit={onSubmit} className="space-y-4">
+        {error && <Alert tone="error">{error}</Alert>}
+        <FormField
+          label="Email"
+          type="email"
+          autoComplete="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <FormField
+          label="Password"
+          type="password"
+          autoComplete="current-password"
+          required
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <div className="flex items-center justify-between">
+          <Link
+            to="/forgot-password"
+            className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
+          >
+            Forgot password?
+          </Link>
+          <Button type="submit" loading={loading}>
+            Sign in
+          </Button>
+        </div>
+      </form>
+    </AuthLayout>
+  );
+}

--- a/client/src/pages/Register.tsx
+++ b/client/src/pages/Register.tsx
@@ -1,0 +1,141 @@
+import { type FormEvent, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AuthLayout } from '../components/layout/AuthLayout';
+import { Button } from '../components/ui/Button';
+import { FormField } from '../components/ui/FormField';
+import { Alert } from '../components/ui/Alert';
+import { api } from '../lib/api';
+import type { RegisterResponse } from '../types/api';
+
+type FieldErrors = Record<string, string>;
+
+export default function Register() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [success, setSuccess] = useState<{ devToken?: string } | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setFieldErrors({});
+    if (password !== confirm) {
+      setFieldErrors({ confirm: 'Passwords do not match' });
+      return;
+    }
+    setLoading(true);
+    const res = await api<RegisterResponse>('/api/auth/register', {
+      method: 'POST',
+      body: { email, password, name: name || undefined },
+      skipAuth: true,
+    });
+    setLoading(false);
+    if (!res.success) {
+      if (res.error.code === 'VALIDATION_ERROR' && res.error.details) {
+        const errs: FieldErrors = {};
+        for (const d of res.error.details) errs[d.path] = d.message;
+        setFieldErrors(errs);
+      } else {
+        setError(res.error.message);
+      }
+      return;
+    }
+    setSuccess({ devToken: res.data.devToken });
+  }
+
+  if (success) {
+    return (
+      <AuthLayout
+        title="Check your email"
+        subtitle="We sent a verification link to your inbox."
+        footer={
+          <Link to="/login" className="font-medium text-indigo-600 hover:underline dark:text-indigo-400">
+            Continue to sign in
+          </Link>
+        }
+      >
+        <Alert tone="success">
+          Account created. Open the verification link to activate your account.
+        </Alert>
+        {success.devToken && (
+          <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-xs dark:border-amber-900/60 dark:bg-amber-950/40">
+            <p className="mb-2 font-medium uppercase tracking-wide text-amber-800 dark:text-amber-300">
+              Dev shortcut
+            </p>
+            <p className="text-amber-900 dark:text-amber-200">
+              No SMTP configured. Use this dev-only link to verify directly:
+            </p>
+            <a
+              href={`/verify-email?token=${encodeURIComponent(success.devToken)}`}
+              className="mt-2 block break-all font-mono text-xs text-indigo-700 hover:underline dark:text-indigo-300"
+            >
+              /verify-email?token={success.devToken}
+            </a>
+          </div>
+        )}
+      </AuthLayout>
+    );
+  }
+
+  return (
+    <AuthLayout
+      title="Create account"
+      subtitle="Track anything on the web."
+      footer={
+        <>
+          Already have an account?{' '}
+          <Link to="/login" className="font-medium text-indigo-600 hover:underline dark:text-indigo-400">
+            Sign in
+          </Link>
+        </>
+      }
+    >
+      <form onSubmit={onSubmit} className="space-y-4">
+        {error && <Alert tone="error">{error}</Alert>}
+        <FormField
+          label="Name"
+          autoComplete="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          error={fieldErrors.name}
+          placeholder="Optional"
+        />
+        <FormField
+          label="Email"
+          type="email"
+          autoComplete="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          error={fieldErrors.email}
+        />
+        <FormField
+          label="Password"
+          type="password"
+          autoComplete="new-password"
+          required
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          error={fieldErrors.password}
+          hint="At least 8 characters."
+        />
+        <FormField
+          label="Confirm password"
+          type="password"
+          autoComplete="new-password"
+          required
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          error={fieldErrors.confirm}
+        />
+        <Button type="submit" loading={loading} className="w-full">
+          Create account
+        </Button>
+      </form>
+    </AuthLayout>
+  );
+}

--- a/client/src/pages/ResetPassword.tsx
+++ b/client/src/pages/ResetPassword.tsx
@@ -1,0 +1,91 @@
+import { type FormEvent, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { AuthLayout } from '../components/layout/AuthLayout';
+import { Button } from '../components/ui/Button';
+import { FormField } from '../components/ui/FormField';
+import { Alert } from '../components/ui/Alert';
+import { api } from '../lib/api';
+
+export default function ResetPassword() {
+  const [params] = useSearchParams();
+  const token = params.get('token') ?? '';
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setFieldErrors({});
+    if (password !== confirm) {
+      setFieldErrors({ confirm: 'Passwords do not match' });
+      return;
+    }
+    setLoading(true);
+    const res = await api<{ reset: boolean }>('/api/auth/reset-password', {
+      method: 'POST',
+      body: { token, password },
+      skipAuth: true,
+    });
+    setLoading(false);
+    if (!res.success) {
+      if (res.error.code === 'VALIDATION_ERROR' && res.error.details) {
+        const errs: Record<string, string> = {};
+        for (const d of res.error.details) errs[d.path] = d.message;
+        setFieldErrors(errs);
+      } else {
+        setError(res.error.message);
+      }
+      return;
+    }
+    navigate('/login?reset=1', { replace: true });
+  }
+
+  if (!token) {
+    return (
+      <AuthLayout title="Reset password">
+        <Alert tone="error">Missing reset token. Request a new link from the forgot-password page.</Alert>
+      </AuthLayout>
+    );
+  }
+
+  return (
+    <AuthLayout
+      title="Set a new password"
+      footer={
+        <Link to="/login" className="font-medium text-indigo-600 hover:underline dark:text-indigo-400">
+          Back to sign in
+        </Link>
+      }
+    >
+      <form onSubmit={onSubmit} className="space-y-4">
+        {error && <Alert tone="error">{error}</Alert>}
+        <FormField
+          label="New password"
+          type="password"
+          autoComplete="new-password"
+          required
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          error={fieldErrors.password}
+          hint="At least 8 characters."
+        />
+        <FormField
+          label="Confirm password"
+          type="password"
+          autoComplete="new-password"
+          required
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          error={fieldErrors.confirm}
+        />
+        <Button type="submit" loading={loading} className="w-full">
+          Update password
+        </Button>
+      </form>
+    </AuthLayout>
+  );
+}

--- a/client/src/pages/VerifyEmail.tsx
+++ b/client/src/pages/VerifyEmail.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { AuthLayout } from '../components/layout/AuthLayout';
+import { Alert } from '../components/ui/Alert';
+import { api } from '../lib/api';
+import type { PublicUser } from '../types/api';
+
+type Status = 'pending' | 'success' | 'error';
+
+export default function VerifyEmail() {
+  const [params] = useSearchParams();
+  const token = params.get('token') ?? '';
+  const [status, setStatus] = useState<Status>('pending');
+  const [message, setMessage] = useState<string>('');
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    if (ranRef.current) return;
+    ranRef.current = true;
+    if (!token) {
+      setStatus('error');
+      setMessage('Missing verification token.');
+      return;
+    }
+    void (async () => {
+      const res = await api<{ user: PublicUser }>('/api/auth/verify-email', {
+        method: 'POST',
+        body: { token },
+        skipAuth: true,
+      });
+      if (res.success) {
+        setStatus('success');
+        setMessage(`${res.data.user.email} is verified.`);
+      } else {
+        setStatus('error');
+        setMessage(res.error.message);
+      }
+    })();
+  }, [token]);
+
+  return (
+    <AuthLayout
+      title="Verify email"
+      footer={
+        <Link to="/login" className="font-medium text-indigo-600 hover:underline dark:text-indigo-400">
+          Continue to sign in
+        </Link>
+      }
+    >
+      {status === 'pending' && <p className="text-sm text-gray-500">Verifying&hellip;</p>}
+      {status === 'success' && <Alert tone="success">{message}</Alert>}
+      {status === 'error' && <Alert tone="error">{message}</Alert>}
+    </AuthLayout>
+  );
+}

--- a/client/src/stores/auth.ts
+++ b/client/src/stores/auth.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { PublicUser, Session } from '../types/api';
+
+type AuthState = {
+  accessToken: string | null;
+  refreshToken: string | null;
+  refreshExpiresAt: string | null;
+  user: PublicUser | null;
+  setSession: (session: Session) => void;
+  setUser: (user: PublicUser | null) => void;
+  clear: () => void;
+};
+
+export const useAuth = create<AuthState>()(
+  persist(
+    (set) => ({
+      accessToken: null,
+      refreshToken: null,
+      refreshExpiresAt: null,
+      user: null,
+      setSession: (session) =>
+        set({
+          accessToken: session.accessToken,
+          refreshToken: session.refreshToken,
+          refreshExpiresAt: session.refreshExpiresAt,
+        }),
+      setUser: (user) => set({ user }),
+      clear: () =>
+        set({
+          accessToken: null,
+          refreshToken: null,
+          refreshExpiresAt: null,
+          user: null,
+        }),
+    }),
+    {
+      name: 'smartscrape-auth',
+      // Only persist session-relevant fields; user is refetched on mount.
+      partialize: (state) => ({
+        accessToken: state.accessToken,
+        refreshToken: state.refreshToken,
+        refreshExpiresAt: state.refreshExpiresAt,
+        user: state.user,
+      }),
+    },
+  ),
+);

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -1,0 +1,39 @@
+export type PublicUser = {
+  id: string;
+  email: string;
+  name: string | null;
+  email_verified: boolean;
+  telegram_chat_id: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Session = {
+  accessToken: string;
+  refreshToken: string;
+  refreshExpiresAt: string;
+};
+
+export type LoginResponse = Session & { user: PublicUser };
+export type RegisterResponse = { user: PublicUser; devToken?: string };
+export type RefreshResponse = Session;
+
+export type ApiError = {
+  code: string;
+  message: string;
+  details?: { path: string; message: string }[];
+};
+
+export type ApiResponse<T> =
+  | { success: true; data: T; error: null }
+  | { success: false; data: null; error: ApiError };
+
+export type HealthStatus = {
+  status: 'healthy' | 'degraded';
+  checks: {
+    database: { ok: boolean; error?: string };
+    redis: { ok: boolean; error?: string };
+  };
+  uptime: number;
+  timestamp: string;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,9 @@
       "version": "0.0.1",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.1.1",
+        "zustand": "^5.0.2"
       },
       "devDependencies": {
         "@types/react": "^18.3.18",
@@ -1754,7 +1756,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -1775,7 +1777,7 @@
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2654,7 +2656,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -5129,6 +5131,57 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5431,6 +5484,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -6637,6 +6696,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "server": {


### PR DESCRIPTION
## Summary

Companion to [#6](https://github.com/9ny4/smartscrape/pull/6). Completes Build Order step 3 from [HANDOFF-smartscrape.md](HANDOFF-smartscrape.md).

## Changes

### State + network
- `stores/auth.ts` \u2014 Zustand store with `persist` to localStorage so a hard-refresh doesn't log the user out mid-session. Holds access/refresh tokens, expiry, and cached `user`.
- `lib/api.ts` \u2014 fetch wrapper that:
  - Attaches `Authorization: Bearer` when signed in.
  - Auto-refreshes once on 401, then retries. Refresh attempts are coalesced through a single in-flight promise so concurrent requests share one rotation.
  - Excludes `/api/auth/*` endpoints from the refresh-and-retry path to avoid loops.
  - Returns the typed `ApiResponse<T>` envelope so handlers branch on `success` cleanly.

### UI primitives + layout
- `ui/Button`, `ui/FormField`, `ui/Alert` \u2014 design-direction-compliant: subtle borders, generous spacing, Inter sans, mono for data, indigo accent, light/dark classes throughout (toggle deferred to step 16).
- `layout/AuthLayout` \u2014 centered card for every public page.
- `layout/TopNav` \u2014 minimal navbar with an avatar-initial menu and logout for authed pages.
- `RequireAuth` / `RedirectIfAuthed` route guards driven by access-token presence.

### Pages
| Route | Purpose |
|---|---|
| `/login` | Email + password; redirects back to `?from=` |
| `/register` | Name / email / password / confirm. In dev, the success screen includes the `devToken` as a direct verify link so flows are testable without SMTP. |
| `/forgot-password` | Always shows the same success message (mirrors the backend's no-enum guarantee). |
| `/reset-password` | Reads token from query, updates password, redirects to `/login`. |
| `/verify-email` | Reads token from query, auto-POSTs on mount (StrictMode-safe ref guard), shows result. |
| `/` (authed) | Home: signed-in user card, backend health card, logout via TopNav. Refreshes user from `/api/auth/me` on mount. |

### Validation UX

Per-field errors are lifted straight from the API's `VALIDATION_ERROR.details[]` (e.g. `{ path: 'password', message: 'Password must be at least 8 characters' }`) and rendered under the matching `FormField`. Unknown error codes surface as a top-level `Alert`.

## Test plan

- [x] `npm run typecheck` clean (server + client)
- [x] `npm run lint` clean
- [x] `npm run build` clean (client 202 kB \u2192 66 kB gzipped)
- [x] SPA serves at `/` and `/login` via Vite dev (history-API fallback verified)
- [x] Backend end-to-end register \u2192 verify \u2192 login still green against live Postgres + Redis (already covered by PR #6 smoke)
- [ ] Manual browser click-through \u2014 Chrome MCP unavailable this session. Code paths exercised by typecheck + backend smoke are solid; recommend a quick manual pass after merge.

## Out of scope

Dashboard / Jobs / Notifications / Settings pages, dark-mode toggle (Build Order steps 7+, 14\u201316). Integration + e2e tests (follow-up).

Closes #7