### PR TITLE
feat: Google Sheets OAuth + append-on-run export

### DIFF
--- a/client/src/components/GoogleSheetsCard.tsx
+++ b/client/src/components/GoogleSheetsCard.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { api } from '../lib/api';
+import { Alert } from './ui/Alert';
+import { Button } from './ui/Button';
+
+type Status = {
+  configured: boolean;
+  connected: boolean;
+  email: string | null;
+  expires_at: string | null;
+};
+
+export function GoogleSheetsCard() {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+  const [working, setWorking] = useState(false);
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const load = useCallback(async () => {
+    const res = await api<Status>('/api/google/status');
+    if (res.success) setStatus(res.data);
+    else setError(res.error.message);
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Surface success/failure from the /api/google/callback redirect once.
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (params.get('google_connected') === '1') {
+      setNote('Connected to Google. Reloading status…');
+      void load();
+      navigate('/settings', { replace: true });
+    }
+    const err = params.get('google_error');
+    if (err) {
+      setError(`Google connection failed: ${err}`);
+      navigate('/settings', { replace: true });
+    }
+  }, [location.search, load, navigate]);
+
+  async function connect() {
+    setWorking(true);
+    setError(null);
+    const res = await api<{ url: string }>('/api/google/connect');
+    setWorking(false);
+    if (!res.success) {
+      setError(res.error.message);
+      return;
+    }
+    window.location.href = res.data.url;
+  }
+
+  async function disconnect() {
+    if (!confirm('Disconnect Google? Existing jobs with a linked Sheet will stop exporting.')) return;
+    setWorking(true);
+    const res = await api<{ disconnected: boolean }>('/api/google/disconnect', { method: 'DELETE' });
+    setWorking(false);
+    if (!res.success) {
+      setError(res.error.message);
+      return;
+    }
+    void load();
+  }
+
+  const connected = Boolean(status?.connected);
+
+  return (
+    <article className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <header className="mb-3 flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Google Sheets</h3>
+          <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+            Append extracted rows to a sheet after each run.
+          </p>
+        </div>
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${
+            connected
+              ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+              : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+          }`}
+        >
+          <span className={`h-1.5 w-1.5 rounded-full ${connected ? 'bg-emerald-500' : 'bg-gray-400'}`} />
+          {connected ? 'Connected' : 'Not connected'}
+        </span>
+      </header>
+
+      {status && !status.configured && (
+        <Alert tone="info">
+          Google OAuth isn't configured on this server. Ask the admin to set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.
+        </Alert>
+      )}
+
+      {status?.email && (
+        <p className="mb-3 font-mono text-xs text-gray-500 dark:text-gray-400">
+          Connected as {status.email}
+        </p>
+      )}
+
+      {error && <Alert tone="error" className="mb-3">{error}</Alert>}
+      {note && <Alert tone="success" className="mb-3">{note}</Alert>}
+
+      <div className="flex flex-wrap gap-2">
+        {!connected ? (
+          <Button onClick={connect} loading={working} disabled={!status?.configured}>
+            Connect Google
+          </Button>
+        ) : (
+          <Button variant="ghost" onClick={disconnect} loading={working}>
+            Disconnect
+          </Button>
+        )}
+      </div>
+
+      {connected && (
+        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+          To export to a sheet, paste the Sheet ID and tab name into a job's config. The Sheet ID is the long path
+          segment in the URL: <span className="font-mono">/spreadsheets/d/<span className="text-indigo-600 dark:text-indigo-400">SHEET_ID</span>/edit</span>.
+        </p>
+      )}
+    </article>
+  );
+}

--- a/client/src/components/JobForm.tsx
+++ b/client/src/components/JobForm.tsx
@@ -24,6 +24,8 @@ export type JobFormValues = {
   notification_rules: NotificationRule[];
   ai_provider: Provider;
   ai_model: string;
+  google_sheet_id: string | null;
+  sheet_tab_name: string | null;
 };
 
 const SCHEDULE_OPTIONS: { label: string; value: string | null }[] = [
@@ -48,6 +50,8 @@ export function jobToFormValues(job: Job): JobFormValues {
     notification_rules: job.notification_rules,
     ai_provider: job.ai_provider,
     ai_model: job.ai_model,
+    google_sheet_id: job.google_sheet_id,
+    sheet_tab_name: job.sheet_tab_name,
   };
 }
 
@@ -63,6 +67,8 @@ export const EMPTY_FORM: JobFormValues = {
   notification_rules: [],
   ai_provider: 'openrouter',
   ai_model: 'openai/gpt-4o-mini',
+  google_sheet_id: null,
+  sheet_tab_name: null,
 };
 
 type Props = {
@@ -305,6 +311,27 @@ export function JobForm({ initial, submitLabel, submitting, error, onSubmit, onC
             value={v.ai_model}
             onChange={(e) => setV({ ...v, ai_model: e.target.value })}
             placeholder="openai/gpt-4o-mini"
+          />
+        </div>
+      </Section>
+
+      <Section title="Google Sheets (optional)">
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          After each run, extracted rows are appended to the sheet. Connect Google in Settings first, then paste the
+          Sheet ID here.
+        </p>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <FormField
+            label="Sheet ID"
+            value={v.google_sheet_id ?? ''}
+            onChange={(e) => setV({ ...v, google_sheet_id: e.target.value || null })}
+            placeholder="1a2b3c4d... (from the sheet URL)"
+          />
+          <FormField
+            label="Tab name"
+            value={v.sheet_tab_name ?? ''}
+            onChange={(e) => setV({ ...v, sheet_tab_name: e.target.value || null })}
+            placeholder="Sheet1"
           />
         </div>
       </Section>

--- a/client/src/pages/NewJob.tsx
+++ b/client/src/pages/NewJob.tsx
@@ -79,6 +79,8 @@ export default function NewJob() {
       notify_channels: [],
       ai_provider: provider,
       ai_model: model,
+      google_sheet_id: null,
+      sheet_tab_name: null,
     });
     setStep('review');
   }

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { TopNav } from '../components/layout/TopNav';
+import { GoogleSheetsCard } from '../components/GoogleSheetsCard';
 import { ProviderCard } from '../components/ProviderCard';
 import { TelegramCard } from '../components/TelegramCard';
 import { api } from '../lib/api';
@@ -104,16 +105,10 @@ export default function Settings() {
         </section>
 
         <section className="mt-12 space-y-4">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Notifications</h2>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Integrations</h2>
           <div className="grid gap-4 md:grid-cols-2">
+            <GoogleSheetsCard />
             <TelegramCard />
-          </div>
-        </section>
-
-        <section className="mt-12 space-y-4">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Coming soon</h2>
-          <div className="rounded-lg border border-dashed border-gray-300 bg-white/40 p-6 text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-400">
-            Profile, Google Sheets, and account deletion land in upcoming releases.
           </div>
         </section>
       </main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2234,6 +2234,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -2393,6 +2402,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.21",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
@@ -2418,6 +2447,15 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -2920,6 +2958,15 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3604,6 +3651,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3681,6 +3734,38 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3831,6 +3916,18 @@
         "node": ">= 12.20"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3885,6 +3982,52 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/gensync": {
@@ -4006,6 +4149,61 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "150.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-150.0.1.tgz",
+      "integrity": "sha512-9Wa9vm3WtDpss0VFBHsbZWcoRccpOSWdpz7YIfb1LBXopZJEg/Zc8ymmaSgvDkP4FhN+pqPS9nZjO7REAJWSUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.0.0-rc.1",
+        "googleapis-common": "^8.0.2-rc.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.2-rc.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.2-rc.0.tgz",
+      "integrity": "sha512-JTcxRvmFa9Ec1uyfMEimEMeeKq1sHNZX3vn2qmoUMtnvixXXvcqTcbDZvEZXkEWpGlPlOf4joyep6/qs0BrLyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.0.0-rc.1",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4116,6 +4314,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/humanize-ms": {
@@ -4347,6 +4558,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -6756,6 +6976,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7568,6 +7794,7 @@
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "express-rate-limit": "^7.5.0",
+        "googleapis": "^150.0.1",
         "ioredis": "^5.4.2",
         "jsonwebtoken": "^9.0.2",
         "node-pg-migrate": "^8.0.4",

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-rate-limit": "^7.5.0",
+    "googleapis": "^150.0.1",
     "ioredis": "^5.4.2",
     "jsonwebtoken": "^9.0.2",
     "node-pg-migrate": "^8.0.4",

--- a/server/src/db/googleConnections.ts
+++ b/server/src/db/googleConnections.ts
@@ -1,0 +1,69 @@
+import { getPool } from '../config/database.js';
+
+export type GoogleConnectionRow = {
+  id: string;
+  user_id: string;
+  access_token_encrypted: string;
+  refresh_token_encrypted: string;
+  token_expires_at: Date | null;
+  connected_email: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export async function findConnection(userId: string): Promise<GoogleConnectionRow | null> {
+  const { rows } = await getPool().query<GoogleConnectionRow>(
+    `SELECT * FROM google_connections WHERE user_id = $1 LIMIT 1`,
+    [userId],
+  );
+  return rows[0] ?? null;
+}
+
+export async function upsertConnection(args: {
+  userId: string;
+  accessTokenEncrypted: string;
+  refreshTokenEncrypted: string;
+  tokenExpiresAt: Date | null;
+  connectedEmail: string | null;
+}): Promise<GoogleConnectionRow> {
+  const { rows } = await getPool().query<GoogleConnectionRow>(
+    `INSERT INTO google_connections
+       (user_id, access_token_encrypted, refresh_token_encrypted, token_expires_at, connected_email)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (user_id)
+       DO UPDATE SET access_token_encrypted = EXCLUDED.access_token_encrypted,
+                     refresh_token_encrypted = EXCLUDED.refresh_token_encrypted,
+                     token_expires_at = EXCLUDED.token_expires_at,
+                     connected_email = EXCLUDED.connected_email
+     RETURNING *`,
+    [
+      args.userId,
+      args.accessTokenEncrypted,
+      args.refreshTokenEncrypted,
+      args.tokenExpiresAt,
+      args.connectedEmail,
+    ],
+  );
+  return rows[0]!;
+}
+
+export async function updateAccessToken(
+  userId: string,
+  accessTokenEncrypted: string,
+  tokenExpiresAt: Date,
+): Promise<void> {
+  await getPool().query(
+    `UPDATE google_connections
+        SET access_token_encrypted = $1, token_expires_at = $2
+      WHERE user_id = $3`,
+    [accessTokenEncrypted, tokenExpiresAt, userId],
+  );
+}
+
+export async function deleteConnection(userId: string): Promise<boolean> {
+  const { rowCount } = await getPool().query(
+    `DELETE FROM google_connections WHERE user_id = $1`,
+    [userId],
+  );
+  return (rowCount ?? 0) > 0;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,6 +6,7 @@ import { closeQueue, startWorker } from './services/job-queue.js';
 import { closeScraper } from './services/scraper.js';
 import { authRouter } from './routes/auth.js';
 import { healthRouter } from './routes/health.js';
+import { googleRouter } from './routes/google.js';
 import { jobsRouter } from './routes/jobs.js';
 import { notificationsRouter } from './routes/notifications.js';
 import { providersRouter } from './routes/providers.js';
@@ -30,6 +31,7 @@ app.use('/api/providers', providersRouter);
 app.use('/api/jobs', jobsRouter);
 app.use('/api/runs', runsRouter);
 app.use('/api/notifications', notificationsRouter);
+app.use('/api/google', googleRouter);
 
 app.use((_req, res) => {
   res.status(404).json(fail('NOT_FOUND', 'Route not found'));

--- a/server/src/routes/google.ts
+++ b/server/src/routes/google.ts
@@ -1,0 +1,77 @@
+import { Router } from 'express';
+import { env } from '../config/env.js';
+import { deleteConnection, findConnection } from '../db/googleConnections.js';
+import { fail, ok } from '../lib/response.js';
+import { requireAuth } from '../middleware/auth.js';
+import {
+  buildAuthUrl,
+  exchangeAndStore,
+  isConfigured,
+  revokeConnection,
+  verifyState,
+} from '../services/google-sheets.js';
+
+export const googleRouter = Router();
+
+googleRouter.get('/status', requireAuth, async (req, res) => {
+  const conn = await findConnection(req.user!.id);
+  res.status(200).json(
+    ok({
+      configured: isConfigured(),
+      connected: Boolean(conn),
+      email: conn?.connected_email ?? null,
+      expires_at: conn?.token_expires_at?.toISOString() ?? null,
+    }),
+  );
+});
+
+googleRouter.get('/connect', requireAuth, (req, res) => {
+  if (!isConfigured()) {
+    res.status(400).json(fail('NOT_CONFIGURED', 'Google OAuth is not configured on this server'));
+    return;
+  }
+  try {
+    const url = buildAuthUrl(req.user!.id);
+    res.status(200).json(ok({ url }));
+  } catch (err) {
+    res.status(500).json(fail('INTERNAL_ERROR', err instanceof Error ? err.message : 'Unknown error'));
+  }
+});
+
+/**
+ * OAuth callback. Google redirects the user's browser here; we exchange the
+ * code and then redirect back to the client with a success/failure flag.
+ */
+googleRouter.get('/callback', async (req, res) => {
+  const error = typeof req.query.error === 'string' ? req.query.error : null;
+  const code = typeof req.query.code === 'string' ? req.query.code : null;
+  const state = typeof req.query.state === 'string' ? req.query.state : '';
+
+  const clientBase = env.appUrl.replace(/\/$/, '');
+  if (error) {
+    res.redirect(`${clientBase}/settings?google_error=${encodeURIComponent(error)}`);
+    return;
+  }
+  if (!code) {
+    res.redirect(`${clientBase}/settings?google_error=missing_code`);
+    return;
+  }
+  const st = verifyState(state);
+  if (!st.ok) {
+    res.redirect(`${clientBase}/settings?google_error=${encodeURIComponent(st.error)}`);
+    return;
+  }
+  try {
+    await exchangeAndStore(st.userId, code);
+    res.redirect(`${clientBase}/settings?google_connected=1`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Token exchange failed';
+    res.redirect(`${clientBase}/settings?google_error=${encodeURIComponent(msg)}`);
+  }
+});
+
+googleRouter.delete('/disconnect', requireAuth, async (req, res) => {
+  await revokeConnection(req.user!.id);
+  await deleteConnection(req.user!.id);
+  res.status(200).json(ok({ disconnected: true }));
+});

--- a/server/src/services/google-sheets.ts
+++ b/server/src/services/google-sheets.ts
@@ -1,0 +1,188 @@
+import { google } from 'googleapis';
+import jwt from 'jsonwebtoken';
+import { requireSecrets } from '../config/env.js';
+import { decrypt, encrypt } from '../config/encryption.js';
+import {
+  findConnection,
+  updateAccessToken,
+  upsertConnection,
+} from '../db/googleConnections.js';
+
+// Minimal scopes: write sheets + read user's email to display which account is connected.
+export const SHEETS_SCOPES = [
+  'https://www.googleapis.com/auth/spreadsheets',
+  'https://www.googleapis.com/auth/userinfo.email',
+];
+
+function clientConfig() {
+  const id = process.env.GOOGLE_CLIENT_ID ?? '';
+  const secret = process.env.GOOGLE_CLIENT_SECRET ?? '';
+  const redirect = process.env.GOOGLE_REDIRECT_URI ?? 'http://localhost:3000/api/google/callback';
+  if (!id || !secret) {
+    throw new Error('GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET are not configured');
+  }
+  return { id, secret, redirect };
+}
+
+export function isConfigured(): boolean {
+  return Boolean(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
+}
+
+function oauthClient() {
+  const c = clientConfig();
+  return new google.auth.OAuth2(c.id, c.secret, c.redirect);
+}
+
+/**
+ * Build the OAuth consent URL. State carries a short-lived signed token so the
+ * callback can recover the initiating userId without session cookies.
+ */
+export function buildAuthUrl(userId: string): string {
+  const { jwtAccessSecret } = requireSecrets();
+  const state = jwt.sign({ sub: userId }, jwtAccessSecret, { expiresIn: '10m' });
+  return oauthClient().generateAuthUrl({
+    access_type: 'offline',
+    prompt: 'consent', // force refresh_token on re-auth
+    scope: SHEETS_SCOPES,
+    state,
+  });
+}
+
+export type StateVerify = { ok: true; userId: string } | { ok: false; error: string };
+
+export function verifyState(state: string): StateVerify {
+  try {
+    const { jwtAccessSecret } = requireSecrets();
+    const payload = jwt.verify(state, jwtAccessSecret);
+    if (typeof payload !== 'object' || !payload || !('sub' in payload)) {
+      return { ok: false, error: 'Invalid state' };
+    }
+    return { ok: true, userId: String((payload as { sub: unknown }).sub) };
+  } catch {
+    return { ok: false, error: 'Invalid or expired state' };
+  }
+}
+
+/** Exchange a callback code for tokens + the connected email, then persist. */
+export async function exchangeAndStore(userId: string, code: string): Promise<{ email: string | null }> {
+  const client = oauthClient();
+  const { tokens } = await client.getToken(code);
+  if (!tokens.access_token) throw new Error('Google did not return an access token');
+  if (!tokens.refresh_token) {
+    // On re-auth Google omits refresh_token. If we already have one stored, reuse it.
+    const existing = await findConnection(userId);
+    if (!existing) {
+      throw new Error('Google did not return a refresh_token; revoke app access in your Google account and retry.');
+    }
+    const existingRefresh = decrypt(existing.refresh_token_encrypted);
+    tokens.refresh_token = existingRefresh;
+  }
+
+  client.setCredentials(tokens);
+  const oauth2 = google.oauth2({ version: 'v2', auth: client });
+  const { data } = await oauth2.userinfo.get();
+  const email = data.email ?? null;
+
+  await upsertConnection({
+    userId,
+    accessTokenEncrypted: encrypt(tokens.access_token),
+    refreshTokenEncrypted: encrypt(tokens.refresh_token),
+    tokenExpiresAt: tokens.expiry_date ? new Date(tokens.expiry_date) : null,
+    connectedEmail: email,
+  });
+
+  return { email };
+}
+
+/** Return an OAuth2 client with credentials set, refreshing the access token if near expiry. */
+async function authedClient(userId: string) {
+  const conn = await findConnection(userId);
+  if (!conn) throw new Error('No Google connection');
+  const client = oauthClient();
+  const access = decrypt(conn.access_token_encrypted);
+  const refresh = decrypt(conn.refresh_token_encrypted);
+  client.setCredentials({
+    access_token: access,
+    refresh_token: refresh,
+    expiry_date: conn.token_expires_at?.getTime(),
+  });
+  // Refresh if < 60s remaining.
+  const now = Date.now();
+  if (!conn.token_expires_at || conn.token_expires_at.getTime() - now < 60_000) {
+    const { credentials } = await client.refreshAccessToken();
+    if (credentials.access_token) {
+      await updateAccessToken(
+        userId,
+        encrypt(credentials.access_token),
+        credentials.expiry_date ? new Date(credentials.expiry_date) : new Date(now + 3600_000),
+      );
+      client.setCredentials({
+        access_token: credentials.access_token,
+        refresh_token: refresh,
+        expiry_date: credentials.expiry_date,
+      });
+    }
+  }
+  return client;
+}
+
+/**
+ * Append rows to {sheetId}!{tabName}. Writes a header row first if the tab is empty.
+ * `rows` is a list of objects; the first row's keys define the column order.
+ */
+export async function pushRows(args: {
+  userId: string;
+  sheetId: string;
+  tabName?: string | null;
+  rows: Record<string, unknown>[];
+}): Promise<{ appended: number }> {
+  if (args.rows.length === 0) return { appended: 0 };
+  const client = await authedClient(args.userId);
+  const sheets = google.sheets({ version: 'v4', auth: client });
+  const tab = args.tabName && args.tabName.length > 0 ? args.tabName : 'Sheet1';
+  const range = `${tab}!A:Z`;
+
+  const headers = Object.keys(args.rows[0]!);
+
+  // Check if the tab has any rows yet; write a header row if empty.
+  const existing = await sheets.spreadsheets.values.get({
+    spreadsheetId: args.sheetId,
+    range: `${tab}!A1:Z1`,
+  });
+  const hasHeader = Boolean(existing.data.values?.[0]?.length);
+
+  const values: string[][] = [];
+  if (!hasHeader) values.push(headers);
+  for (const row of args.rows) {
+    values.push(
+      headers.map((h) => {
+        const v = row[h];
+        if (v === null || v === undefined) return '';
+        if (typeof v === 'object') return JSON.stringify(v);
+        return String(v);
+      }),
+    );
+  }
+
+  await sheets.spreadsheets.values.append({
+    spreadsheetId: args.sheetId,
+    range,
+    valueInputOption: 'RAW',
+    insertDataOption: 'INSERT_ROWS',
+    requestBody: { values },
+  });
+
+  return { appended: args.rows.length };
+}
+
+export async function revokeConnection(userId: string): Promise<void> {
+  const conn = await findConnection(userId);
+  if (!conn) return;
+  try {
+    const client = oauthClient();
+    const token = decrypt(conn.access_token_encrypted);
+    await client.revokeToken(token).catch(() => undefined);
+  } catch {
+    // best effort; we still delete the DB row.
+  }
+}

--- a/server/src/services/job-runner.ts
+++ b/server/src/services/job-runner.ts
@@ -7,6 +7,8 @@ import { extract, hashItem } from './ai-extractor.js';
 import { scrape } from './scraper.js';
 import { diffRun } from './change-detector.js';
 import { dispatch, evaluateRules } from './notification-service.js';
+import { pushRows } from './google-sheets.js';
+import { findConnection } from '../db/googleConnections.js';
 
 export type RunSummary = {
   runId: string;
@@ -82,6 +84,24 @@ export async function runJob(job: JobRow, existingRunId?: string): Promise<RunSu
     }
 
     await insertExtractedData(run.id, job.id, allBatches);
+
+    // Optional: export to Google Sheets if the job has one linked and the user is connected.
+    if (job.google_sheet_id && allBatches.length > 0) {
+      try {
+        await updateRun(run.id, { status: 'exporting' });
+        const conn = await findConnection(job.user_id);
+        if (conn) {
+          await pushRows({
+            userId: job.user_id,
+            sheetId: job.google_sheet_id,
+            tabName: job.sheet_tab_name,
+            rows: allBatches.map((b) => b.data),
+          });
+        }
+      } catch (err) {
+        console.error('[runner] sheets export failed', err);
+      }
+    }
 
     await updateRun(run.id, {
       status: 'completed',


### PR DESCRIPTION
## Summary

Build Order step 12. Users can link a Google account once and set a Sheet ID on any job; runs append their extracted rows.

## Backend

- `services/google-sheets.ts` (googleapis SDK) \u2014 OAuth URL + signed `state` (JWT, 10-min), code\u2194token exchange, access-token refresh inside 60s of expiry, `pushRows()` that writes a header on an empty tab then appends via `INSERT_ROWS`.
- `db/googleConnections.ts` \u2014 AES-GCM encrypted access + refresh tokens, one per user.
- `routes/google.ts` \u2014 `/status`, `/connect`, `/callback` (redirects to `/settings?google_connected=1` or `?google_error=...`), `/disconnect`.
- Runner hook: when a job has a `google_sheet_id`, status briefly flips to `exporting` and rows are appended. Export failures never fail the run.
- **Scopes** kept to the minimum: `spreadsheets` + `userinfo.email`. No Drive scope; users paste Sheet ID instead.

## Frontend

- `GoogleSheetsCard` in Settings \u2014 Connected / Not connected badge, account email when connected, Connect that hands off to Google, Disconnect with confirm. Consumes the OAuth redirect's `?google_connected=1` / `?google_error=...` and then clears the URL.
- `JobForm` \u2014 new Google Sheets section with Sheet ID + Tab name inputs. Empty \u2192 no export.

## Smoke

- `/google/status` \u2014 `{ configured: true, connected: false, \u2026 }` when env is set.
- `/google/connect` \u2014 returns a proper `https://accounts.google.com/o/oauth2/v2/auth?\u2026` URL with `state=<jwt>`, `access_type=offline`, `prompt=consent`.
- `/google/callback?state=invalid` \u2014 302 redirect to `http://localhost:5173/settings?google_error=Invalid%20or%20expired%20state`.
- Full consent round-trip and real append-to-sheet \u2014 **not exercised in this session (browser flow)**. Code follows the documented OAuth2 installed-app pattern; token refresh is unit-path independent.

Closes #27