### PR TITLE
fix(html-cleaner): don't collapse listing pages to the first <article>

### DIFF
--- a/server/src/services/html-cleaner.ts
+++ b/server/src/services/html-cleaner.ts
@@ -77,11 +77,14 @@ export function cleanHtml(html: string, opts: CleanOptions = {}): string {
     }
   });
 
-  // Prefer <main> / <article> if present.
+  // Prefer <main> when present (usually one per page, wraps real content).
+  // Never collapse to a single <article>: listing pages often have one
+  // <article> per item (product cards, search results, posts), and grabbing
+  // the first would silently drop the rest. If there's no <main>, use body.
   let workingHtml: string;
-  const main = $('main, article').first();
-  if (main.length > 0) {
-    workingHtml = $.html(main);
+  const mains = $('main');
+  if (mains.length > 0) {
+    workingHtml = mains.map((_, el) => $.html(el)).get().join('\n');
   } else {
     workingHtml = $('body').length ? $.html($('body')) : $.html();
   }


### PR DESCRIPTION
## Summary

User scraped https://books.toscrape.com/ asking for \"all books under 20 pounds\" and got exactly one row back \u2014 A Light in the Attic at \u00a351.77 (over 20, to boot).

## Root cause

\`cleanHtml()\` used \`$('main, article').first()\` and then used just that one element as the working HTML. On listing pages where every item is its own \`<article>\` (book cards, product grids, search results, blog indices), \`.first()\` returned only the first card. The other 19 books on the page never made it into the AI prompt. The AI did exactly what it was asked; the upstream HTML was wrong.

## Fix

- Prefer \`<main>\` when present (concat if multiple, rare but safe).
- Otherwise fall back to the scrubbed \`<body>\`.
- Never grab a single \`<article>\`.

## Verify (live stack, dev OpenRouter key)

Before: `books.toscrape.com` \u2192 656 chars cleaned, 1 book extracted.
After: `books.toscrape.com` \u2192 16,136 chars cleaned, **20 books extracted**, 3 of them under \u00a320. Example.com (single-article page) still cleans down to 219 chars identically.

Closes #41