### PR TITLE
feat: change detection + diff view

### DIFF
--- a/client/src/components/RunDiff.tsx
+++ b/client/src/components/RunDiff.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api';
+import type { DiffResult } from '../types/api';
+
+export function RunDiff({ runId }: { runId: string }) {
+  const [diff, setDiff] = useState<DiffResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const res = await api<{ diff: DiffResult }>(`/api/runs/${runId}/diff`);
+      if (cancelled) return;
+      if (res.success) setDiff(res.data.diff);
+      else setError(res.error.message);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [runId]);
+
+  if (error) return <p className="text-xs text-red-600">{error}</p>;
+  if (!diff) return <p className="text-xs text-gray-500">Loading…</p>;
+
+  if (!diff.previous_run) {
+    return (
+      <p className="text-xs text-gray-500">
+        First run for this job — {diff.added.length} item{diff.added.length === 1 ? '' : 's'} as the baseline.
+      </p>
+    );
+  }
+
+  const nothing = diff.added.length === 0 && diff.removed.length === 0 && diff.changed.length === 0;
+
+  return (
+    <div className="space-y-3 text-xs">
+      <p className="font-mono text-gray-500">
+        vs run {diff.previous_run.id.slice(0, 8)} · {new Date(diff.previous_run.started_at).toLocaleString()}
+      </p>
+      {nothing && <p className="text-gray-500">No changes since the previous run.</p>}
+      {diff.added.length > 0 && <Group tone="added" label={`Added (${diff.added.length})`} items={diff.added} />}
+      {diff.removed.length > 0 && (
+        <Group tone="removed" label={`Removed (${diff.removed.length})`} items={diff.removed} />
+      )}
+      {diff.changed.length > 0 && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-900/60 dark:bg-amber-950/40">
+          <p className="mb-2 font-medium text-amber-800 dark:text-amber-300">Changed ({diff.changed.length})</p>
+          <ul className="space-y-2">
+            {diff.changed.map((c, i) => (
+              <li key={i} className="border-l-2 border-amber-300 pl-2 font-mono text-[11px]">
+                <div className="text-amber-900 dark:text-amber-200">key: {c.key}</div>
+                <ul className="mt-1 space-y-0.5">
+                  {c.field_diffs.map((f, j) => (
+                    <li key={j}>
+                      <span className="text-gray-500">{f.field}:</span>{' '}
+                      <span className="line-through opacity-70">{renderValue(f.old)}</span>{' '}
+                      <span className="text-amber-900 dark:text-amber-200">→ {renderValue(f.new)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Group({
+  tone,
+  label,
+  items,
+}: {
+  tone: 'added' | 'removed';
+  label: string;
+  items: Record<string, unknown>[];
+}) {
+  const cls =
+    tone === 'added'
+      ? 'border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-200'
+      : 'border-red-200 bg-red-50 text-red-900 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-200';
+  return (
+    <div className={`rounded-md border p-3 ${cls}`}>
+      <p className="mb-2 font-medium">{label}</p>
+      <ul className="space-y-1 font-mono text-[11px]">
+        {items.slice(0, 10).map((item, i) => (
+          <li key={i} className="truncate">
+            {Object.entries(item)
+              .slice(0, 4)
+              .map(([k, v]) => `${k}=${renderValue(v)}`)
+              .join('  ·  ')}
+          </li>
+        ))}
+        {items.length > 10 && <li className="text-xs opacity-70">+ {items.length - 10} more</li>}
+      </ul>
+    </div>
+  );
+}
+
+function renderValue(v: unknown): string {
+  if (v === null || v === undefined) return '—';
+  if (typeof v === 'object') return JSON.stringify(v).slice(0, 60);
+  return String(v).slice(0, 60);
+}

--- a/client/src/pages/JobDetail.tsx
+++ b/client/src/pages/JobDetail.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { TopNav } from '../components/layout/TopNav';
+import { RunDiff } from '../components/RunDiff';
 import { Alert } from '../components/ui/Alert';
 import { Button } from '../components/ui/Button';
 import { api } from '../lib/api';
@@ -14,6 +15,7 @@ export default function JobDetail() {
   const [error, setError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [runningNow, setRunningNow] = useState(false);
+  const [openDiff, setOpenDiff] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     const [jr, rr] = await Promise.all([
@@ -148,25 +150,47 @@ export default function JobDetail() {
                   <th className="py-2">Tokens</th>
                   <th className="py-2">Duration</th>
                   <th className="py-2">When</th>
+                  <th className="py-2"></th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
                 {runs.map((r) => (
-                  <tr key={r.id}>
-                    <td className="py-2">
-                      <StatusBadge status={r.status} />
-                    </td>
-                    <td className="py-2 font-mono text-xs">{r.items_extracted}</td>
-                    <td className="py-2 font-mono text-xs">{r.tokens_used}</td>
-                    <td className="py-2 font-mono text-xs">
-                      {r.completed_at
-                        ? `${Math.round(
-                            (new Date(r.completed_at).getTime() - new Date(r.started_at).getTime()) / 100,
-                          ) / 10}s`
-                        : '—'}
-                    </td>
-                    <td className="py-2 font-mono text-xs text-gray-500">{new Date(r.started_at).toLocaleString()}</td>
-                  </tr>
+                  <Fragment key={r.id}>
+                    <tr>
+                      <td className="py-2">
+                        <StatusBadge status={r.status} />
+                      </td>
+                      <td className="py-2 font-mono text-xs">{r.items_extracted}</td>
+                      <td className="py-2 font-mono text-xs">{r.tokens_used}</td>
+                      <td className="py-2 font-mono text-xs">
+                        {r.completed_at
+                          ? `${Math.round(
+                              (new Date(r.completed_at).getTime() - new Date(r.started_at).getTime()) / 100,
+                            ) / 10}s`
+                          : '—'}
+                      </td>
+                      <td className="py-2 font-mono text-xs text-gray-500">
+                        {new Date(r.started_at).toLocaleString()}
+                      </td>
+                      <td className="py-2 text-right">
+                        {r.status === 'completed' && (
+                          <button
+                            onClick={() => setOpenDiff(openDiff === r.id ? null : r.id)}
+                            className="text-xs text-indigo-600 hover:underline dark:text-indigo-400"
+                          >
+                            {openDiff === r.id ? 'Hide diff' : 'Diff'}
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                    {openDiff === r.id && (
+                      <tr>
+                        <td colSpan={6} className="bg-gray-50 px-2 py-3 dark:bg-gray-950/40">
+                          <RunDiff runId={r.id} />
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
                 ))}
               </tbody>
             </table>

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -119,6 +119,22 @@ export type ExtractedData = {
   created_at: string;
 };
 
+export type FieldDiff = { field: string; old: unknown; new: unknown };
+
+export type DiffResult = {
+  current_run: { id: string; started_at: string };
+  previous_run: { id: string; started_at: string } | null;
+  added: Record<string, unknown>[];
+  removed: Record<string, unknown>[];
+  changed: {
+    key: string | null;
+    before: Record<string, unknown>;
+    after: Record<string, unknown>;
+    field_diffs: FieldDiff[];
+  }[];
+  comparison_key: string | null;
+};
+
 export type HealthStatus = {
   status: 'healthy' | 'degraded';
   checks: {

--- a/server/src/routes/runs.ts
+++ b/server/src/routes/runs.ts
@@ -4,6 +4,7 @@ import { fail, ok } from '../lib/response.js';
 import { requireAuth } from '../middleware/auth.js';
 import { validate } from '../middleware/validate.js';
 import { findRun, listDataForRun, toDTO as toRunDTO } from '../db/runs.js';
+import { diffRun } from '../services/change-detector.js';
 
 export const runsRouter = Router();
 runsRouter.use(requireAuth);
@@ -18,6 +19,16 @@ runsRouter.get('/:id', validate(idParam, 'params'), async (req, res) => {
     return;
   }
   res.status(200).json(ok({ run: toRunDTO(row) }));
+});
+
+runsRouter.get('/:id/diff', validate(idParam, 'params'), async (req, res) => {
+  const { id } = req.params as unknown as z.infer<typeof idParam>;
+  const diff = await diffRun(req.user!.id, id);
+  if (!diff) {
+    res.status(404).json(fail('NOT_FOUND', 'Run not found'));
+    return;
+  }
+  res.status(200).json(ok({ diff }));
 });
 
 runsRouter.get('/:id/data', validate(idParam, 'params'), async (req, res) => {

--- a/server/src/services/change-detector.ts
+++ b/server/src/services/change-detector.ts
@@ -1,0 +1,135 @@
+import { getPool } from '../config/database.js';
+import type { ExtractedDataDTO } from '../db/runs.js';
+
+export type FieldDiff = { field: string; old: unknown; new: unknown };
+
+export type DiffResult = {
+  current_run: { id: string; started_at: string };
+  previous_run: { id: string; started_at: string } | null;
+  added: Record<string, unknown>[];
+  removed: Record<string, unknown>[];
+  changed: {
+    key: string | null;
+    before: Record<string, unknown>;
+    after: Record<string, unknown>;
+    field_diffs: FieldDiff[];
+  }[];
+  comparison_key: string | null;
+};
+
+type DataRow = Pick<ExtractedDataDTO, 'source_url' | 'data' | 'data_hash' | 'created_at'>;
+
+function fieldLevelDiff(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): FieldDiff[] {
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  const out: FieldDiff[] = [];
+  for (const k of keys) {
+    const a = before[k];
+    const b = after[k];
+    // Structural compare for objects/arrays; primitives compared with ===.
+    const same =
+      a === b || (typeof a === 'object' && typeof b === 'object' && JSON.stringify(a) === JSON.stringify(b));
+    if (!same) out.push({ field: k, old: a, new: b });
+  }
+  return out;
+}
+
+function indexByKey(
+  rows: DataRow[],
+  comparisonKey: string | null,
+): Map<string, DataRow> {
+  const map = new Map<string, DataRow>();
+  for (const r of rows) {
+    const key =
+      comparisonKey && r.data[comparisonKey] != null
+        ? String(r.data[comparisonKey])
+        : r.data_hash;
+    if (!map.has(key)) map.set(key, r);
+  }
+  return map;
+}
+
+/**
+ * Diff the given run against the most recent earlier completed run for the same job.
+ * Returns `previous_run: null` when there isn't one yet.
+ */
+export async function diffRun(userId: string, runId: string): Promise<DiffResult | null> {
+  const pool = getPool();
+  // Load the current run (and verify ownership via the scrape_jobs join).
+  const { rows: currentRows } = await pool.query<{
+    id: string;
+    job_id: string;
+    started_at: Date;
+    comparison_key: string | null;
+  }>(
+    `SELECT r.id, r.job_id, r.started_at, j.comparison_key
+       FROM scrape_runs r
+       JOIN scrape_jobs j ON j.id = r.job_id AND j.user_id = $1
+      WHERE r.id = $2
+      LIMIT 1`,
+    [userId, runId],
+  );
+  const current = currentRows[0];
+  if (!current) return null;
+
+  // Pick the previous completed run (excluding the current one).
+  const { rows: prevRows } = await pool.query<{ id: string; started_at: Date }>(
+    `SELECT id, started_at
+       FROM scrape_runs
+      WHERE job_id = $1 AND id <> $2 AND status = 'completed' AND started_at < $3
+      ORDER BY started_at DESC
+      LIMIT 1`,
+    [current.job_id, current.id, current.started_at],
+  );
+  const prev = prevRows[0] ?? null;
+
+  const { rows: curData } = await pool.query<DataRow>(
+    `SELECT source_url, data, data_hash, created_at FROM extracted_data WHERE run_id = $1`,
+    [current.id],
+  );
+
+  const result: DiffResult = {
+    current_run: { id: current.id, started_at: current.started_at.toISOString() },
+    previous_run: prev ? { id: prev.id, started_at: prev.started_at.toISOString() } : null,
+    added: [],
+    removed: [],
+    changed: [],
+    comparison_key: current.comparison_key,
+  };
+
+  if (!prev) {
+    // First run ever \u2014 every item is "added" against an empty baseline.
+    result.added = curData.map((r) => r.data);
+    return result;
+  }
+
+  const { rows: prevData } = await pool.query<DataRow>(
+    `SELECT source_url, data, data_hash, created_at FROM extracted_data WHERE run_id = $1`,
+    [prev.id],
+  );
+
+  const key = current.comparison_key;
+  const curByKey = indexByKey(curData, key);
+  const prevByKey = indexByKey(prevData, key);
+
+  for (const [k, row] of curByKey) {
+    const match = prevByKey.get(k);
+    if (!match) {
+      result.added.push(row.data);
+    } else if (row.data_hash !== match.data_hash && key) {
+      result.changed.push({
+        key: k,
+        before: match.data,
+        after: row.data,
+        field_diffs: fieldLevelDiff(match.data, row.data),
+      });
+    }
+  }
+  for (const [k, row] of prevByKey) {
+    if (!curByKey.has(k)) result.removed.push(row.data);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Build Order step 10. Completed runs now have a reversible, per-field diff against their predecessor.

## Changes

- `services/change-detector.ts` \u2014 `diffRun(userId, runId)` loads the run (ownership via scrape_jobs), finds the most recent earlier completed run for the same job, and bucketes items into added / removed / changed. When `comparison_key` is set, `changed` items carry a `field_diffs[]` with per-field `old` / `new` values (structural compare for objects/arrays). Without a key we fall back to `data_hash` equality and only report added/removed.
- `GET /api/runs/:id/diff` \u2014 returns `{ current_run, previous_run, added, removed, changed, comparison_key }`. First-run case returns `previous_run: null` with every row in `added` so the UI has a uniform baseline to render.
- `RunDiff` component \u2014 inline expansion from JobDetail's run table; green/red/amber tones matching the handoff design notes.

## Smoke (live stack, dev OpenRouter key)

Ran the HN job twice with the `url` comparison key:
- Run 1: `previous_run: null`, `added: 5`, `removed: 0`, `changed: 0` \u2014 correct baseline.
- Run 2: `previous_run: <run1.id>`, `added: 0, removed: 0, changed: 0` \u2014 HN stable between the two requests; empty diff rendered as "No changes since the previous run."

Closes #23