### PR TITLE
feat: Settings page with AI provider cards

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import Home from './pages/Home';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import ResetPassword from './pages/ResetPassword';
+import Settings from './pages/Settings';
 import VerifyEmail from './pages/VerifyEmail';
 
 export default function App() {
@@ -36,6 +37,14 @@ export default function App() {
           element={
             <RequireAuth>
               <Home />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/settings"
+          element={
+            <RequireAuth>
+              <Settings />
             </RequireAuth>
           }
         />

--- a/client/src/components/ProviderCard.tsx
+++ b/client/src/components/ProviderCard.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react';
+import { Alert } from './ui/Alert';
+import { Button } from './ui/Button';
+import { FormField } from './ui/FormField';
+import { api } from '../lib/api';
+import type { Provider, ProviderSummary, ProviderTestResult } from '../types/api';
+
+type Props = {
+  provider: Provider;
+  label: string;
+  description: string;
+  summary: ProviderSummary | undefined;
+  onChange: () => void;
+};
+
+type Status =
+  | { kind: 'idle' }
+  | { kind: 'saving' }
+  | { kind: 'testing' }
+  | { kind: 'removing' }
+  | { kind: 'tested'; result: ProviderTestResult }
+  | { kind: 'error'; message: string };
+
+export function ProviderCard({ provider, label, description, summary, onChange }: Props) {
+  const [apiKey, setApiKey] = useState('');
+  const [status, setStatus] = useState<Status>({ kind: 'idle' });
+  const connected = Boolean(summary?.connected);
+
+  async function save() {
+    if (!apiKey.trim()) return;
+    setStatus({ kind: 'saving' });
+    const res = await api<{ provider: ProviderSummary }>('/api/providers', {
+      method: 'POST',
+      body: { provider, apiKey: apiKey.trim() },
+    });
+    if (!res.success) {
+      setStatus({
+        kind: 'error',
+        message: res.error.details?.[0]?.message ?? res.error.message,
+      });
+      return;
+    }
+    setApiKey('');
+    setStatus({ kind: 'idle' });
+    onChange();
+  }
+
+  async function test() {
+    setStatus({ kind: 'testing' });
+    const res = await api<ProviderTestResult>(`/api/providers/${provider}/test`, { method: 'POST' });
+    if (!res.success) {
+      setStatus({ kind: 'error', message: res.error.message });
+      return;
+    }
+    setStatus({ kind: 'tested', result: res.data });
+  }
+
+  async function remove() {
+    setStatus({ kind: 'removing' });
+    const res = await api<{ removed: boolean }>(`/api/providers/${provider}`, { method: 'DELETE' });
+    if (!res.success) {
+      setStatus({ kind: 'error', message: res.error.message });
+      return;
+    }
+    setStatus({ kind: 'idle' });
+    onChange();
+  }
+
+  return (
+    <article className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">{label}</h3>
+          <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">{description}</p>
+        </div>
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${
+            connected
+              ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+              : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+          }`}
+        >
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${
+              connected ? 'bg-emerald-500' : 'bg-gray-400'
+            }`}
+          />
+          {connected ? 'Connected' : 'Not configured'}
+        </span>
+      </header>
+
+      {connected && summary && (
+        <p className="mt-3 font-mono text-xs text-gray-500 dark:text-gray-400">
+          Added {new Date(summary.created_at).toLocaleString()}
+        </p>
+      )}
+
+      <div className="mt-4">
+        <FormField
+          label={connected ? 'Replace API key' : 'API key'}
+          type="password"
+          autoComplete="off"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder={connected ? '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022 (enter to replace)' : 'Paste key'}
+          hint={connected ? 'Saved keys are never displayed. Enter a new key to replace.' : undefined}
+        />
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <Button onClick={save} loading={status.kind === 'saving'} disabled={!apiKey.trim()}>
+          {connected ? 'Replace' : 'Save'}
+        </Button>
+        {connected && (
+          <>
+            <Button variant="secondary" onClick={test} loading={status.kind === 'testing'}>
+              Test
+            </Button>
+            <Button variant="ghost" onClick={remove} loading={status.kind === 'removing'}>
+              Remove
+            </Button>
+          </>
+        )}
+      </div>
+
+      {status.kind === 'tested' && (
+        <div className="mt-4">
+          {status.result.ok ? (
+            <Alert tone="success">
+              Credentials valid \u2014 <span className="font-mono">{status.result.latencyMs}ms</span>
+            </Alert>
+          ) : (
+            <Alert tone="error">
+              {status.result.error ?? 'Test failed'} (<span className="font-mono">{status.result.latencyMs}ms</span>)
+            </Alert>
+          )}
+        </div>
+      )}
+      {status.kind === 'error' && (
+        <div className="mt-4">
+          <Alert tone="error">{status.message}</Alert>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/client/src/components/layout/TopNav.tsx
+++ b/client/src/components/layout/TopNav.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
 import { useAuth } from '../../stores/auth';
 
 export function TopNav() {
@@ -10,9 +10,15 @@ export function TopNav() {
   return (
     <header className="border-b border-gray-200 bg-white/70 backdrop-blur dark:border-gray-800 dark:bg-gray-950/70">
       <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-3">
-        <Link to="/" className="text-sm font-semibold tracking-tight text-gray-900 dark:text-gray-100">
-          SmartScrape
-        </Link>
+        <div className="flex items-center gap-6">
+          <Link to="/" className="text-sm font-semibold tracking-tight text-gray-900 dark:text-gray-100">
+            SmartScrape
+          </Link>
+          <nav className="hidden items-center gap-1 sm:flex">
+            <NavItem to="/">Home</NavItem>
+            <NavItem to="/settings">Settings</NavItem>
+          </nav>
+        </div>
         <div className="relative">
           <button
             onClick={() => setOpen((v) => !v)}
@@ -48,5 +54,23 @@ export function TopNav() {
         </div>
       </div>
     </header>
+  );
+}
+
+function NavItem({ to, children }: { to: string; children: React.ReactNode }) {
+  return (
+    <NavLink
+      to={to}
+      end={to === '/'}
+      className={({ isActive }) =>
+        `rounded-md px-2.5 py-1.5 text-sm transition ${
+          isActive
+            ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+            : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100'
+        }`
+      }
+    >
+      {children}
+    </NavLink>
   );
 }

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useState } from 'react';
+import { TopNav } from '../components/layout/TopNav';
+import { ProviderCard } from '../components/ProviderCard';
+import { api } from '../lib/api';
+import type { Provider, ProviderSummary } from '../types/api';
+
+type ProviderSpec = {
+  provider: Provider;
+  label: string;
+  description: string;
+};
+
+const PROVIDER_SPECS: ProviderSpec[] = [
+  {
+    provider: 'openai',
+    label: 'OpenAI',
+    description: 'Used for GPT-family extraction models. Create a key at platform.openai.com.',
+  },
+  {
+    provider: 'anthropic',
+    label: 'Anthropic',
+    description: 'Claude models. Create a key at console.anthropic.com.',
+  },
+  {
+    provider: 'openrouter',
+    label: 'OpenRouter',
+    description: 'Unified gateway to many models. Create a key at openrouter.ai.',
+  },
+];
+
+export default function Settings() {
+  const [providers, setProviders] = useState<ProviderSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const res = await api<{ providers: ProviderSummary[] }>('/api/providers');
+    if (res.success) {
+      setProviders(res.data.providers);
+      setError(null);
+    } else {
+      setError(res.error.message);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const byProvider = new Map(providers?.map((p) => [p.provider, p]) ?? []);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+      <TopNav />
+      <main className="mx-auto max-w-5xl px-6 py-10">
+        <div className="mb-8">
+          <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">Settings</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Manage AI provider keys and account preferences.
+          </p>
+        </div>
+
+        <section className="space-y-4">
+          <div className="flex items-end justify-between">
+            <div>
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+                AI providers
+              </h2>
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                Keys are encrypted at rest with AES-256-GCM. Smart\u00adScrape never logs or exposes them.
+              </p>
+            </div>
+          </div>
+
+          {error && (
+            <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+              {error}
+            </p>
+          )}
+
+          {providers === null ? (
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {PROVIDER_SPECS.map((s) => (
+                <div
+                  key={s.provider}
+                  className="h-40 animate-pulse rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900"
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {PROVIDER_SPECS.map((s) => (
+                <ProviderCard
+                  key={s.provider}
+                  provider={s.provider}
+                  label={s.label}
+                  description={s.description}
+                  summary={byProvider.get(s.provider)}
+                  onChange={refresh}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="mt-12 space-y-4">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+            Coming soon
+          </h2>
+          <div className="rounded-lg border border-dashed border-gray-300 bg-white/40 p-6 text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-400">
+            Profile, Google Sheets, Telegram, Email, and account deletion land in upcoming releases.
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -28,6 +28,20 @@ export type ApiResponse<T> =
   | { success: true; data: T; error: null }
   | { success: false; data: null; error: ApiError };
 
+export type Provider = 'openai' | 'anthropic' | 'openrouter';
+
+export type ProviderSummary = {
+  provider: Provider;
+  connected: boolean;
+  created_at: string;
+};
+
+export type ProviderTestResult = {
+  ok: boolean;
+  latencyMs: number;
+  error?: string;
+};
+
 export type HealthStatus = {
   status: 'healthy' | 'degraded';
   checks: {


### PR DESCRIPTION
## Summary

Companion to [#10](https://github.com/9ny4/smartscrape/pull/10). Completes Build Order step 4 from [HANDOFF-smartscrape.md](HANDOFF-smartscrape.md).

## Changes

- `ProviderCard.tsx` \u2014 per-provider card with:
  - Connected / Not configured badge.
  - Saved-on timestamp when configured.
  - Masked key input (placeholder prompts for a replacement; existing key never rendered).
  - Save/Replace, Test, Remove actions.
  - Inline success/error alerts with test latency.
- `Settings.tsx` \u2014 lists all three providers (OpenAI, Anthropic, OpenRouter) with brief helper copy each. Skeleton loaders while `/api/providers` is in flight. Re-fetches after save/remove. Stubs a \"Coming soon\" block for Profile / Google / Telegram / Email / Data sections (later Build Order steps).
- `/settings` route under `RequireAuth`.
- TopNav: Home / Settings `NavLink` group with active-state highlighting.
- Adds `Provider`, `ProviderSummary`, `ProviderTestResult` shared types mirroring the backend.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean (client 208 kB \u2192 67 kB gzipped)
- [ ] Manual click-through \u2014 Chrome MCP still unavailable this session. Add a fake OpenAI key, hit Test, confirm `Invalid API key` message (real 401 from OpenAI in ~260ms, already verified in #10 curl smoke).

## Out of scope

Profile / Google Sheets / Telegram / Email / Data sections are stubbed but not built \u2014 later Build Order steps.

Closes #11