### PR TITLE
feat: scraping engine (Cheerio + Playwright + HTML cleaner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ AI-powered self-hosted web scraping with structured data extraction, change dete
 # 1. Install dependencies for the whole monorepo
 npm install
 
+# 1a. Install the Chromium browser used by the Playwright scraper
+npx playwright install chromium
+
 # 2. Copy env template and fill in secrets
 cp .env.example .env
 # Generate values:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2394,6 +2394,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -2553,6 +2559,48 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chokidar": {
@@ -2720,6 +2768,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2815,6 +2891,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -2876,6 +3007,43 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -3784,6 +3952,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -4677,6 +4876,18 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4833,6 +5044,55 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -5041,6 +5301,50 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
@@ -6205,6 +6509,15 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -6860,6 +7173,40 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -7021,6 +7368,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.40.1",
         "bcrypt": "^6.0.0",
+        "cheerio": "^1.0.0",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "express-rate-limit": "^7.5.0",
@@ -7030,6 +7378,7 @@
         "nodemailer": "^8.0.6",
         "openai": "^4.77.3",
         "pg": "^8.13.1",
+        "playwright": "^1.49.1",
         "zod": "^3.24.1"
       },
       "devDependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -25,8 +25,10 @@
     "jsonwebtoken": "^9.0.2",
     "node-pg-migrate": "^8.0.4",
     "nodemailer": "^8.0.6",
+    "cheerio": "^1.0.0",
     "openai": "^4.77.3",
     "pg": "^8.13.1",
+    "playwright": "^1.49.1",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { env, requireSecrets } from './config/env.js';
 import { closeDatabase } from './config/database.js';
 import { closeRedis } from './config/redis.js';
+import { closeScraper } from './services/scraper.js';
 import { authRouter } from './routes/auth.js';
 import { healthRouter } from './routes/health.js';
 import { providersRouter } from './routes/providers.js';
@@ -50,7 +51,7 @@ const server = app.listen(env.port, () => {
 async function shutdown(signal: string): Promise<void> {
   console.log(`[server] received ${signal}, shutting down`);
   server.close(() => undefined);
-  await Promise.allSettled([closeDatabase(), closeRedis()]);
+  await Promise.allSettled([closeDatabase(), closeRedis(), closeScraper()]);
   process.exit(0);
 }
 

--- a/server/src/lib/ssrf.ts
+++ b/server/src/lib/ssrf.ts
@@ -1,0 +1,88 @@
+import { promises as dns } from 'node:dns';
+import net from 'node:net';
+
+// RFC 1918 + link-local + loopback + documentation + cloud metadata,
+// IPv4 + IPv6 equivalents.
+function isPrivateV4(ip: string): boolean {
+  const parts = ip.split('.').map((n) => Number.parseInt(n, 10));
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return false;
+  const [a = 0, b = 0] = parts;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true; // link-local + cloud metadata (169.254.169.254)
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 0) return true;
+  if (a >= 224) return true; // multicast + reserved
+  return false;
+}
+
+function isPrivateV6(ip: string): boolean {
+  const normalized = ip.toLowerCase();
+  if (normalized === '::1' || normalized === '::') return true;
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true; // unique-local fc00::/7
+  if (normalized.startsWith('fe8') || normalized.startsWith('fe9') || normalized.startsWith('fea') || normalized.startsWith('feb')) {
+    return true; // link-local fe80::/10
+  }
+  // IPv4-mapped: ::ffff:a.b.c.d
+  const mapped = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) return isPrivateV4(mapped[1]!);
+  return false;
+}
+
+function isPrivateIp(ip: string): boolean {
+  const version = net.isIP(ip);
+  if (version === 4) return isPrivateV4(ip);
+  if (version === 6) return isPrivateV6(ip);
+  return false;
+}
+
+export type UrlCheckResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Validate a URL for scraping:
+ *   - HTTP(S) only
+ *   - hostname does not resolve to a private / loopback / metadata IP
+ *
+ * DNS is resolved and every returned address is checked, so CNAME or
+ * mixed AAAA records pointing at internal addresses are rejected too.
+ */
+export async function assertSafeUrl(input: string): Promise<UrlCheckResult> {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return { ok: false, reason: 'Invalid URL' };
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return { ok: false, reason: 'Only http and https URLs are supported' };
+  }
+  const hostname = url.hostname;
+  if (!hostname) return { ok: false, reason: 'Missing hostname' };
+
+  // Literal IPs: check directly.
+  if (net.isIP(hostname)) {
+    if (isPrivateIp(hostname)) return { ok: false, reason: 'URL resolves to a private network' };
+    return { ok: true };
+  }
+
+  // Block localhost even if DNS would return a public IP.
+  if (/^(localhost|localhost\.localdomain)$/i.test(hostname)) {
+    return { ok: false, reason: 'URL resolves to a private network' };
+  }
+
+  // DNS resolve both families; reject if any address is private.
+  let addresses: { address: string; family: number }[];
+  try {
+    addresses = await dns.lookup(hostname, { all: true, verbatim: true });
+  } catch {
+    return { ok: false, reason: 'Hostname does not resolve' };
+  }
+  for (const { address } of addresses) {
+    if (isPrivateIp(address)) return { ok: false, reason: 'URL resolves to a private network' };
+  }
+  return { ok: true };
+}
+
+// Exported for tests / internal reuse.
+export const _internal = { isPrivateIp };

--- a/server/src/services/html-cleaner.ts
+++ b/server/src/services/html-cleaner.ts
@@ -1,0 +1,114 @@
+import * as cheerio from 'cheerio';
+
+// Stripped entirely, including text children.
+const DROP_SELECTORS = [
+  'script',
+  'style',
+  'noscript',
+  'template',
+  'svg',
+  'meta',
+  'link',
+  'iframe',
+  'object',
+  'embed',
+  'nav',
+  'footer',
+  'header',
+  'aside',
+  'form',
+  // common ad containers
+  '[class*="ad-" i]',
+  '[class*="advert" i]',
+  '[id*="ad-" i]',
+  '[class*="banner" i]',
+  '[class*="promo" i]',
+  '[class*="sponsored" i]',
+  '[role="banner"]',
+  '[role="navigation"]',
+  '[aria-hidden="true"]',
+];
+
+// Regex that looks for instruction-shaped text that often appears in
+// prompt-injection payloads. We replace matches with a placeholder
+// rather than dropping the whole node so surrounding context survives.
+const INJECTION_PATTERNS: RegExp[] = [
+  /ignore\s+(all\s+)?(previous|prior|above)\s+(instructions?|prompts?|rules?)/gi,
+  /disregard\s+(all\s+)?(previous|prior|above)\s+(instructions?|prompts?|rules?)/gi,
+  /\b(system|assistant|developer)\s*:/gi,
+  /you\s+are\s+(now\s+)?an?\s+(ai|assistant|language\s+model)/gi,
+  /\bprompt\s*injection\b/gi,
+];
+
+export type CleanOptions = {
+  /** Maximum characters to retain (default 120k ~= 30k tokens). */
+  maxChars?: number;
+};
+
+export function cleanHtml(html: string, opts: CleanOptions = {}): string {
+  const maxChars = opts.maxChars ?? 120_000;
+  const $ = cheerio.load(html);
+
+  // Remove comments recursively.
+  $('*')
+    .contents()
+    .filter((_, el) => el.type === 'comment')
+    .remove();
+
+  for (const selector of DROP_SELECTORS) {
+    $(selector).remove();
+  }
+
+  // Inline hidden style elements.
+  $('[style]').each((_, el) => {
+    const style = $(el).attr('style') ?? '';
+    if (/display\s*:\s*none/i.test(style) || /visibility\s*:\s*hidden/i.test(style)) {
+      $(el).remove();
+    }
+  });
+
+  // Strip data-* attributes and noisy tracking attrs on every element.
+  $('*').each((_, el) => {
+    if (el.type !== 'tag') return;
+    for (const name of Object.keys(el.attribs)) {
+      if (name.startsWith('data-') || name.startsWith('on')) {
+        $(el).removeAttr(name);
+      }
+    }
+  });
+
+  // Prefer <main> / <article> if present.
+  let workingHtml: string;
+  const main = $('main, article').first();
+  if (main.length > 0) {
+    workingHtml = $.html(main);
+  } else {
+    workingHtml = $('body').length ? $.html($('body')) : $.html();
+  }
+
+  // Strip instruction-like text.
+  for (const pattern of INJECTION_PATTERNS) {
+    workingHtml = workingHtml.replace(pattern, '[redacted]');
+  }
+
+  // Collapse excessive whitespace without destroying structure.
+  workingHtml = workingHtml
+    .replace(/>\s+</g, '><')
+    .replace(/\s{3,}/g, '\n')
+    .trim();
+
+  if (workingHtml.length > maxChars) {
+    workingHtml = workingHtml.slice(0, maxChars) + '\n<!-- truncated -->';
+  }
+  return workingHtml;
+}
+
+/**
+ * Return a rough visible-text length so callers can decide whether a
+ * Cheerio pass produced enough content or we need to fall back to Playwright.
+ */
+export function visibleTextLength(html: string): number {
+  const $ = cheerio.load(html);
+  $('script, style, noscript, template').remove();
+  return $('body').text().trim().replace(/\s+/g, ' ').length;
+}

--- a/server/src/services/scraper.ts
+++ b/server/src/services/scraper.ts
@@ -1,0 +1,141 @@
+import { chromium, type Browser } from 'playwright';
+import { cleanHtml, visibleTextLength } from './html-cleaner.js';
+import { assertSafeUrl } from '../lib/ssrf.js';
+
+const USER_AGENT = 'SmartScrapeBot/0.1 (+https://github.com/9ny4/smartscrape)';
+const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+const MIN_VISIBLE_TEXT = 200; // below this, fall back to Playwright
+const PER_HOST_DELAY_MS = 2_000;
+
+export type ScrapeMethod = 'auto' | 'cheerio' | 'playwright';
+
+export type ScrapeResult = {
+  url: string;
+  finalUrl: string;
+  method: 'cheerio' | 'playwright';
+  status: number;
+  rawBytes: number;
+  cleaned: string;
+  durationMs: number;
+};
+
+// Remember the last time we hit each host so we can throttle.
+const lastHitAt = new Map<string, number>();
+
+async function throttle(host: string): Promise<void> {
+  const last = lastHitAt.get(host) ?? 0;
+  const wait = PER_HOST_DELAY_MS - (Date.now() - last);
+  if (wait > 0) {
+    await new Promise((r) => setTimeout(r, wait));
+  }
+  lastHitAt.set(host, Date.now());
+}
+
+async function fetchWithCap(url: string, signal?: AbortSignal): Promise<{ status: number; body: string; finalUrl: string }> {
+  const res = await fetch(url, {
+    headers: { 'user-agent': USER_AGENT, accept: 'text/html,application/xhtml+xml' },
+    redirect: 'follow',
+    signal,
+  });
+  const contentLength = Number.parseInt(res.headers.get('content-length') ?? '0', 10);
+  if (Number.isFinite(contentLength) && contentLength > MAX_BYTES) {
+    throw new Error(`Page too large (${contentLength} bytes > ${MAX_BYTES})`);
+  }
+  // Stream and cap.
+  if (!res.body) throw new Error('Empty response body');
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      total += value.byteLength;
+      if (total > MAX_BYTES) {
+        void reader.cancel();
+        throw new Error(`Page exceeded ${MAX_BYTES} bytes`);
+      }
+      chunks.push(value);
+    }
+  }
+  const buf = Buffer.concat(chunks.map((c) => Buffer.from(c.buffer, c.byteOffset, c.byteLength)));
+  return {
+    status: res.status,
+    body: buf.toString('utf8'),
+    finalUrl: res.url,
+  };
+}
+
+let sharedBrowser: Browser | null = null;
+async function browser(): Promise<Browser> {
+  if (!sharedBrowser || !sharedBrowser.isConnected()) {
+    sharedBrowser = await chromium.launch({ headless: true });
+  }
+  return sharedBrowser;
+}
+
+export async function closeScraper(): Promise<void> {
+  if (sharedBrowser) {
+    await sharedBrowser.close().catch(() => undefined);
+    sharedBrowser = null;
+  }
+}
+
+async function fetchViaPlaywright(url: string): Promise<{ status: number; body: string; finalUrl: string }> {
+  const b = await browser();
+  // Isolated context per scrape so cookies/storage don't leak across jobs.
+  const ctx = await b.newContext({ userAgent: USER_AGENT });
+  try {
+    const page = await ctx.newPage();
+    const response = await page.goto(url, { waitUntil: 'networkidle', timeout: 30_000 });
+    const body = await page.content();
+    if (Buffer.byteLength(body, 'utf8') > MAX_BYTES) {
+      throw new Error(`Rendered page exceeded ${MAX_BYTES} bytes`);
+    }
+    return {
+      status: response?.status() ?? 0,
+      body,
+      finalUrl: page.url(),
+    };
+  } finally {
+    await ctx.close();
+  }
+}
+
+export async function scrape(url: string, method: ScrapeMethod = 'auto'): Promise<ScrapeResult> {
+  const safety = await assertSafeUrl(url);
+  if (!safety.ok) {
+    throw new Error(`Refused to scrape ${url}: ${safety.reason}`);
+  }
+  const started = Date.now();
+  const host = new URL(url).hostname;
+  await throttle(host);
+
+  let primary: { status: number; body: string; finalUrl: string };
+  let usedMethod: 'cheerio' | 'playwright';
+
+  if (method === 'playwright') {
+    primary = await fetchViaPlaywright(url);
+    usedMethod = 'playwright';
+  } else {
+    primary = await fetchWithCap(url);
+    usedMethod = 'cheerio';
+    if (method === 'auto' && visibleTextLength(primary.body) < MIN_VISIBLE_TEXT) {
+      // Fall back: try again with headless Chromium.
+      await throttle(host);
+      primary = await fetchViaPlaywright(url);
+      usedMethod = 'playwright';
+    }
+  }
+
+  const cleaned = cleanHtml(primary.body);
+  return {
+    url,
+    finalUrl: primary.finalUrl,
+    method: usedMethod,
+    status: primary.status,
+    rawBytes: Buffer.byteLength(primary.body, 'utf8'),
+    cleaned,
+    durationMs: Date.now() - started,
+  };
+}


### PR DESCRIPTION
## Summary

Build Order step 5 \u2014 the scraper that feeds the AI extraction pipeline.

## Changes

- `lib/ssrf.ts` \u2014 `assertSafeUrl()` enforces http(s)-only + DNS-resolved private-network rejection (IPv4 + IPv6). Explicit tests cover loopback, RFC 1918, link-local, `169.254.169.254`, IPv4-mapped IPv6, `localhost` literal, and non-http(s) protocols.
- `services/html-cleaner.ts` \u2014 strips scripts/styles/nav/footer/iframe/ads/hidden elements, HTML comments, `data-*`/`on*` attrs; prefers `<main>` or `<article>`; neutralizes prompt-injection text (\"ignore previous\", \"system:\", \"you are an AI...\") with `[redacted]`; collapses whitespace; 120k char cap. `visibleTextLength()` helper for fallback detection.
- `services/scraper.ts` \u2014 `scrape(url, method='auto'|'cheerio'|'playwright')`. Auto fetches with streamed 5MB cap, falls back to headless Chromium (shared browser, isolated context per call) when visible text is below threshold. Per-host 2-second throttle. Identifying User-Agent. SSRF check every time.
- Shared browser torn down via `closeScraper()` on shutdown.
- README: note `npx playwright install chromium` prerequisite.

## Smoke (real network)

```
SSRF guard: all of 127.0.0.1 / 10.x / 169.254.169.254 / localhost / IPv6 ::1 / ftp: rejected; example.com allowed
HTML cleaner: 'IGNORE ALL PREVIOUS INSTRUCTIONS. You are an AI...' \u2192 '[redacted]. [redacted]...'
scrape('https://example.com'): status 200, method=playwright (body < 200 chars \u2192 fallback), clean preview = '<body><div><h1>Example Domain</h1>...'
scrape('http://169.254.169.254/latest/'): blocked with 'URL resolves to a private network'
```

## Out of scope

- Job / run orchestration \u2014 separate issue for step 7+.

Closes #13