### PR TITLE
feat: dark mode toggle

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SmartScrape</title>
+    <script>
+      // Apply saved theme before React mounts to avoid a flash.
+      (function () {
+        try {
+          var v = localStorage.getItem('smartscrape-theme') || 'system';
+          var dark = v === 'dark' || (v === 'system' && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+          if (dark) document.documentElement.classList.add('dark');
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body class="bg-white text-gray-900 antialiased dark:bg-gray-950 dark:text-gray-100">
     <div id="root"></div>

--- a/client/src/components/layout/TopNav.tsx
+++ b/client/src/components/layout/TopNav.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { useAuth } from '../../stores/auth';
+import { useTheme, type ThemePref } from '../../stores/theme';
 
 export function TopNav() {
   const user = useAuth((s) => s.user);
@@ -42,12 +43,13 @@ export function TopNav() {
               <div className="border-b border-gray-100 px-3 py-2 text-xs text-gray-500 dark:border-gray-800">
                 {user?.email}
               </div>
+              <ThemeRow />
               <button
                 onClick={() => {
                   setOpen(false);
                   clear();
                 }}
-                className="block w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+                className="block w-full border-t border-gray-100 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:border-gray-800 dark:text-gray-200 dark:hover:bg-gray-800"
               >
                 Log out
               </button>
@@ -56,6 +58,37 @@ export function TopNav() {
         </div>
       </div>
     </header>
+  );
+}
+
+const THEME_OPTIONS: { value: ThemePref; label: string }[] = [
+  { value: 'system', label: 'System' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+];
+
+function ThemeRow() {
+  const pref = useTheme((s) => s.pref);
+  const setPref = useTheme((s) => s.set);
+  return (
+    <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+      <div className="mb-1.5">Theme</div>
+      <div className="flex gap-1 rounded-md border border-gray-200 p-0.5 dark:border-gray-700">
+        {THEME_OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            onClick={() => setPref(opt.value)}
+            className={`flex-1 rounded px-2 py-1 text-xs transition ${
+              pref === opt.value
+                ? 'bg-indigo-600 text-white'
+                : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/client/src/stores/theme.ts
+++ b/client/src/stores/theme.ts
@@ -1,0 +1,58 @@
+import { create } from 'zustand';
+
+export type ThemePref = 'system' | 'light' | 'dark';
+
+const KEY = 'smartscrape-theme';
+
+function readPref(): ThemePref {
+  try {
+    const v = localStorage.getItem(KEY);
+    if (v === 'light' || v === 'dark' || v === 'system') return v;
+  } catch {
+    /* ignore */
+  }
+  return 'system';
+}
+
+function systemPrefersDark(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+}
+
+export function applyTheme(pref: ThemePref): void {
+  const dark = pref === 'dark' || (pref === 'system' && systemPrefersDark());
+  document.documentElement.classList.toggle('dark', dark);
+}
+
+type ThemeState = {
+  pref: ThemePref;
+  set: (pref: ThemePref) => void;
+  toggle: () => void;
+};
+
+export const useTheme = create<ThemeState>((set, get) => ({
+  pref: readPref(),
+  set: (pref) => {
+    try {
+      localStorage.setItem(KEY, pref);
+    } catch {
+      /* ignore */
+    }
+    applyTheme(pref);
+    set({ pref });
+  },
+  toggle: () => {
+    // Cycle: system -> light -> dark -> system.
+    const cur = get().pref;
+    const next: ThemePref = cur === 'system' ? 'light' : cur === 'light' ? 'dark' : 'system';
+    get().set(next);
+  },
+}));
+
+// Re-apply when the system preference changes and the user is on 'system'.
+if (typeof window !== 'undefined') {
+  window.matchMedia?.('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    const pref = useTheme.getState().pref;
+    if (pref === 'system') applyTheme('system');
+  });
+  applyTheme(readPref());
+}


### PR DESCRIPTION
## Summary

Build Order step 16.

- `stores/theme.ts` \u2014 `'system' | 'light' | 'dark'`, persisted to localStorage. Listens for `prefers-color-scheme` changes when on System.
- `index.html` inlines a pre-hydration script that applies `.dark` before React mounts, avoiding a light\u2192dark flash.
- TopNav user menu gains a segmented System / Light / Dark picker.

Closes #35