### PR TITLE
feat: Dashboard (stats + activity + usage chart)

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,16 +1,43 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { TopNav } from '../components/layout/TopNav';
 import { api } from '../lib/api';
 import { useAuth } from '../stores/auth';
-import type { HealthStatus, PublicUser } from '../types/api';
+import type { PublicUser, RunStatus } from '../types/api';
+
+type Stats = {
+  active_jobs: number;
+  runs_today: number;
+  items_tracked: number;
+  changes_this_week: number;
+};
+
+type ActivityRow = {
+  run_id: string;
+  job_id: string;
+  job_name: string;
+  status: RunStatus;
+  items_extracted: number;
+  tokens_used: number;
+  started_at: string;
+  completed_at: string | null;
+};
+
+type UsageRow = { day: string; provider: string; tokens: number };
+
+const PROVIDER_COLORS: Record<string, string> = {
+  openrouter: '#6366f1',
+  openai: '#10b981',
+  anthropic: '#f59e0b',
+};
 
 export default function Home() {
   const user = useAuth((s) => s.user);
   const setUser = useAuth((s) => s.setUser);
-  const [health, setHealth] = useState<HealthStatus | null>(null);
-  const [healthError, setHealthError] = useState<string | null>(null);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [activity, setActivity] = useState<ActivityRow[] | null>(null);
+  const [usage, setUsage] = useState<UsageRow[] | null>(null);
 
-  // Refresh the user on mount in case the persisted profile is stale.
   useEffect(() => {
     void (async () => {
       const res = await api<{ user: PublicUser }>('/api/auth/me');
@@ -20,70 +47,88 @@ export default function Home() {
 
   useEffect(() => {
     void (async () => {
-      const res = await api<HealthStatus>('/api/health', { skipAuth: true });
-      if (res.success) setHealth(res.data);
-      else setHealthError(res.error.message);
+      const [s, a, u] = await Promise.all([
+        api<Stats>('/api/dashboard/stats'),
+        api<{ items: ActivityRow[] }>('/api/dashboard/recent-activity'),
+        api<{ days: UsageRow[] }>('/api/dashboard/usage'),
+      ]);
+      if (s.success) setStats(s.data);
+      if (a.success) setActivity(a.data.items);
+      if (u.success) setUsage(u.data.days);
     })();
   }, []);
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <TopNav />
-      <main className="mx-auto max-w-5xl px-6 py-10">
-        <div className="mb-8">
+      <main className="mx-auto max-w-5xl px-6 py-10 space-y-8">
+        <div>
           <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
-            Welcome{user?.name ? `, ${user.name}` : ''}
+            {user?.name ? `Hi, ${user.name}` : 'Dashboard'}
           </h1>
           <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Dashboard, Jobs, and Notifications land in upcoming releases. For now, backend wiring.
+            Overview of your jobs, recent runs, and AI usage.
           </p>
         </div>
 
-        <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-          <h2 className="text-xs font-medium uppercase tracking-wide text-gray-500">Account</h2>
-          <dl className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2 font-mono text-sm">
-            <Row label="email" value={user?.email ?? '\u2014'} />
-            <Row
-              label="verified"
-              value={user?.email_verified ? 'yes' : 'no'}
-              tone={user?.email_verified ? 'good' : 'warn'}
-            />
-            <Row label="name" value={user?.name ?? '\u2014'} />
-            <Row label="telegram" value={user?.telegram_chat_id ?? '\u2014'} />
-          </dl>
+        <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          <StatCard label="Active jobs" value={stats?.active_jobs} />
+          <StatCard label="Runs today" value={stats?.runs_today} />
+          <StatCard label="Items tracked" value={stats?.items_tracked} />
+          <StatCard label="Changes this week" value={stats?.changes_this_week} />
         </section>
 
-        <section className="mt-6 rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-          <h2 className="text-xs font-medium uppercase tracking-wide text-gray-500">Backend status</h2>
-          {healthError && <p className="mt-3 font-mono text-sm text-red-600">{healthError}</p>}
-          {!healthError && !health && <p className="mt-3 text-sm text-gray-500">Loading&hellip;</p>}
-          {health && (
-            <dl className="mt-3 space-y-2 font-mono text-sm">
-              <Row
-                label="status"
-                value={health.status}
-                tone={health.status === 'healthy' ? 'good' : 'warn'}
-              />
-              <Row
-                label="database"
-                value={
-                  health.checks.database.ok
-                    ? 'ok'
-                    : `down${health.checks.database.error ? ` \u2014 ${health.checks.database.error}` : ''}`
-                }
-                tone={health.checks.database.ok ? 'good' : 'bad'}
-              />
-              <Row
-                label="redis"
-                value={
-                  health.checks.redis.ok
-                    ? 'ok'
-                    : `down${health.checks.redis.error ? ` \u2014 ${health.checks.redis.error}` : ''}`
-                }
-                tone={health.checks.redis.ok ? 'good' : 'bad'}
-              />
-              <Row label="uptime" value={`${health.uptime.toFixed(1)}s`} />
-            </dl>
+        <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <div className="mb-3 flex items-end justify-between">
+            <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500">Recent activity</h2>
+            <Link to="/jobs" className="text-xs text-indigo-600 hover:underline dark:text-indigo-400">
+              All jobs
+            </Link>
+          </div>
+          {activity === null ? (
+            <p className="text-sm text-gray-500">Loading…</p>
+          ) : activity.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              No runs yet. <Link to="/jobs/new" className="text-indigo-600 hover:underline">Create your first job</Link>.
+            </p>
+          ) : (
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-gray-500">
+                  <th className="py-2">Job</th>
+                  <th className="py-2">Status</th>
+                  <th className="py-2">Items</th>
+                  <th className="py-2">Tokens</th>
+                  <th className="py-2">When</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+                {activity.map((r) => (
+                  <tr key={r.run_id}>
+                    <td className="py-2">
+                      <Link to={`/jobs/${r.job_id}`} className="text-indigo-600 hover:underline">
+                        {r.job_name}
+                      </Link>
+                    </td>
+                    <td className="py-2">
+                      <StatusBadge status={r.status} />
+                    </td>
+                    <td className="py-2 font-mono text-xs">{r.items_extracted}</td>
+                    <td className="py-2 font-mono text-xs">{r.tokens_used.toLocaleString()}</td>
+                    <td className="py-2 font-mono text-xs text-gray-500">{new Date(r.started_at).toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+
+        <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">AI usage (last 30 days)</h2>
+          {usage === null ? (
+            <p className="text-sm text-gray-500">Loading…</p>
+          ) : (
+            <UsageChart data={usage} />
           )}
         </section>
       </main>
@@ -91,19 +136,99 @@ export default function Home() {
   );
 }
 
-function Row({ label, value, tone }: { label: string; value: string; tone?: 'good' | 'warn' | 'bad' }) {
-  const toneClass =
-    tone === 'good'
-      ? 'text-emerald-600 dark:text-emerald-400'
-      : tone === 'warn'
-        ? 'text-amber-600 dark:text-amber-400'
-        : tone === 'bad'
-          ? 'text-red-600 dark:text-red-400'
-          : 'text-gray-900 dark:text-gray-100';
+function StatCard({ label, value }: { label: string; value: number | undefined }) {
   return (
-    <div className="flex justify-between">
-      <dt className="text-gray-500">{label}</dt>
-      <dd className={toneClass}>{value}</dd>
+    <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <p className="text-xs font-medium uppercase tracking-wide text-gray-500">{label}</p>
+      <p className="mt-1 font-mono text-2xl font-semibold text-gray-900 dark:text-gray-100">
+        {value === undefined ? '—' : value.toLocaleString()}
+      </p>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: RunStatus }) {
+  const classes: Record<RunStatus, string> = {
+    pending: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+    scraping: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    extracting: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    exporting: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    completed: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+    failed: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  };
+  return (
+    <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${classes[status]}`}>
+      {status}
+    </span>
+  );
+}
+
+function UsageChart({ data }: { data: UsageRow[] }) {
+  // Build a 30-day range ending today.
+  const today = new Date();
+  const days: string[] = [];
+  for (let i = 29; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    days.push(d.toISOString().slice(0, 10));
+  }
+
+  const byDay = new Map<string, Record<string, number>>();
+  for (const d of days) byDay.set(d, {});
+  let max = 0;
+  for (const row of data) {
+    const bucket = byDay.get(row.day) ?? {};
+    bucket[row.provider] = (bucket[row.provider] ?? 0) + Number(row.tokens ?? 0);
+    byDay.set(row.day, bucket);
+  }
+  for (const bucket of byDay.values()) {
+    const total = Object.values(bucket).reduce((s, v) => s + v, 0);
+    if (total > max) max = total;
+  }
+
+  const providers = Array.from(new Set(data.map((d) => d.provider)));
+
+  if (max === 0) {
+    return <p className="text-sm text-gray-500">No AI usage in the last 30 days.</p>;
+  }
+
+  return (
+    <div>
+      <div className="flex h-40 items-end gap-1">
+        {days.map((d) => {
+          const bucket = byDay.get(d) ?? {};
+          const total = Object.values(bucket).reduce((s, v) => s + v, 0);
+          const heightPct = (total / max) * 100;
+          return (
+            <div key={d} className="group relative flex flex-1 flex-col justify-end">
+              <div className="flex flex-col-reverse" style={{ height: `${heightPct || 0}%` }}>
+                {providers.map((p) => {
+                  const v = bucket[p] ?? 0;
+                  const share = total > 0 ? (v / total) * 100 : 0;
+                  return (
+                    <div
+                      key={p}
+                      style={{ height: `${share}%`, backgroundColor: PROVIDER_COLORS[p] ?? '#9ca3af' }}
+                      className="w-full first:rounded-t"
+                    />
+                  );
+                })}
+              </div>
+              <div className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-[10px] text-white opacity-0 shadow group-hover:opacity-100">
+                {d} · {total.toLocaleString()} tokens
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="mt-3 flex flex-wrap gap-4 text-xs">
+        {providers.map((p) => (
+          <div key={p} className="flex items-center gap-1.5 text-gray-600 dark:text-gray-400">
+            <span className="inline-block h-2 w-2 rounded" style={{ backgroundColor: PROVIDER_COLORS[p] ?? '#9ca3af' }} />
+            {p}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,6 +6,7 @@ import { closeQueue, startWorker } from './services/job-queue.js';
 import { closeScraper } from './services/scraper.js';
 import { authRouter } from './routes/auth.js';
 import { healthRouter } from './routes/health.js';
+import { dashboardRouter } from './routes/dashboard.js';
 import { googleRouter } from './routes/google.js';
 import { jobsRouter } from './routes/jobs.js';
 import { notificationsRouter } from './routes/notifications.js';
@@ -32,6 +33,7 @@ app.use('/api/jobs', jobsRouter);
 app.use('/api/runs', runsRouter);
 app.use('/api/notifications', notificationsRouter);
 app.use('/api/google', googleRouter);
+app.use('/api/dashboard', dashboardRouter);
 
 app.use((_req, res) => {
   res.status(404).json(fail('NOT_FOUND', 'Route not found'));

--- a/server/src/routes/dashboard.ts
+++ b/server/src/routes/dashboard.ts
@@ -1,0 +1,105 @@
+import { Router } from 'express';
+import { getPool } from '../config/database.js';
+import { ok } from '../lib/response.js';
+import { requireAuth } from '../middleware/auth.js';
+
+export const dashboardRouter = Router();
+dashboardRouter.use(requireAuth);
+
+dashboardRouter.get('/stats', async (req, res) => {
+  const userId = req.user!.id;
+  const pool = getPool();
+  const [activeJobs, runsToday, itemsTracked, changesWeek] = await Promise.all([
+    pool.query<{ c: number }>(
+      `SELECT COUNT(*)::int AS c FROM scrape_jobs WHERE user_id = $1 AND enabled = true`,
+      [userId],
+    ),
+    pool.query<{ c: number }>(
+      `SELECT COUNT(*)::int AS c
+         FROM scrape_runs r
+         JOIN scrape_jobs j ON j.id = r.job_id
+        WHERE j.user_id = $1
+          AND r.started_at >= date_trunc('day', now())`,
+      [userId],
+    ),
+    pool.query<{ c: number }>(
+      `SELECT COUNT(*)::int AS c
+         FROM extracted_data d
+         JOIN scrape_jobs j ON j.id = d.job_id
+        WHERE j.user_id = $1`,
+      [userId],
+    ),
+    pool.query<{ c: number }>(
+      `SELECT COUNT(*)::int AS c
+         FROM notification_log
+        WHERE user_id = $1
+          AND sent_at >= now() - interval '7 days'
+          AND type = 'change_detected'`,
+      [userId],
+    ),
+  ]);
+  res.status(200).json(
+    ok({
+      active_jobs: activeJobs.rows[0]?.c ?? 0,
+      runs_today: runsToday.rows[0]?.c ?? 0,
+      items_tracked: itemsTracked.rows[0]?.c ?? 0,
+      changes_this_week: changesWeek.rows[0]?.c ?? 0,
+    }),
+  );
+});
+
+dashboardRouter.get('/recent-activity', async (req, res) => {
+  const userId = req.user!.id;
+  const { rows } = await getPool().query<{
+    run_id: string;
+    job_id: string;
+    job_name: string;
+    status: string;
+    items_extracted: number;
+    tokens_used: number;
+    started_at: Date;
+    completed_at: Date | null;
+  }>(
+    `SELECT r.id AS run_id, r.job_id, j.name AS job_name, r.status,
+            r.items_extracted, r.tokens_used, r.started_at, r.completed_at
+       FROM scrape_runs r
+       JOIN scrape_jobs j ON j.id = r.job_id AND j.user_id = $1
+      ORDER BY r.started_at DESC
+      LIMIT 10`,
+    [userId],
+  );
+  res.status(200).json(
+    ok({
+      items: rows.map((r) => ({
+        run_id: r.run_id,
+        job_id: r.job_id,
+        job_name: r.job_name,
+        status: r.status,
+        items_extracted: r.items_extracted,
+        tokens_used: r.tokens_used,
+        started_at: r.started_at.toISOString(),
+        completed_at: r.completed_at?.toISOString() ?? null,
+      })),
+    }),
+  );
+});
+
+dashboardRouter.get('/usage', async (req, res) => {
+  const userId = req.user!.id;
+  const { rows } = await getPool().query<{
+    day: string;
+    provider: string;
+    tokens: number;
+  }>(
+    `SELECT to_char(date_trunc('day', r.started_at), 'YYYY-MM-DD') AS day,
+            j.ai_provider AS provider,
+            SUM(r.tokens_used)::int AS tokens
+       FROM scrape_runs r
+       JOIN scrape_jobs j ON j.id = r.job_id AND j.user_id = $1
+      WHERE r.started_at >= now() - interval '30 days'
+      GROUP BY 1, 2
+      ORDER BY 1`,
+    [userId],
+  );
+  res.status(200).json(ok({ days: rows }));
+});


### PR DESCRIPTION
## Summary

Build Order step 14. Home page turns into the Dashboard.

## Backend

- `GET /api/dashboard/stats` \u2014 active_jobs, runs_today, items_tracked, changes_this_week (change count comes from `notification_log.type='change_detected'` in the last 7 days).
- `GET /api/dashboard/recent-activity` \u2014 10 most recent runs with the job name joined in.
- `GET /api/dashboard/usage` \u2014 per-day token totals grouped by `ai_provider` for the last 30 days.

## Frontend

- `Home.tsx` rewritten: stats row, recent activity table with links to each job, and an SVG-free stacked-bar usage chart (pure CSS/flex, per-provider colours). Hover tooltips show daily token totals. Empty states guide a new user to create their first job.

## Smoke

- Fresh account: all counters 0, activity empty, usage empty \u2014 confirmed.
- After a real run (from earlier step 9 smoke): stats reflect the run.

Closes #31