### PR TITLE
feat: CSV export

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -80,6 +80,33 @@ export async function api<T>(path: string, opts: RequestOptions = {}): Promise<A
   }
 }
 
+/**
+ * Download a blob from an authenticated endpoint by issuing a fetch with the Bearer
+ * header, then triggering a saveAs. Used for CSV export because anchor downloads
+ * can't carry an Authorization header.
+ */
+export async function downloadBlob(path: string, suggestedName: string): Promise<boolean> {
+  let res = await doFetch(path, {});
+  if (res.status === 401) {
+    const refreshed = await refreshSession();
+    if (refreshed) res = await doFetch(path, {});
+  }
+  if (!res.ok) return false;
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  // Prefer the server's filename if it set one.
+  const disposition = res.headers.get('content-disposition') ?? '';
+  const match = disposition.match(/filename="?([^"]+)"?/);
+  a.download = match?.[1] ?? suggestedName;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+  return true;
+}
+
 /** Convenience: throws if the envelope reports failure. Use when you don't need to branch on the error. */
 export async function apiOrThrow<T>(path: string, opts: RequestOptions = {}): Promise<T> {
   const result = await api<T>(path, opts);

--- a/client/src/pages/JobDetail.tsx
+++ b/client/src/pages/JobDetail.tsx
@@ -4,7 +4,7 @@ import { TopNav } from '../components/layout/TopNav';
 import { RunDiff } from '../components/RunDiff';
 import { Alert } from '../components/ui/Alert';
 import { Button } from '../components/ui/Button';
-import { api } from '../lib/api';
+import { api, downloadBlob } from '../lib/api';
 import type { Job, Run, RunStatus } from '../types/api';
 
 export default function JobDetail() {
@@ -174,12 +174,22 @@ export default function JobDetail() {
                       </td>
                       <td className="py-2 text-right">
                         {r.status === 'completed' && (
-                          <button
-                            onClick={() => setOpenDiff(openDiff === r.id ? null : r.id)}
-                            className="text-xs text-indigo-600 hover:underline dark:text-indigo-400"
-                          >
-                            {openDiff === r.id ? 'Hide diff' : 'Diff'}
-                          </button>
+                          <div className="flex justify-end gap-3">
+                            <button
+                              onClick={() =>
+                                void downloadBlob(`/api/jobs/${id}/export/csv/${r.id}`, `run-${r.id.slice(0, 8)}.csv`)
+                              }
+                              className="text-xs text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+                            >
+                              CSV
+                            </button>
+                            <button
+                              onClick={() => setOpenDiff(openDiff === r.id ? null : r.id)}
+                              className="text-xs text-indigo-600 hover:underline dark:text-indigo-400"
+                            >
+                              {openDiff === r.id ? 'Hide diff' : 'Diff'}
+                            </button>
+                          </div>
                         )}
                       </td>
                     </tr>

--- a/server/src/lib/csv.ts
+++ b/server/src/lib/csv.ts
@@ -1,0 +1,35 @@
+/**
+ * Serialize objects to RFC-4180 CSV. Column order comes from the union of all
+ * keys in the first N rows so rare fields aren't silently dropped.
+ */
+export function toCsv(rows: Record<string, unknown>[], opts: { peek?: number } = {}): string {
+  if (rows.length === 0) return '';
+  const peek = opts.peek ?? Math.min(rows.length, 50);
+  const keys: string[] = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < peek; i++) {
+    const row = rows[i];
+    if (!row) continue;
+    for (const k of Object.keys(row)) {
+      if (!seen.has(k)) {
+        seen.add(k);
+        keys.push(k);
+      }
+    }
+  }
+  const lines: string[] = [keys.map(csvField).join(',')];
+  for (const row of rows) {
+    lines.push(keys.map((k) => csvField(row[k])).join(','));
+  }
+  // CRLF per RFC 4180.
+  return lines.join('\r\n') + '\r\n';
+}
+
+function csvField(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const s = typeof value === 'object' ? JSON.stringify(value) : String(value);
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}

--- a/server/src/routes/jobs.ts
+++ b/server/src/routes/jobs.ts
@@ -13,7 +13,8 @@ import {
   toggleJob,
   updateJob,
 } from '../db/jobs.js';
-import { listRunsForJob } from '../db/runs.js';
+import { listDataForRun, listRunsForJob } from '../db/runs.js';
+import { toCsv } from '../lib/csv.js';
 import { findForUser as findApiKey, type Provider as ProviderName } from '../db/apiKeys.js';
 import { decrypt } from '../config/encryption.js';
 import { scrape } from '../services/scraper.js';
@@ -317,6 +318,52 @@ jobsRouter.post('/:id/run', validate(idParam, 'params'), async (req, res) => {
   const run = await createRun(job.id);
   await enqueueNow({ jobId: job.id, userId: job.user_id, runId: run.id });
   res.status(202).json(ok({ run: toRunDTO(run) }));
+});
+
+async function sendCsvForRun(res: import('express').Response, jobId: string, runId: string, userId: string, jobName: string): Promise<void> {
+  const rows = await listDataForRun(userId, runId);
+  const csv = toCsv(rows.map((r) => ({ source_url: r.source_url, extracted_at: r.created_at, ...r.data })));
+  const safeName = jobName.replace(/[^a-z0-9_-]+/gi, '_').slice(0, 60) || 'export';
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader(
+    'Content-Disposition',
+    `attachment; filename="${safeName}-${runId.slice(0, 8)}.csv"`,
+  );
+  res.status(200).send(csv);
+  void jobId;
+}
+
+jobsRouter.get('/:id/export/csv', validate(idParam, 'params'), async (req, res) => {
+  const { id } = req.params as unknown as z.infer<typeof idParam>;
+  const job = await findJob(req.user!.id, id);
+  if (!job) {
+    res.status(404).json(fail('NOT_FOUND', 'Job not found'));
+    return;
+  }
+  const runs = await listRunsForJob(req.user!.id, id, 1, 0);
+  const latest = runs.find((r) => r.status === 'completed') ?? runs[0];
+  if (!latest) {
+    res.status(404).json(fail('NO_RUNS', 'No runs yet'));
+    return;
+  }
+  await sendCsvForRun(res, id, latest.id, req.user!.id, job.name);
+});
+
+jobsRouter.get('/:id/export/csv/:runId', async (req, res) => {
+  const parsed = z
+    .object({ id: z.string().uuid(), runId: z.string().uuid() })
+    .safeParse(req.params);
+  if (!parsed.success) {
+    res.status(400).json(fail('VALIDATION_ERROR', 'Invalid params'));
+    return;
+  }
+  const { id, runId } = parsed.data;
+  const job = await findJob(req.user!.id, id);
+  if (!job) {
+    res.status(404).json(fail('NOT_FOUND', 'Job not found'));
+    return;
+  }
+  await sendCsvForRun(res, id, runId, req.user!.id, job.name);
 });
 
 jobsRouter.get('/:id/runs', validate(idParam, 'params'), async (req, res) => {


### PR DESCRIPTION
## Summary

Build Order step 13.

## Changes

- `lib/csv.ts` \u2014 RFC 4180 serializer (CRLF lines, quote-only-when-needed, doubled internal quotes, key-union across the first 50 rows).
- `GET /api/jobs/:id/export/csv` \u2014 latest completed run.
- `GET /api/jobs/:id/export/csv/:runId` \u2014 specific run.
- `downloadBlob()` helper in `lib/api.ts` (bearer-auth fetch \u2192 blob \u2192 object URL \u2192 saveAs), reused by the new CSV link on each completed run row in JobDetail.

## Smoke (live stack)

```
GET /jobs/:id/export/csv
200, Content-Type: text/csv; charset=utf-8
Content-Disposition: attachment; filename="CSV_Test_HN-385e8411.csv"
source_url,extracted_at,url,title
...,https://kevinlynagh.com/...,"Sabotaging projects by overthinking, scope creep, and structural diffing"
```

Quoting behaves correctly \u2014 the comma-containing title is wrapped in quotes with no doubled internal quotes (since there were none).

Closes #29