### PR TITLE
feat: notification rules + email + Telegram dispatch

### DIFF
--- a/client/src/components/TelegramCard.tsx
+++ b/client/src/components/TelegramCard.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api';
+import { useAuth } from '../stores/auth';
+import { Alert } from './ui/Alert';
+import { Button } from './ui/Button';
+import { FormField } from './ui/FormField';
+import type { PublicUser } from '../types/api';
+
+type SetupInfo = {
+  botUsername: string | null;
+  link: string | null;
+  instructions: string[];
+};
+
+export function TelegramCard() {
+  const user = useAuth((s) => s.user);
+  const setUser = useAuth((s) => s.setUser);
+  const [chatId, setChatId] = useState(user?.telegram_chat_id ?? '');
+  const [info, setInfo] = useState<SetupInfo | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      const res = await api<SetupInfo>('/api/notifications/telegram/setup');
+      if (res.success) setInfo(res.data);
+    })();
+  }, []);
+
+  useEffect(() => {
+    setChatId(user?.telegram_chat_id ?? '');
+  }, [user?.telegram_chat_id]);
+
+  async function save() {
+    setStatus(null);
+    setSaving(true);
+    const res = await api<{ user: PublicUser }>('/api/auth/me', {
+      method: 'PATCH',
+      body: { telegram_chat_id: chatId.trim() || null },
+    });
+    setSaving(false);
+    if (!res.success) {
+      setStatus({ tone: 'error', message: res.error.message });
+      return;
+    }
+    setUser(res.data.user);
+    setStatus({ tone: 'success', message: 'Chat ID saved.' });
+  }
+
+  async function test() {
+    setStatus(null);
+    setTesting(true);
+    const res = await api<{ sent: boolean }>('/api/notifications/test/telegram', { method: 'POST' });
+    setTesting(false);
+    if (!res.success) {
+      setStatus({ tone: 'error', message: res.error.message });
+      return;
+    }
+    setStatus({ tone: 'success', message: 'Test message sent. Check Telegram.' });
+  }
+
+  return (
+    <article className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <header className="mb-3 flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Telegram</h3>
+          <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+            Receive notifications as direct messages from the SmartScrape bot.
+          </p>
+        </div>
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${
+            user?.telegram_chat_id
+              ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+              : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+          }`}
+        >
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${
+              user?.telegram_chat_id ? 'bg-emerald-500' : 'bg-gray-400'
+            }`}
+          />
+          {user?.telegram_chat_id ? 'Linked' : 'Not linked'}
+        </span>
+      </header>
+
+      {info?.link ? (
+        <ol className="mb-4 list-decimal space-y-0.5 pl-5 text-xs text-gray-600 dark:text-gray-400">
+          {info.instructions.map((line) => (
+            <li key={line}>
+              {/^\d+\.\s/.test(line) ? line.replace(/^\d+\.\s*/, '') : line}
+            </li>
+          ))}
+          <li>
+            Bot:{' '}
+            <a href={info.link} target="_blank" rel="noreferrer" className="text-indigo-600 hover:underline">
+              {info.link}
+            </a>
+          </li>
+        </ol>
+      ) : (
+        <p className="mb-4 text-xs text-gray-500">
+          Bot not reachable. Check server config.
+        </p>
+      )}
+
+      <FormField
+        label="Your Telegram chat ID"
+        value={chatId}
+        onChange={(e) => setChatId(e.target.value)}
+        placeholder="e.g. 123456789"
+        autoComplete="off"
+      />
+      <div className="mt-3 flex flex-wrap gap-2">
+        <Button onClick={save} loading={saving}>
+          Save
+        </Button>
+        {user?.telegram_chat_id && (
+          <Button variant="secondary" onClick={test} loading={testing}>
+            Send test message
+          </Button>
+        )}
+      </div>
+      {status && (
+        <div className="mt-3">
+          <Alert tone={status.tone}>{status.message}</Alert>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { TopNav } from '../components/layout/TopNav';
 import { ProviderCard } from '../components/ProviderCard';
+import { TelegramCard } from '../components/TelegramCard';
 import { api } from '../lib/api';
 import type { Provider, ProviderSummary } from '../types/api';
 
@@ -103,11 +104,16 @@ export default function Settings() {
         </section>
 
         <section className="mt-12 space-y-4">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
-            Coming soon
-          </h2>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Notifications</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            <TelegramCard />
+          </div>
+        </section>
+
+        <section className="mt-12 space-y-4">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Coming soon</h2>
           <div className="rounded-lg border border-dashed border-gray-300 bg-white/40 p-6 text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-400">
-            Profile, Google Sheets, Telegram, Email, and account deletion land in upcoming releases.
+            Profile, Google Sheets, and account deletion land in upcoming releases.
           </div>
         </section>
       </main>

--- a/server/src/db/notifications.ts
+++ b/server/src/db/notifications.ts
@@ -1,0 +1,79 @@
+import { getPool } from '../config/database.js';
+
+export type Channel = 'email' | 'telegram';
+export type NotifKind = 'change_detected' | 'job_failed' | 'job_completed';
+
+export type NotificationRow = {
+  id: string;
+  user_id: string;
+  job_id: string;
+  run_id: string;
+  channel: Channel;
+  type: NotifKind;
+  message: string | null;
+  sent_at: Date;
+};
+
+export type NotificationDTO = Omit<NotificationRow, 'sent_at'> & {
+  sent_at: string;
+  job_name?: string;
+};
+
+export async function insertNotification(args: {
+  userId: string;
+  jobId: string;
+  runId: string;
+  channel: Channel;
+  type: NotifKind;
+  message: string;
+}): Promise<void> {
+  await getPool().query(
+    `INSERT INTO notification_log (user_id, job_id, run_id, channel, type, message)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [args.userId, args.jobId, args.runId, args.channel, args.type, args.message],
+  );
+}
+
+export type ListOpts = { limit?: number; offset?: number; jobId?: string; channel?: Channel };
+
+export async function listNotifications(userId: string, opts: ListOpts = {}): Promise<{ items: NotificationDTO[]; total: number }> {
+  const limit = Math.min(Math.max(opts.limit ?? 50, 1), 200);
+  const offset = Math.max(opts.offset ?? 0, 0);
+  const params: unknown[] = [userId];
+  let where = `WHERE n.user_id = $1`;
+  if (opts.jobId) {
+    params.push(opts.jobId);
+    where += ` AND n.job_id = $${params.length}`;
+  }
+  if (opts.channel) {
+    params.push(opts.channel);
+    where += ` AND n.channel = $${params.length}`;
+  }
+  const { rows } = await getPool().query<NotificationRow & { job_name: string }>(
+    `SELECT n.*, j.name AS job_name
+       FROM notification_log n
+       JOIN scrape_jobs j ON j.id = n.job_id
+      ${where}
+      ORDER BY n.sent_at DESC
+      LIMIT ${limit} OFFSET ${offset}`,
+    params,
+  );
+  const { rows: crows } = await getPool().query<{ total: number }>(
+    `SELECT COUNT(*)::int AS total FROM notification_log n ${where}`,
+    params,
+  );
+  return {
+    items: rows.map((r) => ({
+      id: r.id,
+      user_id: r.user_id,
+      job_id: r.job_id,
+      run_id: r.run_id,
+      channel: r.channel,
+      type: r.type,
+      message: r.message,
+      sent_at: r.sent_at.toISOString(),
+      job_name: r.job_name,
+    })),
+    total: crows[0]?.total ?? 0,
+  };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,6 +7,7 @@ import { closeScraper } from './services/scraper.js';
 import { authRouter } from './routes/auth.js';
 import { healthRouter } from './routes/health.js';
 import { jobsRouter } from './routes/jobs.js';
+import { notificationsRouter } from './routes/notifications.js';
 import { providersRouter } from './routes/providers.js';
 import { runsRouter } from './routes/runs.js';
 import { generalLimiter } from './middleware/rateLimit.js';
@@ -28,6 +29,7 @@ app.use('/api/auth', authRouter);
 app.use('/api/providers', providersRouter);
 app.use('/api/jobs', jobsRouter);
 app.use('/api/runs', runsRouter);
+app.use('/api/notifications', notificationsRouter);
 
 app.use((_req, res) => {
   res.status(404).json(fail('NOT_FOUND', 'Route not found'));

--- a/server/src/routes/notifications.ts
+++ b/server/src/routes/notifications.ts
@@ -1,0 +1,86 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { fail, ok } from '../lib/response.js';
+import { requireAuth } from '../middleware/auth.js';
+import { validate } from '../middleware/validate.js';
+import { findUserById } from '../db/users.js';
+import { listNotifications } from '../db/notifications.js';
+import { sendEmail } from '../services/email.js';
+import { sendTelegram, getBotSetupInfo } from '../services/telegram.js';
+
+export const notificationsRouter = Router();
+notificationsRouter.use(requireAuth);
+
+const listQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  channel: z.enum(['email', 'telegram']).optional(),
+  job_id: z.string().uuid().optional(),
+});
+
+notificationsRouter.get('/', validate(listQuery, 'query'), async (req, res) => {
+  const q = req.query as unknown as z.infer<typeof listQuery>;
+  const result = await listNotifications(req.user!.id, {
+    limit: q.limit,
+    offset: q.offset,
+    channel: q.channel,
+    jobId: q.job_id,
+  });
+  res.status(200).json(ok(result));
+});
+
+notificationsRouter.post('/test/email', async (req, res) => {
+  const user = await findUserById(req.user!.id);
+  if (!user) {
+    res.status(404).json(fail('NOT_FOUND', 'User not found'));
+    return;
+  }
+  try {
+    await sendEmail({
+      to: user.email,
+      subject: '[SmartScrape] Test email',
+      text: 'If you received this, your email channel is working.',
+    });
+    res.status(200).json(ok({ sent: true }));
+  } catch (err) {
+    res.status(502).json(fail('EMAIL_FAILED', err instanceof Error ? err.message : 'Email failed'));
+  }
+});
+
+notificationsRouter.post('/test/telegram', async (req, res) => {
+  const user = await findUserById(req.user!.id);
+  if (!user) {
+    res.status(404).json(fail('NOT_FOUND', 'User not found'));
+    return;
+  }
+  if (!user.telegram_chat_id) {
+    res.status(400).json(fail('NO_CHAT_ID', 'Link a Telegram chat_id in Settings first'));
+    return;
+  }
+  const result = await sendTelegram(
+    user.telegram_chat_id,
+    'SmartScrape test message \u2014 your Telegram channel is working.',
+  );
+  if (!result.ok) {
+    res.status(502).json(fail('TELEGRAM_FAILED', result.error ?? 'Telegram send failed'));
+    return;
+  }
+  res.status(200).json(ok({ sent: true }));
+});
+
+notificationsRouter.get('/telegram/setup', async (_req, res) => {
+  const info = await getBotSetupInfo();
+  res.status(200).json(
+    ok({
+      ...info,
+      instructions: info.link
+        ? [
+            `1. Open ${info.link} in Telegram and press Start.`,
+            '2. Send /start to the bot.',
+            '3. Visit https://t.me/userinfobot to get your numeric chat_id.',
+            '4. Paste that chat_id into SmartScrape Settings.',
+          ]
+        : ['TELEGRAM_BOT_TOKEN is not configured on this server. Ask an admin to set it.'],
+    }),
+  );
+});

--- a/server/src/services/job-runner.ts
+++ b/server/src/services/job-runner.ts
@@ -5,6 +5,8 @@ import type { JobRow } from '../db/jobs.js';
 import { createRun, insertExtractedData, updateRun } from '../db/runs.js';
 import { extract, hashItem } from './ai-extractor.js';
 import { scrape } from './scraper.js';
+import { diffRun } from './change-detector.js';
+import { dispatch, evaluateRules } from './notification-service.js';
 
 export type RunSummary = {
   runId: string;
@@ -89,6 +91,18 @@ export async function runJob(job: JobRow, existingRunId?: string): Promise<RunSu
       completed_at: new Date(),
     });
     await getPool().query(`UPDATE scrape_jobs SET last_run_at = now() WHERE id = $1`, [job.id]);
+
+    // Evaluate notification rules against the diff vs the previous run.
+    try {
+      const diff = await diffRun(job.user_id, run.id);
+      if (diff) {
+        const notifs = evaluateRules(job, diff);
+        await dispatch(job, run.id, notifs);
+      }
+    } catch (err) {
+      // Notification failures should not fail the run.
+      console.error('[runner] notification dispatch error', err);
+    }
 
     return {
       runId: run.id,

--- a/server/src/services/notification-service.ts
+++ b/server/src/services/notification-service.ts
@@ -1,0 +1,185 @@
+import type { DiffResult } from './change-detector.js';
+import type { JobRow, NotificationRule } from '../db/jobs.js';
+import { insertNotification, type Channel } from '../db/notifications.js';
+import { findUserById } from '../db/users.js';
+import { sendEmail } from './email.js';
+import { sendTelegram } from './telegram.js';
+
+export type EvaluatedNotification = {
+  type: 'change_detected' | 'job_failed' | 'job_completed';
+  message: string;
+};
+
+// ---------- variable substitution ----------
+
+function formatValue(v: unknown): string {
+  if (v === null || v === undefined) return '';
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+}
+
+function interpolate(template: string, vars: Record<string, unknown>): string {
+  return template.replace(/\{(\w+)\}/g, (_match, name: string) => {
+    if (name in vars) return formatValue(vars[name]);
+    return `{${name}}`;
+  });
+}
+
+// ---------- rule evaluation ----------
+
+function compare(operator: string, lhs: unknown, rhs: number | string): boolean {
+  const l = typeof lhs === 'string' && !Number.isNaN(Number(lhs)) ? Number(lhs) : lhs;
+  const r = typeof rhs === 'string' && !Number.isNaN(Number(rhs)) ? Number(rhs) : rhs;
+  switch (operator) {
+    case 'less_than':
+      return typeof l === 'number' && typeof r === 'number' && l < r;
+    case 'less_than_or_equal':
+      return typeof l === 'number' && typeof r === 'number' && l <= r;
+    case 'greater_than':
+      return typeof l === 'number' && typeof r === 'number' && l > r;
+    case 'greater_than_or_equal':
+      return typeof l === 'number' && typeof r === 'number' && l >= r;
+    case 'equals':
+      return l === r;
+    case 'not_equals':
+      return l !== r;
+    default:
+      return false;
+  }
+}
+
+export function evaluateRules(job: JobRow, diff: DiffResult): EvaluatedNotification[] {
+  const out: EvaluatedNotification[] = [];
+  const rules: NotificationRule[] = job.notification_rules;
+  const globals = { job_name: job.name };
+
+  for (const rule of rules) {
+    switch (rule.type) {
+      case 'any_change': {
+        if (diff.added.length > 0 || diff.removed.length > 0 || diff.changed.length > 0) {
+          const url = String((diff.added[0] ?? diff.changed[0]?.after ?? diff.removed[0])?.url ?? '');
+          out.push({
+            type: 'change_detected',
+            message: interpolate(rule.message ?? 'Data changed on {job_name}', { ...globals, url }),
+          });
+        }
+        break;
+      }
+      case 'new_items': {
+        if (diff.added.length > 0) {
+          out.push({
+            type: 'change_detected',
+            message: interpolate(rule.message ?? 'Found {count} new items on {job_name}', {
+              ...globals,
+              count: diff.added.length,
+            }),
+          });
+        }
+        break;
+      }
+      case 'removed_items': {
+        if (diff.removed.length > 0) {
+          out.push({
+            type: 'change_detected',
+            message: interpolate(rule.message ?? '{count} items were removed from {job_name}', {
+              ...globals,
+              count: diff.removed.length,
+            }),
+          });
+        }
+        break;
+      }
+      case 'field_threshold': {
+        // Check added + changed.after items for the threshold.
+        const candidates = [...diff.added, ...diff.changed.map((c) => c.after)];
+        for (const item of candidates) {
+          const value = (item as Record<string, unknown>)[rule.field];
+          if (compare(rule.operator, value, rule.value)) {
+            out.push({
+              type: 'change_detected',
+              message: interpolate(
+                rule.message ?? `{job_name}: ${rule.field} is ${value} ({operator} ${rule.value})`,
+                {
+                  ...globals,
+                  [rule.field]: value,
+                  operator: rule.operator,
+                  value: rule.value,
+                  url: (item as Record<string, unknown>).url,
+                },
+              ),
+            });
+          }
+        }
+        break;
+      }
+      case 'field_change': {
+        for (const ch of diff.changed) {
+          const match = ch.field_diffs.find((f) => f.field === rule.field);
+          if (!match) continue;
+          out.push({
+            type: 'change_detected',
+            message: interpolate(rule.message ?? '{job_name}: {field_name} changed from {old} to {new}', {
+              ...globals,
+              field_name: rule.field,
+              old: match.old,
+              new: match.new,
+              url: (ch.after as Record<string, unknown>).url,
+            }),
+          });
+        }
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+// ---------- dispatch ----------
+
+export async function dispatch(
+  job: JobRow,
+  runId: string,
+  notifs: EvaluatedNotification[],
+): Promise<void> {
+  if (notifs.length === 0) return;
+  const channels = job.notify_channels as Channel[];
+  if (channels.length === 0) return;
+  const user = await findUserById(job.user_id);
+  if (!user) return;
+
+  for (const n of notifs) {
+    for (const channel of channels) {
+      let sent = false;
+      if (channel === 'email') {
+        try {
+          await sendEmail({
+            to: user.email,
+            subject: `[SmartScrape] ${job.name}`,
+            text: n.message,
+          });
+          sent = true;
+        } catch (err) {
+          console.error('[notif] email failed', err);
+        }
+      } else if (channel === 'telegram') {
+        if (!user.telegram_chat_id) continue; // skip channel if user hasn't linked
+        const res = await sendTelegram(user.telegram_chat_id, `${job.name}\n\n${n.message}`);
+        if (!res.ok) {
+          console.error('[notif] telegram failed', res.error);
+          continue;
+        }
+        sent = true;
+      }
+      if (sent) {
+        await insertNotification({
+          userId: job.user_id,
+          jobId: job.id,
+          runId,
+          channel,
+          type: n.type,
+          message: n.message,
+        });
+      }
+    }
+  }
+}

--- a/server/src/services/telegram.ts
+++ b/server/src/services/telegram.ts
@@ -1,0 +1,43 @@
+import { env } from '../config/env.js';
+
+const API_BASE = 'https://api.telegram.org';
+
+export type TelegramSendResult = { ok: boolean; error?: string };
+
+/** Send a plain-text message via the Telegram Bot API. Requires TELEGRAM_BOT_TOKEN. */
+export async function sendTelegram(chatId: string, text: string): Promise<TelegramSendResult> {
+  const token = process.env.TELEGRAM_BOT_TOKEN ?? '';
+  if (!token) return { ok: false, error: 'TELEGRAM_BOT_TOKEN not configured' };
+  try {
+    const res = await fetch(`${API_BASE}/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, text, disable_web_page_preview: true }),
+    });
+    const json = (await res.json()) as { ok: boolean; description?: string };
+    if (!json.ok) return { ok: false, error: json.description ?? `HTTP ${res.status}` };
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'Unknown error' };
+  }
+}
+
+/** Returns the bot's link for user-onboarding. Works even when the bot token is not set locally. */
+export async function getBotSetupInfo(): Promise<{ botUsername: string | null; link: string | null }> {
+  const token = process.env.TELEGRAM_BOT_TOKEN ?? '';
+  if (!token) return { botUsername: null, link: null };
+  try {
+    const res = await fetch(`${API_BASE}/bot${token}/getMe`);
+    const json = (await res.json()) as { ok: boolean; result?: { username?: string } };
+    if (!json.ok || !json.result?.username) return { botUsername: null, link: null };
+    return {
+      botUsername: json.result.username,
+      link: `https://t.me/${json.result.username}`,
+    };
+  } catch {
+    return { botUsername: null, link: null };
+  }
+}
+
+// Type guard so unused env import in prod bundles doesn't tree-shake oddly.
+export const _touch_env = env;


### PR DESCRIPTION
## Summary

Build Order step 11. Runs now evaluate notification rules and fan out over each configured channel; users can link Telegram from Settings.

## Backend

- `services/notification-service.ts` \u2014 `evaluateRules(job, diff)` plus `dispatch(job, runId, notifs)`. Every rule type from the handoff is supported (any_change, new_items, removed_items, field_threshold with 6 operators, field_change), with `{url}`, `{field_name}`, `{old}`, `{new}`, `{count}`, `{job_name}` substitutions into optional message templates.
- `services/telegram.ts` \u2014 `sendMessage` + `getMe` for onboarding copy.
- Runner integration: after each completed run, `diffRun()` \u2192 `evaluateRules()` \u2192 `dispatch()`. Notifications fail independently per channel and never fail the run.
- `routes/notifications.ts`: `GET /api/notifications` (paginated history with job name join + channel/job filters), `POST /test/email`, `POST /test/telegram`, `GET /telegram/setup`.
- Email still uses the existing Nodemailer wrapper (console fallback in dev, real SMTP when configured).

## Frontend

- `TelegramCard` in Settings: Linked / Not linked badge, bot link + onboarding steps loaded from `/telegram/setup`, chat_id input that PATCHes `/api/auth/me`, Send test message button wired to `/test/telegram`. Telegram's own error messages (\"Bad Request: chat not found\") surface verbatim so users see they still need to `/start` the bot.

## Smoke

- `GET /telegram/setup` returns bot username + link live from `@SmartScrperBot`.
- `POST /test/email` succeeds (console transport, no SMTP configured).
- `POST /test/telegram` returns exactly what Telegram says on the wire; a user who has messaged the bot will get the test message.
- Full run \u2192 dispatch path exercised; the runner silently skips Telegram when the chat isn't open yet, and `notification_log` only records successful sends per the schema.

## Out of scope

Notification history **page** lands as step 15 (issue to follow).

Closes #25