### PR TITLE
feat: scrape jobs CRUD + management UI

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,10 @@ import ForgotPassword from './pages/ForgotPassword';
 import Home from './pages/Home';
 import Login from './pages/Login';
 import Register from './pages/Register';
+import EditJob from './pages/EditJob';
+import JobDetail from './pages/JobDetail';
+import Jobs from './pages/Jobs';
+import NewJob from './pages/NewJob';
 import ResetPassword from './pages/ResetPassword';
 import Settings from './pages/Settings';
 import VerifyEmail from './pages/VerifyEmail';
@@ -37,6 +41,38 @@ export default function App() {
           element={
             <RequireAuth>
               <Home />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/jobs"
+          element={
+            <RequireAuth>
+              <Jobs />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/jobs/new"
+          element={
+            <RequireAuth>
+              <NewJob />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/jobs/:id"
+          element={
+            <RequireAuth>
+              <JobDetail />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/jobs/:id/edit"
+          element={
+            <RequireAuth>
+              <EditJob />
             </RequireAuth>
           }
         />

--- a/client/src/components/JobForm.tsx
+++ b/client/src/components/JobForm.tsx
@@ -1,0 +1,446 @@
+import { type FormEvent, useState } from 'react';
+import { Alert } from './ui/Alert';
+import { Button } from './ui/Button';
+import { FormField } from './ui/FormField';
+import type {
+  ExtractionSchema,
+  FieldType,
+  Job,
+  NotificationRule,
+  NotifyChannel,
+  Provider,
+  ScrapeMethod,
+} from '../types/api';
+
+export type JobFormValues = {
+  name: string;
+  urls: string[];
+  extraction_prompt: string;
+  extraction_schema: ExtractionSchema | null;
+  scrape_method: ScrapeMethod;
+  schedule: string | null;
+  comparison_key: string | null;
+  notify_channels: NotifyChannel[];
+  notification_rules: NotificationRule[];
+  ai_provider: Provider;
+  ai_model: string;
+};
+
+const SCHEDULE_OPTIONS: { label: string; value: string | null }[] = [
+  { label: 'Manual', value: null },
+  { label: 'Hourly', value: '0 * * * *' },
+  { label: 'Daily', value: '0 9 * * *' },
+  { label: 'Weekly', value: '0 9 * * 1' },
+];
+
+const FIELD_TYPES: FieldType[] = ['string', 'number', 'boolean', 'array', 'object'];
+
+export function jobToFormValues(job: Job): JobFormValues {
+  return {
+    name: job.name,
+    urls: job.urls,
+    extraction_prompt: job.extraction_prompt,
+    extraction_schema: job.extraction_schema,
+    scrape_method: job.scrape_method,
+    schedule: job.schedule,
+    comparison_key: job.comparison_key,
+    notify_channels: job.notify_channels,
+    notification_rules: job.notification_rules,
+    ai_provider: job.ai_provider,
+    ai_model: job.ai_model,
+  };
+}
+
+export const EMPTY_FORM: JobFormValues = {
+  name: '',
+  urls: [''],
+  extraction_prompt: '',
+  extraction_schema: null,
+  scrape_method: 'auto',
+  schedule: null,
+  comparison_key: null,
+  notify_channels: [],
+  notification_rules: [],
+  ai_provider: 'openrouter',
+  ai_model: 'openai/gpt-4o-mini',
+};
+
+type Props = {
+  initial: JobFormValues;
+  submitLabel: string;
+  submitting?: boolean;
+  error?: string | null;
+  onSubmit: (values: JobFormValues) => void;
+  onCancel?: () => void;
+};
+
+export function JobForm({ initial, submitLabel, submitting, error, onSubmit, onCancel }: Props) {
+  const [v, setV] = useState<JobFormValues>(initial);
+  const [schemaFields, setSchemaFields] = useState(
+    initial.extraction_schema
+      ? Object.entries(initial.extraction_schema).map(([name, type]) => ({ name, type }))
+      : [],
+  );
+
+  function handle(e: FormEvent) {
+    e.preventDefault();
+    const schema =
+      schemaFields.length > 0
+        ? Object.fromEntries(schemaFields.filter((f) => f.name).map((f) => [f.name, f.type]))
+        : null;
+    onSubmit({ ...v, extraction_schema: schema });
+  }
+
+  function setUrls(i: number, val: string) {
+    setV((s) => ({ ...s, urls: s.urls.map((u, idx) => (idx === i ? val : u)) }));
+  }
+
+  function addField() {
+    setSchemaFields((s) => [...s, { name: '', type: 'string' }]);
+  }
+  function updateField(i: number, patch: { name?: string; type?: FieldType }) {
+    setSchemaFields((s) => s.map((f, idx) => (idx === i ? { ...f, ...patch } : f)));
+  }
+  function removeField(i: number) {
+    setSchemaFields((s) => s.filter((_, idx) => idx !== i));
+  }
+
+  function toggleChannel(ch: NotifyChannel) {
+    setV((s) => ({
+      ...s,
+      notify_channels: s.notify_channels.includes(ch)
+        ? s.notify_channels.filter((c) => c !== ch)
+        : [...s.notify_channels, ch],
+    }));
+  }
+
+  function addRule() {
+    setV((s) => ({
+      ...s,
+      notification_rules: [...s.notification_rules, { type: 'any_change' }],
+    }));
+  }
+  function updateRule(i: number, rule: NotificationRule) {
+    setV((s) => ({
+      ...s,
+      notification_rules: s.notification_rules.map((r, idx) => (idx === i ? rule : r)),
+    }));
+  }
+  function removeRule(i: number) {
+    setV((s) => ({
+      ...s,
+      notification_rules: s.notification_rules.filter((_, idx) => idx !== i),
+    }));
+  }
+
+  return (
+    <form onSubmit={handle} className="space-y-6">
+      {error && <Alert tone="error">{error}</Alert>}
+
+      <Section title="Basics">
+        <FormField
+          label="Job name"
+          required
+          value={v.name}
+          onChange={(e) => setV({ ...v, name: e.target.value })}
+          placeholder="Track GPU prices on example.com"
+        />
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">URLs</label>
+          <div className="space-y-2">
+            {v.urls.map((url, i) => (
+              <div key={i} className="flex gap-2">
+                <input
+                  type="url"
+                  value={url}
+                  required
+                  onChange={(e) => setUrls(i, e.target.value)}
+                  placeholder="https://..."
+                  className="block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900"
+                />
+                {v.urls.length > 1 && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => setV({ ...v, urls: v.urls.filter((_, idx) => idx !== i) })}
+                  >
+                    Remove
+                  </Button>
+                )}
+              </div>
+            ))}
+            {v.urls.length < 10 && (
+              <Button type="button" variant="secondary" onClick={() => setV({ ...v, urls: [...v.urls, ''] })}>
+                + Add URL
+              </Button>
+            )}
+          </div>
+        </div>
+      </Section>
+
+      <Section title="Extraction">
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            What should the AI extract?
+          </label>
+          <textarea
+            value={v.extraction_prompt}
+            onChange={(e) => setV({ ...v, extraction_prompt: e.target.value })}
+            rows={3}
+            required
+            placeholder="Describe the data in plain English, e.g. 'Extract each product card with name, price in USD, and stock status.'"
+            className="block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900"
+          />
+        </div>
+
+        <div>
+          <div className="mb-2 flex items-end justify-between">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Fields (optional)
+            </label>
+            <Button type="button" variant="ghost" onClick={addField}>
+              + Add field
+            </Button>
+          </div>
+          <div className="space-y-2">
+            {schemaFields.map((f, i) => (
+              <div key={i} className="flex gap-2">
+                <input
+                  value={f.name}
+                  onChange={(e) => updateField(i, { name: e.target.value })}
+                  placeholder="field_name"
+                  className="block flex-1 rounded-md border border-gray-300 bg-white px-3 py-2 font-mono text-sm dark:border-gray-700 dark:bg-gray-900"
+                />
+                <select
+                  value={f.type}
+                  onChange={(e) => updateField(i, { type: e.target.value as FieldType })}
+                  className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
+                >
+                  {FIELD_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+                <Button type="button" variant="ghost" onClick={() => removeField(i)}>
+                  Remove
+                </Button>
+              </div>
+            ))}
+            {schemaFields.length === 0 && (
+              <p className="text-xs text-gray-500">
+                Leave empty to let the AI infer fields, or add explicit fields to tighten the output.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <FormField
+          label="Comparison key (for change detection)"
+          hint="Name of the field that uniquely identifies each item across runs. Example: url, sku, id."
+          value={v.comparison_key ?? ''}
+          onChange={(e) => setV({ ...v, comparison_key: e.target.value || null })}
+        />
+      </Section>
+
+      <Section title="Scraping + scheduling">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Scrape method
+            </label>
+            <select
+              value={v.scrape_method}
+              onChange={(e) => setV({ ...v, scrape_method: e.target.value as ScrapeMethod })}
+              className="block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
+            >
+              <option value="auto">Auto (static, fall back to browser)</option>
+              <option value="cheerio">Cheerio only (static)</option>
+              <option value="playwright">Playwright only (browser)</option>
+            </select>
+          </div>
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">Schedule</label>
+            <select
+              value={v.schedule ?? ''}
+              onChange={(e) => setV({ ...v, schedule: e.target.value === '' ? null : e.target.value })}
+              className="block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
+            >
+              {SCHEDULE_OPTIONS.map((opt) => (
+                <option key={opt.label} value={opt.value ?? ''}>
+                  {opt.label}
+                </option>
+              ))}
+              <option value="custom">Custom cron...</option>
+            </select>
+            {v.schedule &&
+              !SCHEDULE_OPTIONS.some((o) => o.value === v.schedule) && (
+                <input
+                  value={v.schedule}
+                  onChange={(e) => setV({ ...v, schedule: e.target.value })}
+                  placeholder="Cron expression"
+                  className="mt-2 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 font-mono text-sm dark:border-gray-700 dark:bg-gray-900"
+                />
+              )}
+          </div>
+        </div>
+      </Section>
+
+      <Section title="AI model">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">Provider</label>
+            <select
+              value={v.ai_provider}
+              onChange={(e) => setV({ ...v, ai_provider: e.target.value as Provider })}
+              className="block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
+            >
+              <option value="openrouter">OpenRouter</option>
+              <option value="openai">OpenAI</option>
+              <option value="anthropic">Anthropic</option>
+            </select>
+          </div>
+          <FormField
+            label="Model"
+            value={v.ai_model}
+            onChange={(e) => setV({ ...v, ai_model: e.target.value })}
+            placeholder="openai/gpt-4o-mini"
+          />
+        </div>
+      </Section>
+
+      <Section title="Notifications">
+        <div className="flex flex-wrap gap-3">
+          {(['email', 'telegram'] as NotifyChannel[]).map((ch) => (
+            <label key={ch} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={v.notify_channels.includes(ch)}
+                onChange={() => toggleChannel(ch)}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="capitalize">{ch}</span>
+            </label>
+          ))}
+        </div>
+
+        <div className="space-y-3">
+          {v.notification_rules.map((rule, i) => (
+            <RuleEditor key={i} rule={rule} onChange={(r) => updateRule(i, r)} onRemove={() => removeRule(i)} />
+          ))}
+          <Button type="button" variant="secondary" onClick={addRule}>
+            + Add notification rule
+          </Button>
+        </div>
+      </Section>
+
+      <div className="flex items-center justify-end gap-3 pt-4">
+        {onCancel && (
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+        )}
+        <Button type="submit" loading={submitting}>
+          {submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-4 border-b border-gray-200 pb-6 dark:border-gray-800">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function RuleEditor({
+  rule,
+  onChange,
+  onRemove,
+}: {
+  rule: NotificationRule;
+  onChange: (r: NotificationRule) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="rounded-md border border-gray-200 p-3 dark:border-gray-800">
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          value={rule.type}
+          onChange={(e) => {
+            const type = e.target.value as NotificationRule['type'];
+            if (type === 'field_threshold') {
+              onChange({ type, field: '', operator: 'less_than', value: 0 });
+            } else if (type === 'field_change') {
+              onChange({ type, field: '' });
+            } else {
+              onChange({ type });
+            }
+          }}
+          className="rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm dark:border-gray-700 dark:bg-gray-900"
+        >
+          <option value="any_change">Any change</option>
+          <option value="new_items">New items appear</option>
+          <option value="removed_items">Items disappear</option>
+          <option value="field_threshold">Field crosses threshold</option>
+          <option value="field_change">Field value changes</option>
+        </select>
+
+        {(rule.type === 'field_threshold' || rule.type === 'field_change') && (
+          <input
+            value={rule.field}
+            onChange={(e) => onChange({ ...rule, field: e.target.value })}
+            placeholder="field name"
+            className="rounded-md border border-gray-300 bg-white px-2 py-1.5 font-mono text-sm dark:border-gray-700 dark:bg-gray-900"
+          />
+        )}
+
+        {rule.type === 'field_threshold' && (
+          <>
+            <select
+              value={rule.operator}
+              onChange={(e) =>
+                onChange({ ...rule, operator: e.target.value as typeof rule.operator })
+              }
+              className="rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm dark:border-gray-700 dark:bg-gray-900"
+            >
+              <option value="less_than">&lt;</option>
+              <option value="less_than_or_equal">&le;</option>
+              <option value="equals">=</option>
+              <option value="not_equals">&ne;</option>
+              <option value="greater_than_or_equal">&ge;</option>
+              <option value="greater_than">&gt;</option>
+            </select>
+            <input
+              value={String(rule.value)}
+              onChange={(e) => {
+                const asNum = Number(e.target.value);
+                onChange({ ...rule, value: Number.isFinite(asNum) && e.target.value !== '' ? asNum : e.target.value });
+              }}
+              placeholder="value"
+              className="w-28 rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm dark:border-gray-700 dark:bg-gray-900"
+            />
+          </>
+        )}
+
+        <button
+          type="button"
+          onClick={onRemove}
+          className="ml-auto text-xs text-gray-500 hover:text-red-600"
+        >
+          Remove
+        </button>
+      </div>
+      <input
+        value={rule.message ?? ''}
+        onChange={(e) => onChange({ ...rule, message: e.target.value || undefined })}
+        placeholder="Optional message template. Use {field_name}, {old}, {new}, {count}, {url}."
+        className="mt-2 block w-full rounded-md border border-gray-200 bg-gray-50 px-2 py-1.5 text-sm dark:border-gray-800 dark:bg-gray-950"
+      />
+    </div>
+  );
+}

--- a/client/src/components/layout/TopNav.tsx
+++ b/client/src/components/layout/TopNav.tsx
@@ -16,6 +16,7 @@ export function TopNav() {
           </Link>
           <nav className="hidden items-center gap-1 sm:flex">
             <NavItem to="/">Home</NavItem>
+            <NavItem to="/jobs">Jobs</NavItem>
             <NavItem to="/settings">Settings</NavItem>
           </nav>
         </div>

--- a/client/src/pages/EditJob.tsx
+++ b/client/src/pages/EditJob.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { TopNav } from '../components/layout/TopNav';
+import { JobForm, jobToFormValues, type JobFormValues } from '../components/JobForm';
+import { api } from '../lib/api';
+import type { Job } from '../types/api';
+
+export default function EditJob() {
+  const { id = '' } = useParams();
+  const navigate = useNavigate();
+  const [initial, setInitial] = useState<JobFormValues | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      const res = await api<{ job: Job }>(`/api/jobs/${id}`);
+      if (res.success) setInitial(jobToFormValues(res.data.job));
+      else setError(res.error.message);
+    })();
+  }, [id]);
+
+  async function onSubmit(values: JobFormValues) {
+    setSubmitting(true);
+    setError(null);
+    const res = await api<{ job: Job }>(`/api/jobs/${id}`, {
+      method: 'PATCH',
+      body: { ...values, urls: values.urls.filter((u) => u.trim()) },
+    });
+    setSubmitting(false);
+    if (!res.success) {
+      setError(res.error.details?.[0]?.message ?? res.error.message);
+      return;
+    }
+    navigate(`/jobs/${id}`);
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+      <TopNav />
+      <main className="mx-auto max-w-3xl px-6 py-10">
+        <div className="mb-6">
+          <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">Edit job</h1>
+        </div>
+        {initial ? (
+          <JobForm
+            initial={initial}
+            submitLabel="Save"
+            submitting={submitting}
+            error={error}
+            onSubmit={onSubmit}
+            onCancel={() => navigate(`/jobs/${id}`)}
+          />
+        ) : (
+          <p className="text-sm text-gray-500">Loading…</p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/JobDetail.tsx
+++ b/client/src/pages/JobDetail.tsx
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { TopNav } from '../components/layout/TopNav';
+import { Alert } from '../components/ui/Alert';
+import { Button } from '../components/ui/Button';
+import { api } from '../lib/api';
+import type { Job, Run, RunStatus } from '../types/api';
+
+export default function JobDetail() {
+  const { id = '' } = useParams();
+  const navigate = useNavigate();
+  const [job, setJob] = useState<Job | null>(null);
+  const [runs, setRuns] = useState<Run[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const load = useCallback(async () => {
+    const [jr, rr] = await Promise.all([
+      api<{ job: Job }>(`/api/jobs/${id}`),
+      api<{ runs: Run[] }>(`/api/jobs/${id}/runs`),
+    ]);
+    if (!jr.success) {
+      setError(jr.error.message);
+      return;
+    }
+    setJob(jr.data.job);
+    if (rr.success) setRuns(rr.data.runs);
+  }, [id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function remove() {
+    if (!confirm('Delete this job and all its runs? This cannot be undone.')) return;
+    setDeleting(true);
+    const res = await api(`/api/jobs/${id}`, { method: 'DELETE' });
+    setDeleting(false);
+    if (res.success) navigate('/jobs');
+    else setError(res.error.message);
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+        <TopNav />
+        <main className="mx-auto max-w-4xl px-6 py-10">
+          <Alert tone="error">{error}</Alert>
+        </main>
+      </div>
+    );
+  }
+
+  if (!job) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+        <TopNav />
+        <main className="mx-auto max-w-4xl px-6 py-10">
+          <p className="text-sm text-gray-500">Loading…</p>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+      <TopNav />
+      <main className="mx-auto max-w-4xl px-6 py-10 space-y-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">{job.name}</h1>
+            <p className="mt-1 font-mono text-xs text-gray-500">
+              {job.urls.length} URL{job.urls.length === 1 ? '' : 's'} · {job.schedule ?? 'Manual'} · {job.ai_provider}/{job.ai_model}
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="secondary" disabled title="Wired up in the next release">
+              Run now
+            </Button>
+            <Link to={`/jobs/${job.id}/edit`}>
+              <Button variant="secondary">Edit</Button>
+            </Link>
+            <Button variant="danger" loading={deleting} onClick={remove}>
+              Delete
+            </Button>
+          </div>
+        </div>
+
+        <Card title="Extraction">
+          <p className="font-mono text-sm text-gray-900 dark:text-gray-100">{job.extraction_prompt}</p>
+          {job.extraction_schema && (
+            <div className="mt-3 grid grid-cols-2 gap-2 font-mono text-xs">
+              {Object.entries(job.extraction_schema).map(([k, t]) => (
+                <div key={k} className="flex gap-2">
+                  <span className="text-gray-500">{k}</span>
+                  <span className="text-indigo-600 dark:text-indigo-400">{t}</span>
+                </div>
+              ))}
+            </div>
+          )}
+          {job.comparison_key && (
+            <p className="mt-3 text-xs text-gray-500">
+              Comparison key: <span className="font-mono">{job.comparison_key}</span>
+            </p>
+          )}
+        </Card>
+
+        <Card title="URLs">
+          <ul className="space-y-1 font-mono text-xs">
+            {job.urls.map((u) => (
+              <li key={u} className="truncate text-gray-700 dark:text-gray-300">
+                {u}
+              </li>
+            ))}
+          </ul>
+        </Card>
+
+        <Card title="Run history">
+          {!runs ? (
+            <p className="text-sm text-gray-500">Loading…</p>
+          ) : runs.length === 0 ? (
+            <p className="text-sm text-gray-500">No runs yet. Scheduling lands next release.</p>
+          ) : (
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-gray-500">
+                  <th className="py-2">Status</th>
+                  <th className="py-2">Items</th>
+                  <th className="py-2">Tokens</th>
+                  <th className="py-2">Duration</th>
+                  <th className="py-2">When</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+                {runs.map((r) => (
+                  <tr key={r.id}>
+                    <td className="py-2">
+                      <StatusBadge status={r.status} />
+                    </td>
+                    <td className="py-2 font-mono text-xs">{r.items_extracted}</td>
+                    <td className="py-2 font-mono text-xs">{r.tokens_used}</td>
+                    <td className="py-2 font-mono text-xs">
+                      {r.completed_at
+                        ? `${Math.round(
+                            (new Date(r.completed_at).getTime() - new Date(r.started_at).getTime()) / 100,
+                          ) / 10}s`
+                        : '—'}
+                    </td>
+                    <td className="py-2 font-mono text-xs text-gray-500">{new Date(r.started_at).toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </Card>
+      </main>
+    </div>
+  );
+}
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function StatusBadge({ status }: { status: RunStatus }) {
+  const classes: Record<RunStatus, string> = {
+    pending: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+    scraping: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    extracting: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    exporting: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    completed: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+    failed: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  };
+  return (
+    <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${classes[status]}`}>
+      {status}
+    </span>
+  );
+}

--- a/client/src/pages/Jobs.tsx
+++ b/client/src/pages/Jobs.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { TopNav } from '../components/layout/TopNav';
+import { Button } from '../components/ui/Button';
+import { api } from '../lib/api';
+import type { JobListItem, RunStatus } from '../types/api';
+
+type Filter = 'all' | 'active' | 'paused' | 'failed';
+const FILTERS: { key: Filter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'active', label: 'Active' },
+  { key: 'paused', label: 'Paused' },
+  { key: 'failed', label: 'Failed' },
+];
+
+export default function Jobs() {
+  const [jobs, setJobs] = useState<JobListItem[] | null>(null);
+  const [filter, setFilter] = useState<Filter>('all');
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  const load = useCallback(async (f: Filter) => {
+    const res = await api<{ items: JobListItem[]; total: number }>(`/api/jobs?filter=${f}`);
+    if (!res.success) setError(res.error.message);
+    else {
+      setJobs(res.data.items);
+      setError(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load(filter);
+  }, [filter, load]);
+
+  async function toggle(id: string) {
+    await api(`/api/jobs/${id}/toggle`, { method: 'PATCH' });
+    void load(filter);
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+      <TopNav />
+      <main className="mx-auto max-w-6xl px-6 py-10">
+        <div className="mb-6 flex items-end justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">Jobs</h1>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Scrape configurations, their schedules, and most recent runs.
+            </p>
+          </div>
+          <Button onClick={() => navigate('/jobs/new')}>New job</Button>
+        </div>
+
+        <div className="mb-4 inline-flex rounded-md border border-gray-200 bg-white p-1 dark:border-gray-800 dark:bg-gray-900">
+          {FILTERS.map((f) => (
+            <button
+              key={f.key}
+              onClick={() => setFilter(f.key)}
+              className={`rounded px-3 py-1.5 text-sm font-medium transition ${
+                filter === f.key
+                  ? 'bg-indigo-600 text-white'
+                  : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100'
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+
+        {error && (
+          <p className="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+            {error}
+          </p>
+        )}
+
+        {jobs === null ? (
+          <div className="space-y-2">
+            {[0, 1, 2].map((i) => (
+              <div
+                key={i}
+                className="h-14 animate-pulse rounded-md border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900"
+              />
+            ))}
+          </div>
+        ) : jobs.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50 dark:bg-gray-950/40">
+                <tr className="text-left text-xs font-medium uppercase tracking-wide text-gray-500">
+                  <th className="px-4 py-3">Name</th>
+                  <th className="px-4 py-3">URLs</th>
+                  <th className="px-4 py-3">Schedule</th>
+                  <th className="px-4 py-3">Last run</th>
+                  <th className="px-4 py-3">Items</th>
+                  <th className="px-4 py-3">Enabled</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+                {jobs.map((job) => (
+                  <tr
+                    key={job.id}
+                    className="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/40"
+                    onClick={() => navigate(`/jobs/${job.id}`)}
+                  >
+                    <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">
+                      <Link to={`/jobs/${job.id}`} onClick={(e) => e.stopPropagation()}>
+                        {job.name}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs text-gray-500">{job.urls.length}</td>
+                    <td className="px-4 py-3 font-mono text-xs text-gray-500">{job.schedule ?? 'Manual'}</td>
+                    <td className="px-4 py-3">
+                      <StatusBadge status={job.last_run_status} />
+                      {job.last_run_at && (
+                        <span className="ml-2 text-xs text-gray-500">
+                          {new Date(job.last_run_at).toLocaleString()}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs text-gray-500">{job.last_run_items ?? '—'}</td>
+                    <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                      <label className="inline-flex cursor-pointer items-center">
+                        <input
+                          type="checkbox"
+                          checked={job.enabled}
+                          onChange={() => void toggle(job.id)}
+                          className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                        />
+                      </label>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: RunStatus | null }) {
+  if (!status) return <span className="text-xs text-gray-400">no runs yet</span>;
+  const classes: Record<RunStatus, string> = {
+    pending: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+    scraping: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    extracting: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    exporting: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    completed: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+    failed: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  };
+  return (
+    <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${classes[status]}`}>
+      {status}
+    </span>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="rounded-lg border border-dashed border-gray-300 bg-white/60 p-10 text-center dark:border-gray-700 dark:bg-gray-900/40">
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">No jobs yet</h3>
+      <p className="mx-auto mt-1 max-w-md text-sm text-gray-500 dark:text-gray-400">
+        A job watches one or more URLs, extracts structured data with your AI provider, and tells you when things change.
+      </p>
+      <div className="mt-4">
+        <Link
+          to="/jobs/new"
+          className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500"
+        >
+          Create your first job
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/NewJob.tsx
+++ b/client/src/pages/NewJob.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { TopNav } from '../components/layout/TopNav';
+import { EMPTY_FORM, JobForm, type JobFormValues } from '../components/JobForm';
+import { api } from '../lib/api';
+import type { Job } from '../types/api';
+
+export default function NewJob() {
+  const navigate = useNavigate();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(values: JobFormValues) {
+    setSubmitting(true);
+    setError(null);
+    const res = await api<{ job: Job }>('/api/jobs', {
+      method: 'POST',
+      body: { ...values, setup_method: 'manual', urls: values.urls.filter((u) => u.trim()) },
+    });
+    setSubmitting(false);
+    if (!res.success) {
+      setError(res.error.details?.[0]?.message ?? res.error.message);
+      return;
+    }
+    navigate(`/jobs/${res.data.job.id}`);
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+      <TopNav />
+      <main className="mx-auto max-w-3xl px-6 py-10">
+        <div className="mb-6">
+          <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">New job</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Manual setup. The AI-assisted setup wizard lands in the next release.
+          </p>
+        </div>
+        <JobForm
+          initial={EMPTY_FORM}
+          submitLabel="Create job"
+          submitting={submitting}
+          error={error}
+          onSubmit={onSubmit}
+          onCancel={() => navigate('/jobs')}
+        />
+      </main>
+    </div>
+  );
+}

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -42,6 +42,83 @@ export type ProviderTestResult = {
   error?: string;
 };
 
+export type ScrapeMethod = 'auto' | 'cheerio' | 'playwright';
+export type SetupMethod = 'ai' | 'manual';
+export type NotifyChannel = 'email' | 'telegram';
+export type RunStatus = 'pending' | 'scraping' | 'extracting' | 'exporting' | 'completed' | 'failed';
+
+export type FieldType = 'string' | 'number' | 'boolean' | 'array' | 'object';
+export type ExtractionSchema = Record<string, FieldType>;
+
+export type NotificationRule =
+  | { type: 'any_change'; message?: string }
+  | { type: 'new_items'; message?: string }
+  | { type: 'removed_items'; message?: string }
+  | {
+      type: 'field_threshold';
+      field: string;
+      operator:
+        | 'less_than'
+        | 'greater_than'
+        | 'equals'
+        | 'not_equals'
+        | 'less_than_or_equal'
+        | 'greater_than_or_equal';
+      value: number | string;
+      message?: string;
+    }
+  | { type: 'field_change'; field: string; message?: string };
+
+export type Job = {
+  id: string;
+  user_id: string;
+  name: string;
+  urls: string[];
+  extraction_prompt: string;
+  extraction_schema: ExtractionSchema | null;
+  scrape_method: ScrapeMethod;
+  schedule: string | null;
+  enabled: boolean;
+  notification_rules: NotificationRule[];
+  notify_channels: NotifyChannel[];
+  comparison_key: string | null;
+  ai_provider: Provider;
+  ai_model: string;
+  google_sheet_id: string | null;
+  sheet_tab_name: string | null;
+  setup_method: SetupMethod;
+  last_run_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type JobListItem = Job & {
+  last_run_status: RunStatus | null;
+  last_run_items: number | null;
+};
+
+export type Run = {
+  id: string;
+  job_id: string;
+  status: RunStatus;
+  urls_scraped: number;
+  items_extracted: number;
+  tokens_used: number;
+  error_message: string | null;
+  started_at: string;
+  completed_at: string | null;
+};
+
+export type ExtractedData = {
+  id: string;
+  run_id: string;
+  job_id: string;
+  source_url: string;
+  data: Record<string, unknown>;
+  data_hash: string;
+  created_at: string;
+};
+
 export type HealthStatus = {
   status: 'healthy' | 'degraded';
   checks: {

--- a/server/src/db/jobs.ts
+++ b/server/src/db/jobs.ts
@@ -1,0 +1,234 @@
+import { getPool } from '../config/database.js';
+import type { Provider } from './apiKeys.js';
+
+export type ScrapeMethod = 'auto' | 'cheerio' | 'playwright';
+export type SetupMethod = 'ai' | 'manual';
+
+export type NotificationRule =
+  | { type: 'any_change'; message?: string }
+  | { type: 'new_items'; message?: string }
+  | { type: 'removed_items'; message?: string }
+  | {
+      type: 'field_threshold';
+      field: string;
+      operator:
+        | 'less_than'
+        | 'greater_than'
+        | 'equals'
+        | 'not_equals'
+        | 'less_than_or_equal'
+        | 'greater_than_or_equal';
+      value: number | string;
+      message?: string;
+    }
+  | { type: 'field_change'; field: string; message?: string };
+
+export type NotifyChannel = 'email' | 'telegram';
+
+export type JobRow = {
+  id: string;
+  user_id: string;
+  name: string;
+  urls: string[];
+  extraction_prompt: string;
+  extraction_schema: Record<string, string> | null;
+  scrape_method: ScrapeMethod;
+  schedule: string | null;
+  enabled: boolean;
+  notification_rules: NotificationRule[];
+  notify_channels: NotifyChannel[];
+  comparison_key: string | null;
+  ai_provider: Provider;
+  ai_model: string;
+  google_sheet_id: string | null;
+  sheet_tab_name: string | null;
+  setup_method: SetupMethod;
+  last_run_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export type JobDTO = Omit<JobRow, 'last_run_at' | 'created_at' | 'updated_at'> & {
+  last_run_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export function toDTO(row: JobRow): JobDTO {
+  return {
+    ...row,
+    last_run_at: row.last_run_at?.toISOString() ?? null,
+    created_at: row.created_at.toISOString(),
+    updated_at: row.updated_at.toISOString(),
+  };
+}
+
+export type CreateJobArgs = {
+  name: string;
+  urls: string[];
+  extraction_prompt: string;
+  extraction_schema: Record<string, string> | null;
+  scrape_method?: ScrapeMethod;
+  schedule?: string | null;
+  enabled?: boolean;
+  notification_rules?: NotificationRule[];
+  notify_channels?: NotifyChannel[];
+  comparison_key?: string | null;
+  ai_provider?: Provider;
+  ai_model?: string;
+  google_sheet_id?: string | null;
+  sheet_tab_name?: string | null;
+  setup_method?: SetupMethod;
+};
+
+export async function createJob(userId: string, args: CreateJobArgs): Promise<JobRow> {
+  const { rows } = await getPool().query<JobRow>(
+    `INSERT INTO scrape_jobs (
+       user_id, name, urls, extraction_prompt, extraction_schema,
+       scrape_method, schedule, enabled, notification_rules, notify_channels,
+       comparison_key, ai_provider, ai_model, google_sheet_id, sheet_tab_name, setup_method
+     )
+     VALUES ($1,$2,$3::jsonb,$4,$5::jsonb,$6,$7,$8,$9::jsonb,$10::jsonb,$11,$12,$13,$14,$15,$16)
+     RETURNING *`,
+    [
+      userId,
+      args.name,
+      JSON.stringify(args.urls),
+      args.extraction_prompt,
+      args.extraction_schema ? JSON.stringify(args.extraction_schema) : null,
+      args.scrape_method ?? 'auto',
+      args.schedule ?? null,
+      args.enabled ?? true,
+      JSON.stringify(args.notification_rules ?? []),
+      JSON.stringify(args.notify_channels ?? []),
+      args.comparison_key ?? null,
+      args.ai_provider ?? 'openrouter',
+      args.ai_model ?? 'openai/gpt-4o-mini',
+      args.google_sheet_id ?? null,
+      args.sheet_tab_name ?? null,
+      args.setup_method ?? 'manual',
+    ],
+  );
+  return rows[0]!;
+}
+
+export type ListOpts = {
+  filter?: 'all' | 'active' | 'paused' | 'failed';
+  limit?: number;
+  offset?: number;
+};
+
+export type JobListItem = JobDTO & {
+  last_run_status: string | null;
+  last_run_items: number | null;
+};
+
+export async function listJobs(userId: string, opts: ListOpts = {}): Promise<{ items: JobListItem[]; total: number }> {
+  const limit = Math.min(Math.max(opts.limit ?? 50, 1), 200);
+  const offset = Math.max(opts.offset ?? 0, 0);
+
+  let where = `WHERE j.user_id = $1`;
+  const vals: unknown[] = [userId];
+  if (opts.filter === 'active') where += ` AND j.enabled = true`;
+  else if (opts.filter === 'paused') where += ` AND j.enabled = false`;
+  // "failed" is evaluated after the LATERAL join so we add it below.
+
+  const sql = `
+    SELECT j.*, lr.status AS last_run_status, lr.items_extracted AS last_run_items
+      FROM scrape_jobs j
+      LEFT JOIN LATERAL (
+        SELECT status, items_extracted
+          FROM scrape_runs
+         WHERE job_id = j.id
+         ORDER BY started_at DESC
+         LIMIT 1
+      ) lr ON true
+      ${where}
+      ${opts.filter === 'failed' ? `AND lr.status = 'failed'` : ''}
+      ORDER BY j.created_at DESC
+      LIMIT ${limit} OFFSET ${offset}`;
+  const { rows } = await getPool().query<JobRow & { last_run_status: string | null; last_run_items: number | null }>(
+    sql,
+    vals,
+  );
+  const items = rows.map((r) => ({
+    ...toDTO(r),
+    last_run_status: r.last_run_status,
+    last_run_items: r.last_run_items,
+  }));
+
+  const countSql = `
+    SELECT COUNT(*)::int AS total
+      FROM scrape_jobs j
+      LEFT JOIN LATERAL (
+        SELECT status FROM scrape_runs WHERE job_id = j.id ORDER BY started_at DESC LIMIT 1
+      ) lr ON true
+      ${where}
+      ${opts.filter === 'failed' ? `AND lr.status = 'failed'` : ''}`;
+  const { rows: crows } = await getPool().query<{ total: number }>(countSql, vals);
+  return { items, total: crows[0]?.total ?? 0 };
+}
+
+export async function findJob(userId: string, jobId: string): Promise<JobRow | null> {
+  const { rows } = await getPool().query<JobRow>(
+    `SELECT * FROM scrape_jobs WHERE id = $1 AND user_id = $2 LIMIT 1`,
+    [jobId, userId],
+  );
+  return rows[0] ?? null;
+}
+
+export type UpdateJobArgs = Partial<CreateJobArgs>;
+
+export async function updateJob(userId: string, jobId: string, args: UpdateJobArgs): Promise<JobRow | null> {
+  // Build dynamic SET clause only for provided keys.
+  const sets: string[] = [];
+  const vals: unknown[] = [];
+  const push = (col: string, value: unknown, jsonb = false) => {
+    vals.push(value);
+    sets.push(`${col} = $${vals.length}${jsonb ? '::jsonb' : ''}`);
+  };
+  if (args.name !== undefined) push('name', args.name);
+  if (args.urls !== undefined) push('urls', JSON.stringify(args.urls), true);
+  if (args.extraction_prompt !== undefined) push('extraction_prompt', args.extraction_prompt);
+  if (args.extraction_schema !== undefined)
+    push('extraction_schema', args.extraction_schema ? JSON.stringify(args.extraction_schema) : null, true);
+  if (args.scrape_method !== undefined) push('scrape_method', args.scrape_method);
+  if (args.schedule !== undefined) push('schedule', args.schedule);
+  if (args.enabled !== undefined) push('enabled', args.enabled);
+  if (args.notification_rules !== undefined) push('notification_rules', JSON.stringify(args.notification_rules), true);
+  if (args.notify_channels !== undefined) push('notify_channels', JSON.stringify(args.notify_channels), true);
+  if (args.comparison_key !== undefined) push('comparison_key', args.comparison_key);
+  if (args.ai_provider !== undefined) push('ai_provider', args.ai_provider);
+  if (args.ai_model !== undefined) push('ai_model', args.ai_model);
+  if (args.google_sheet_id !== undefined) push('google_sheet_id', args.google_sheet_id);
+  if (args.sheet_tab_name !== undefined) push('sheet_tab_name', args.sheet_tab_name);
+
+  if (sets.length === 0) return findJob(userId, jobId);
+
+  vals.push(userId, jobId);
+  const { rows } = await getPool().query<JobRow>(
+    `UPDATE scrape_jobs SET ${sets.join(', ')}
+      WHERE user_id = $${vals.length - 1} AND id = $${vals.length}
+      RETURNING *`,
+    vals,
+  );
+  return rows[0] ?? null;
+}
+
+export async function toggleJob(userId: string, jobId: string): Promise<JobRow | null> {
+  const { rows } = await getPool().query<JobRow>(
+    `UPDATE scrape_jobs SET enabled = NOT enabled
+      WHERE id = $1 AND user_id = $2
+      RETURNING *`,
+    [jobId, userId],
+  );
+  return rows[0] ?? null;
+}
+
+export async function deleteJob(userId: string, jobId: string): Promise<boolean> {
+  const { rowCount } = await getPool().query(
+    `DELETE FROM scrape_jobs WHERE id = $1 AND user_id = $2`,
+    [jobId, userId],
+  );
+  return (rowCount ?? 0) > 0;
+}

--- a/server/src/db/runs.ts
+++ b/server/src/db/runs.ts
@@ -1,0 +1,138 @@
+import { getPool } from '../config/database.js';
+
+export type RunStatus =
+  | 'pending'
+  | 'scraping'
+  | 'extracting'
+  | 'exporting'
+  | 'completed'
+  | 'failed';
+
+export type RunRow = {
+  id: string;
+  job_id: string;
+  status: RunStatus;
+  urls_scraped: number;
+  items_extracted: number;
+  tokens_used: number;
+  error_message: string | null;
+  started_at: Date;
+  completed_at: Date | null;
+};
+
+export type RunDTO = Omit<RunRow, 'started_at' | 'completed_at'> & {
+  started_at: string;
+  completed_at: string | null;
+};
+
+export function toDTO(r: RunRow): RunDTO {
+  return {
+    ...r,
+    started_at: r.started_at.toISOString(),
+    completed_at: r.completed_at?.toISOString() ?? null,
+  };
+}
+
+export async function listRunsForJob(
+  userId: string,
+  jobId: string,
+  limit = 50,
+  offset = 0,
+): Promise<RunDTO[]> {
+  const { rows } = await getPool().query<RunRow>(
+    `SELECT r.*
+       FROM scrape_runs r
+       JOIN scrape_jobs j ON j.id = r.job_id AND j.user_id = $1
+      WHERE r.job_id = $2
+      ORDER BY r.started_at DESC
+      LIMIT $3 OFFSET $4`,
+    [userId, jobId, limit, offset],
+  );
+  return rows.map(toDTO);
+}
+
+export async function findRun(userId: string, runId: string): Promise<RunRow | null> {
+  const { rows } = await getPool().query<RunRow>(
+    `SELECT r.*
+       FROM scrape_runs r
+       JOIN scrape_jobs j ON j.id = r.job_id AND j.user_id = $1
+      WHERE r.id = $2
+      LIMIT 1`,
+    [userId, runId],
+  );
+  return rows[0] ?? null;
+}
+
+export async function createRun(jobId: string): Promise<RunRow> {
+  const { rows } = await getPool().query<RunRow>(
+    `INSERT INTO scrape_runs (job_id, status) VALUES ($1, 'pending') RETURNING *`,
+    [jobId],
+  );
+  return rows[0]!;
+}
+
+export async function updateRun(
+  runId: string,
+  patch: Partial<Pick<RunRow, 'status' | 'urls_scraped' | 'items_extracted' | 'tokens_used' | 'error_message' | 'completed_at'>>,
+): Promise<void> {
+  const sets: string[] = [];
+  const vals: unknown[] = [];
+  const push = (col: string, v: unknown) => {
+    vals.push(v);
+    sets.push(`${col} = $${vals.length}`);
+  };
+  if (patch.status !== undefined) push('status', patch.status);
+  if (patch.urls_scraped !== undefined) push('urls_scraped', patch.urls_scraped);
+  if (patch.items_extracted !== undefined) push('items_extracted', patch.items_extracted);
+  if (patch.tokens_used !== undefined) push('tokens_used', patch.tokens_used);
+  if (patch.error_message !== undefined) push('error_message', patch.error_message);
+  if (patch.completed_at !== undefined) push('completed_at', patch.completed_at);
+  if (sets.length === 0) return;
+  vals.push(runId);
+  await getPool().query(`UPDATE scrape_runs SET ${sets.join(', ')} WHERE id = $${vals.length}`, vals);
+}
+
+export type ExtractedDataRow = {
+  id: string;
+  run_id: string;
+  job_id: string;
+  source_url: string;
+  data: Record<string, unknown>;
+  data_hash: string;
+  created_at: Date;
+};
+
+export type ExtractedDataDTO = Omit<ExtractedDataRow, 'created_at'> & { created_at: string };
+
+export async function listDataForRun(
+  userId: string,
+  runId: string,
+): Promise<ExtractedDataDTO[]> {
+  const { rows } = await getPool().query<ExtractedDataRow>(
+    `SELECT d.*
+       FROM extracted_data d
+       JOIN scrape_jobs j ON j.id = d.job_id AND j.user_id = $1
+      WHERE d.run_id = $2
+      ORDER BY d.source_url, d.created_at`,
+    [userId, runId],
+  );
+  return rows.map((r) => ({ ...r, created_at: r.created_at.toISOString() }));
+}
+
+export async function insertExtractedData(
+  runId: string,
+  jobId: string,
+  rows: { source_url: string; data: Record<string, unknown>; data_hash: string }[],
+): Promise<void> {
+  if (rows.length === 0) return;
+  const values: unknown[] = [];
+  const placeholders = rows.map((r, i) => {
+    const base = i * 5;
+    values.push(runId, jobId, r.source_url, JSON.stringify(r.data), r.data_hash);
+    return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}::jsonb, $${base + 5})`;
+  });
+  await getPool().query(
+    `INSERT INTO extracted_data (run_id, job_id, source_url, data, data_hash) VALUES ${placeholders.join(', ')}`,
+    values,
+  );
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,7 +5,9 @@ import { closeRedis } from './config/redis.js';
 import { closeScraper } from './services/scraper.js';
 import { authRouter } from './routes/auth.js';
 import { healthRouter } from './routes/health.js';
+import { jobsRouter } from './routes/jobs.js';
 import { providersRouter } from './routes/providers.js';
+import { runsRouter } from './routes/runs.js';
 import { generalLimiter } from './middleware/rateLimit.js';
 import { fail } from './lib/response.js';
 
@@ -23,6 +25,8 @@ app.use('/api/health', healthRouter);
 app.use('/api', generalLimiter);
 app.use('/api/auth', authRouter);
 app.use('/api/providers', providersRouter);
+app.use('/api/jobs', jobsRouter);
+app.use('/api/runs', runsRouter);
 
 app.use((_req, res) => {
   res.status(404).json(fail('NOT_FOUND', 'Route not found'));

--- a/server/src/routes/jobs.ts
+++ b/server/src/routes/jobs.ts
@@ -1,0 +1,176 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { assertSafeUrl } from '../lib/ssrf.js';
+import { fail, ok } from '../lib/response.js';
+import { requireAuth } from '../middleware/auth.js';
+import { validate } from '../middleware/validate.js';
+import {
+  createJob,
+  deleteJob,
+  findJob,
+  listJobs,
+  toDTO as toJobDTO,
+  toggleJob,
+  updateJob,
+} from '../db/jobs.js';
+import { listRunsForJob } from '../db/runs.js';
+
+export const jobsRouter = Router();
+jobsRouter.use(requireAuth);
+
+// ---------- schemas ----------
+
+const providerEnum = z.enum(['openai', 'anthropic', 'openrouter']);
+const scrapeMethodEnum = z.enum(['auto', 'playwright', 'cheerio']);
+const setupMethodEnum = z.enum(['ai', 'manual']);
+const channelEnum = z.enum(['email', 'telegram']);
+
+const notificationRule = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('any_change'), message: z.string().optional() }),
+  z.object({ type: z.literal('new_items'), message: z.string().optional() }),
+  z.object({ type: z.literal('removed_items'), message: z.string().optional() }),
+  z.object({
+    type: z.literal('field_threshold'),
+    field: z.string().min(1),
+    operator: z.enum([
+      'less_than',
+      'greater_than',
+      'equals',
+      'not_equals',
+      'less_than_or_equal',
+      'greater_than_or_equal',
+    ]),
+    value: z.union([z.number(), z.string()]),
+    message: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('field_change'),
+    field: z.string().min(1),
+    message: z.string().optional(),
+  }),
+]);
+
+const extractionSchema = z.record(z.enum(['string', 'number', 'boolean', 'array', 'object']));
+
+const createBody = z.object({
+  name: z.string().trim().min(1).max(200),
+  urls: z.array(z.string().url()).min(1).max(10),
+  extraction_prompt: z.string().trim().min(5).max(5000),
+  extraction_schema: extractionSchema.nullable().optional(),
+  scrape_method: scrapeMethodEnum.optional(),
+  schedule: z.string().nullable().optional(),
+  enabled: z.boolean().optional(),
+  notification_rules: z.array(notificationRule).optional(),
+  notify_channels: z.array(channelEnum).optional(),
+  comparison_key: z.string().nullable().optional(),
+  ai_provider: providerEnum.optional(),
+  ai_model: z.string().min(1).max(120).optional(),
+  google_sheet_id: z.string().nullable().optional(),
+  sheet_tab_name: z.string().nullable().optional(),
+  setup_method: setupMethodEnum.optional(),
+});
+
+const updateBody = createBody.partial();
+
+const idParam = z.object({ id: z.string().uuid() });
+
+const listQuery = z.object({
+  filter: z.enum(['all', 'active', 'paused', 'failed']).optional(),
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+});
+
+// ---------- helpers ----------
+
+async function validateAllUrls(urls: string[]): Promise<string | null> {
+  for (const u of urls) {
+    const r = await assertSafeUrl(u);
+    if (!r.ok) return `${u}: ${r.reason}`;
+  }
+  return null;
+}
+
+// ---------- routes ----------
+
+jobsRouter.get('/', validate(listQuery, 'query'), async (req, res) => {
+  const q = req.query as unknown as z.infer<typeof listQuery>;
+  const result = await listJobs(req.user!.id, {
+    filter: q.filter ?? 'all',
+    limit: q.limit,
+    offset: q.offset,
+  });
+  res.status(200).json(ok(result));
+});
+
+jobsRouter.post('/', validate(createBody), async (req, res) => {
+  const body = req.body as z.infer<typeof createBody>;
+  const bad = await validateAllUrls(body.urls);
+  if (bad) {
+    res.status(400).json(fail('UNSAFE_URL', bad));
+    return;
+  }
+  const row = await createJob(req.user!.id, {
+    ...body,
+    extraction_schema: body.extraction_schema ?? null,
+  });
+  res.status(201).json(ok({ job: toJobDTO(row) }));
+});
+
+jobsRouter.get('/:id', validate(idParam, 'params'), async (req, res) => {
+  const { id } = req.params as unknown as z.infer<typeof idParam>;
+  const row = await findJob(req.user!.id, id);
+  if (!row) {
+    res.status(404).json(fail('NOT_FOUND', 'Job not found'));
+    return;
+  }
+  res.status(200).json(ok({ job: toJobDTO(row) }));
+});
+
+jobsRouter.patch('/:id', validate(idParam, 'params'), validate(updateBody), async (req, res) => {
+  const { id } = req.params as unknown as z.infer<typeof idParam>;
+  const body = req.body as z.infer<typeof updateBody>;
+  if (body.urls) {
+    const bad = await validateAllUrls(body.urls);
+    if (bad) {
+      res.status(400).json(fail('UNSAFE_URL', bad));
+      return;
+    }
+  }
+  const row = await updateJob(req.user!.id, id, body);
+  if (!row) {
+    res.status(404).json(fail('NOT_FOUND', 'Job not found'));
+    return;
+  }
+  res.status(200).json(ok({ job: toJobDTO(row) }));
+});
+
+jobsRouter.patch('/:id/toggle', validate(idParam, 'params'), async (req, res) => {
+  const { id } = req.params as unknown as z.infer<typeof idParam>;
+  const row = await toggleJob(req.user!.id, id);
+  if (!row) {
+    res.status(404).json(fail('NOT_FOUND', 'Job not found'));
+    return;
+  }
+  res.status(200).json(ok({ job: toJobDTO(row) }));
+});
+
+jobsRouter.delete('/:id', validate(idParam, 'params'), async (req, res) => {
+  const { id } = req.params as unknown as z.infer<typeof idParam>;
+  const removed = await deleteJob(req.user!.id, id);
+  if (!removed) {
+    res.status(404).json(fail('NOT_FOUND', 'Job not found'));
+    return;
+  }
+  res.status(200).json(ok({ removed: true }));
+});
+
+jobsRouter.get('/:id/runs', validate(idParam, 'params'), async (req, res) => {
+  const { id } = req.params as unknown as z.infer<typeof idParam>;
+  const job = await findJob(req.user!.id, id);
+  if (!job) {
+    res.status(404).json(fail('NOT_FOUND', 'Job not found'));
+    return;
+  }
+  const runs = await listRunsForJob(req.user!.id, id);
+  res.status(200).json(ok({ runs }));
+});

--- a/server/src/routes/runs.ts
+++ b/server/src/routes/runs.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { fail, ok } from '../lib/response.js';
+import { requireAuth } from '../middleware/auth.js';
+import { validate } from '../middleware/validate.js';
+import { findRun, listDataForRun, toDTO as toRunDTO } from '../db/runs.js';
+
+export const runsRouter = Router();
+runsRouter.use(requireAuth);
+
+const idParam = z.object({ id: z.string().uuid() });
+
+runsRouter.get('/:id', validate(idParam, 'params'), async (req, res) => {
+  const { id } = req.params as unknown as z.infer<typeof idParam>;
+  const row = await findRun(req.user!.id, id);
+  if (!row) {
+    res.status(404).json(fail('NOT_FOUND', 'Run not found'));
+    return;
+  }
+  res.status(200).json(ok({ run: toRunDTO(row) }));
+});
+
+runsRouter.get('/:id/data', validate(idParam, 'params'), async (req, res) => {
+  const { id } = req.params as unknown as z.infer<typeof idParam>;
+  const run = await findRun(req.user!.id, id);
+  if (!run) {
+    res.status(404).json(fail('NOT_FOUND', 'Run not found'));
+    return;
+  }
+  const data = await listDataForRun(req.user!.id, id);
+  res.status(200).json(ok({ data }));
+});


### PR DESCRIPTION
## Summary

Build Order step 7. The shell around steps 8\u201310 \u2014 users can now create, edit, toggle, delete, and browse jobs and their run histories end-to-end.

## Backend

- `db/jobs.ts` \u2014 list with LATERAL join to the latest run (needed for `filter=failed`), create, find, update (dynamic SET), toggle, delete. All queries user-scoped.
- `db/runs.ts` \u2014 list-for-job, find, create, update, list-data-for-run, batch insertExtractedData. Every read joins through scrape_jobs so only the owner sees them.
- `routes/jobs.ts` \u2014 `GET /api/jobs?filter=all|active|paused|failed&limit&offset`, `POST /api/jobs`, `GET/PATCH/DELETE /api/jobs/:id`, `PATCH /api/jobs/:id/toggle`, `GET /api/jobs/:id/runs`. URL lists run through the SSRF guard at the route layer, returning `UNSAFE_URL` up front.
- `routes/runs.ts` \u2014 `GET /api/runs/:id`, `GET /api/runs/:id/data`.
- `z.discriminatedUnion` validates notification rule shapes.

## Frontend

- `Jobs.tsx` list with filter tabs, skeleton loading, empty state with CTA, inline enabled toggle.
- `NewJob.tsx` / `EditJob.tsx` wrap shared `JobForm.tsx`: Basics / Extraction (prompt + typed schema + comparison key) / Scraping + scheduling / AI model / Notifications (channels + rule editor that adapts inputs per rule type).
- `JobDetail.tsx` with config summary, URL list, and run-history table. \"Run Now\" is a disabled shell \u2014 wiring arrives with step 9.
- `/jobs`, `/jobs/new`, `/jobs/:id`, `/jobs/:id/edit` routes under `RequireAuth`. New `Jobs` entry in the TopNav.

## Smoke test (live stack)

- Create, list (filters `all` / `active` / `paused` / `failed`), toggle, patch name, delete.
- Unsafe URL (`http://169.254.169.254/`) with a passing extraction_prompt \u2192 `UNSAFE_URL` with the specific failing URL and reason.
- Runs endpoint: empty list returned; `404 NOT_FOUND` after job deletion.
- Schema validation: short prompt \u2192 `VALIDATION_ERROR` with field path.

## Out of scope

- `POST /api/jobs/:id/run` wiring (step 9).
- `/api/jobs/ai-setup` + wizard UI (step 8).
- Diff endpoint (step 10).

Closes #17