### PR TITLE
feat: AI provider key management (backend)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.40.1.tgz",
+      "integrity": "sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -1724,10 +1754,19 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/nodemailer": {
@@ -2069,6 +2108,18 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2103,6 +2154,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2198,6 +2261,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
@@ -2565,6 +2634,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2682,6 +2763,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/denque": {
       "version": "2.1.0",
@@ -2813,6 +2903,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3131,6 +3236,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/express": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
@@ -3399,6 +3513,41 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3608,6 +3757,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -3638,6 +3802,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -4293,6 +4466,46 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -4507,6 +4720,51 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -5837,6 +6095,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -5945,7 +6209,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -6582,6 +6845,31 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6731,6 +7019,7 @@
       "name": "@smartscrape/server",
       "version": "0.0.1",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.40.1",
         "bcrypt": "^6.0.0",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
@@ -6739,6 +7028,7 @@
         "jsonwebtoken": "^9.0.2",
         "node-pg-migrate": "^8.0.4",
         "nodemailer": "^8.0.6",
+        "openai": "^4.77.3",
         "pg": "^8.13.1",
         "zod": "^3.24.1"
       },

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "migrate:create": "node --import tsx/esm scripts/migrate.ts create"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.40.1",
     "bcrypt": "^6.0.0",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
@@ -24,6 +25,7 @@
     "jsonwebtoken": "^9.0.2",
     "node-pg-migrate": "^8.0.4",
     "nodemailer": "^8.0.6",
+    "openai": "^4.77.3",
     "pg": "^8.13.1",
     "zod": "^3.24.1"
   },

--- a/server/src/config/encryption.ts
+++ b/server/src/config/encryption.ts
@@ -1,0 +1,37 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import { requireSecrets } from './env.js';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12; // 96-bit IV recommended for GCM
+const AUTH_TAG_LENGTH = 16;
+
+function keyBuffer(): Buffer {
+  const { encryptionKey } = requireSecrets();
+  return Buffer.from(encryptionKey, 'hex');
+}
+
+/**
+ * Encrypt a UTF-8 string with AES-256-GCM. Returns a self-contained
+ * base64url-encoded payload of `iv | authTag | ciphertext` so rotation
+ * of stored values doesn't need a schema change.
+ */
+export function encrypt(plaintext: string): string {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, keyBuffer(), iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([iv, authTag, ciphertext]).toString('base64url');
+}
+
+export function decrypt(encoded: string): string {
+  const buf = Buffer.from(encoded, 'base64url');
+  if (buf.length <= IV_LENGTH + AUTH_TAG_LENGTH) {
+    throw new Error('Ciphertext too short');
+  }
+  const iv = buf.subarray(0, IV_LENGTH);
+  const authTag = buf.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const ciphertext = buf.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, keyBuffer(), iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+}

--- a/server/src/db/apiKeys.ts
+++ b/server/src/db/apiKeys.ts
@@ -1,0 +1,70 @@
+import { getPool } from '../config/database.js';
+
+export const PROVIDERS = ['openai', 'anthropic', 'openrouter'] as const;
+export type Provider = (typeof PROVIDERS)[number];
+
+export type ApiKeyRow = {
+  id: string;
+  user_id: string;
+  provider: Provider;
+  api_key_encrypted: string;
+  is_active: boolean;
+  created_at: Date;
+};
+
+export type ProviderSummary = {
+  provider: Provider;
+  connected: boolean;
+  created_at: string;
+};
+
+export async function listByUser(userId: string): Promise<ProviderSummary[]> {
+  const { rows } = await getPool().query<Pick<ApiKeyRow, 'provider' | 'created_at' | 'is_active'>>(
+    `SELECT provider, created_at, is_active FROM api_keys WHERE user_id = $1 ORDER BY provider`,
+    [userId],
+  );
+  return rows.map((r) => ({
+    provider: r.provider,
+    connected: r.is_active,
+    created_at: r.created_at.toISOString(),
+  }));
+}
+
+export async function upsertForUser(
+  userId: string,
+  provider: Provider,
+  encrypted: string,
+): Promise<ProviderSummary> {
+  const { rows } = await getPool().query<Pick<ApiKeyRow, 'provider' | 'created_at' | 'is_active'>>(
+    `INSERT INTO api_keys (user_id, provider, api_key_encrypted)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (user_id, provider)
+       DO UPDATE SET api_key_encrypted = EXCLUDED.api_key_encrypted,
+                     is_active = true,
+                     created_at = now()
+     RETURNING provider, created_at, is_active`,
+    [userId, provider, encrypted],
+  );
+  const row = rows[0]!;
+  return {
+    provider: row.provider,
+    connected: row.is_active,
+    created_at: row.created_at.toISOString(),
+  };
+}
+
+export async function findForUser(userId: string, provider: Provider): Promise<ApiKeyRow | null> {
+  const { rows } = await getPool().query<ApiKeyRow>(
+    `SELECT * FROM api_keys WHERE user_id = $1 AND provider = $2 LIMIT 1`,
+    [userId, provider],
+  );
+  return rows[0] ?? null;
+}
+
+export async function deleteForUser(userId: string, provider: Provider): Promise<boolean> {
+  const { rowCount } = await getPool().query(
+    `DELETE FROM api_keys WHERE user_id = $1 AND provider = $2`,
+    [userId, provider],
+  );
+  return (rowCount ?? 0) > 0;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import { closeDatabase } from './config/database.js';
 import { closeRedis } from './config/redis.js';
 import { authRouter } from './routes/auth.js';
 import { healthRouter } from './routes/health.js';
+import { providersRouter } from './routes/providers.js';
 import { generalLimiter } from './middleware/rateLimit.js';
 import { fail } from './lib/response.js';
 
@@ -20,6 +21,7 @@ app.use('/api/health', healthRouter);
 
 app.use('/api', generalLimiter);
 app.use('/api/auth', authRouter);
+app.use('/api/providers', providersRouter);
 
 app.use((_req, res) => {
   res.status(404).json(fail('NOT_FOUND', 'Route not found'));

--- a/server/src/routes/providers.ts
+++ b/server/src/routes/providers.ts
@@ -1,0 +1,63 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { decrypt, encrypt } from '../config/encryption.js';
+import { deleteForUser, findForUser, listByUser, PROVIDERS, upsertForUser } from '../db/apiKeys.js';
+import { fail, ok } from '../lib/response.js';
+import { requireAuth } from '../middleware/auth.js';
+import { validate } from '../middleware/validate.js';
+import { testCredentials } from '../services/ai-providers.js';
+
+export const providersRouter = Router();
+
+const providerEnum = z.enum(PROVIDERS);
+
+const upsertBody = z.object({
+  provider: providerEnum,
+  apiKey: z.string().min(10, 'API key looks too short').max(500),
+});
+
+const providerParams = z.object({
+  provider: providerEnum,
+});
+
+providersRouter.use(requireAuth);
+
+providersRouter.get('/', async (req, res) => {
+  const rows = await listByUser(req.user!.id);
+  res.status(200).json(ok({ providers: rows }));
+});
+
+providersRouter.post('/', validate(upsertBody), async (req, res) => {
+  const { provider, apiKey } = req.body as z.infer<typeof upsertBody>;
+  const encrypted = encrypt(apiKey);
+  const row = await upsertForUser(req.user!.id, provider, encrypted);
+  res.status(200).json(ok({ provider: row }));
+});
+
+providersRouter.delete('/:provider', validate(providerParams, 'params'), async (req, res) => {
+  const { provider } = req.params as unknown as z.infer<typeof providerParams>;
+  const removed = await deleteForUser(req.user!.id, provider);
+  if (!removed) {
+    res.status(404).json(fail('NOT_FOUND', 'No key stored for that provider'));
+    return;
+  }
+  res.status(200).json(ok({ provider, removed: true }));
+});
+
+providersRouter.post('/:provider/test', validate(providerParams, 'params'), async (req, res) => {
+  const { provider } = req.params as unknown as z.infer<typeof providerParams>;
+  const row = await findForUser(req.user!.id, provider);
+  if (!row) {
+    res.status(404).json(fail('NOT_FOUND', 'No key stored for that provider'));
+    return;
+  }
+  let apiKey: string;
+  try {
+    apiKey = decrypt(row.api_key_encrypted);
+  } catch {
+    res.status(500).json(fail('DECRYPT_FAILED', 'Stored key could not be decrypted'));
+    return;
+  }
+  const result = await testCredentials(provider, apiKey);
+  res.status(200).json(ok(result));
+});

--- a/server/src/services/ai-providers.ts
+++ b/server/src/services/ai-providers.ts
@@ -1,0 +1,51 @@
+import Anthropic from '@anthropic-ai/sdk';
+import OpenAI from 'openai';
+import type { Provider } from '../db/apiKeys.js';
+
+export type TestResult = {
+  ok: boolean;
+  latencyMs: number;
+  error?: string;
+};
+
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+
+/**
+ * Make the cheapest possible authenticated call to verify the API key.
+ * For all three providers that's a models-list call \u2014 no tokens consumed,
+ * but requires a valid key. Network/auth errors are caught and surfaced
+ * as a user-friendly message rather than crashing the request.
+ */
+export async function testCredentials(provider: Provider, apiKey: string): Promise<TestResult> {
+  const started = Date.now();
+  try {
+    if (provider === 'openai') {
+      const client = new OpenAI({ apiKey });
+      await client.models.list();
+    } else if (provider === 'anthropic') {
+      const client = new Anthropic({ apiKey });
+      await client.models.list({ limit: 1 });
+    } else {
+      // OpenRouter implements the OpenAI spec.
+      const client = new OpenAI({ apiKey, baseURL: OPENROUTER_BASE_URL });
+      await client.models.list();
+    }
+    return { ok: true, latencyMs: Date.now() - started };
+  } catch (err) {
+    return {
+      ok: false,
+      latencyMs: Date.now() - started,
+      error: friendlyError(err),
+    };
+  }
+}
+
+function friendlyError(err: unknown): string {
+  if (err instanceof OpenAI.APIError || err instanceof Anthropic.APIError) {
+    if (err.status === 401 || err.status === 403) return 'Invalid API key';
+    if (err.status === 429) return 'Rate limited by provider';
+    return `${err.status ?? 'error'}: ${err.message}`;
+  }
+  if (err instanceof Error) return err.message;
+  return 'Unknown error';
+}


### PR DESCRIPTION
## Summary

Build Order step 4 from [HANDOFF-smartscrape.md](HANDOFF-smartscrape.md), backend half. Frontend Settings UI follows.

## Changes

### Crypto
- `config/encryption.ts` \u2014 AES-256-GCM with a fresh 96-bit IV per call. Output is base64url `iv|authTag|ciphertext` so a future key rotation can be versioned without a schema change. Pulls the key through `requireSecrets()` so misconfiguration fails at boot, not on first write.

### Data
- `db/apiKeys.ts` \u2014 `listByUser`, `upsertForUser` (ON CONFLICT replaces and bumps `created_at`), `findForUser`, `deleteForUser`. All queries scoped to `user_id`.

### Services
- `services/ai-providers.ts` \u2014 `testCredentials(provider, apiKey)` uses the official SDKs per handoff:
  - OpenAI \u2192 `openai` SDK
  - Anthropic \u2192 `@anthropic-ai/sdk`
  - OpenRouter \u2192 `openai` SDK with `baseURL = https://openrouter.ai/api/v1`
- The test call is each SDK's `models.list()` \u2014 authenticated but token-free. Errors are mapped to friendly strings (`Invalid API key`, `Rate limited by provider`, ...).

### Routes (all `requireAuth`)
| Method | Route | Notes |
|---|---|---|
| GET | `/api/providers` | Returns `{provider, connected, created_at}` \u2014 key never leaves the server |
| POST | `/api/providers` | `{provider, apiKey}`; encrypts + upserts |
| DELETE | `/api/providers/:provider` | `NOT_FOUND` on second call |
| POST | `/api/providers/:provider/test` | `{ok, latencyMs, error?}` |

## Smoke test (all green on live Postgres + fake key hitting real OpenAI)

- Encryption round-trip OK, and two successive `encrypt(plain)` calls produce different ciphertext (fresh IV).
- Empty list \u2192 add \u2192 list (no key leaked) \u2192 upsert replaces \u2192 test returns `ok:false, error:\"Invalid API key\"` (real OpenAI 401 in 261ms) \u2192 delete \u2192 delete-again `NOT_FOUND`.
- Unknown provider \u2192 `VALIDATION_ERROR` with enum detail.
- Test on unconfigured provider \u2192 `NOT_FOUND`.
- Unauthed \u2192 `UNAUTHORIZED`.

## Out of scope

- Frontend Settings UI with per-provider cards (follow-up issue).
- Token-usage tracking (explicit v1 exclusion).

Closes #9