### PR TITLE
fix: first-run notification spam + silent Sheets export failures + Sheet URL parsing

### DIFF
--- a/client/src/components/JobForm.tsx
+++ b/client/src/components/JobForm.tsx
@@ -55,6 +55,19 @@ export function jobToFormValues(job: Job): JobFormValues {
   };
 }
 
+/**
+ * Accept anything the user pastes and return the bare sheet ID. Users often
+ * paste the whole URL (https://docs.google.com/spreadsheets/d/XYZ/edit?\u2026)
+ * rather than the ID.
+ */
+function extractSheetId(input: string): string | null {
+  const s = input.trim();
+  if (!s) return null;
+  const match = s.match(/\/spreadsheets\/d\/([a-zA-Z0-9_-]+)/);
+  if (match) return match[1]!;
+  return s;
+}
+
 export const EMPTY_FORM: JobFormValues = {
   name: '',
   urls: [''],
@@ -324,8 +337,8 @@ export function JobForm({ initial, submitLabel, submitting, error, onSubmit, onC
           <FormField
             label="Sheet ID"
             value={v.google_sheet_id ?? ''}
-            onChange={(e) => setV({ ...v, google_sheet_id: e.target.value || null })}
-            placeholder="1a2b3c4d... (from the sheet URL)"
+            onChange={(e) => setV({ ...v, google_sheet_id: extractSheetId(e.target.value) })}
+            placeholder="Paste the full URL or just the ID"
           />
           <FormField
             label="Tab name"

--- a/client/src/pages/JobDetail.tsx
+++ b/client/src/pages/JobDetail.tsx
@@ -170,6 +170,14 @@ export default function JobDetail() {
                     <tr>
                       <td className="py-2">
                         <StatusBadge status={r.status} />
+                        {r.export_error && (
+                          <span
+                            className="ml-2 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+                            title={r.export_error}
+                          >
+                            ⚠ export
+                          </span>
+                        )}
                       </td>
                       <td className="py-2 font-mono text-xs">{r.items_extracted}</td>
                       <td className="py-2 font-mono text-xs">{r.tokens_used}</td>
@@ -204,6 +212,13 @@ export default function JobDetail() {
                         )}
                       </td>
                     </tr>
+                    {r.export_error && (
+                      <tr>
+                        <td colSpan={6} className="bg-amber-50/60 px-2 py-2 text-xs text-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+                          <span className="font-medium">Sheets export:</span> {r.export_error}
+                        </td>
+                      </tr>
+                    )}
                     {openDiff === r.id && (
                       <tr>
                         <td colSpan={6} className="bg-gray-50 px-2 py-3 dark:bg-gray-950/40">

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -105,6 +105,7 @@ export type Run = {
   items_extracted: number;
   tokens_used: number;
   error_message: string | null;
+  export_error: string | null;
   started_at: string;
   completed_at: string | null;
 };

--- a/server/migrations/20260425000001_run_export_error.js
+++ b/server/migrations/20260425000001_run_export_error.js
@@ -1,0 +1,15 @@
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+
+export const up = (pgm) => {
+  pgm.sql(`
+    ALTER TABLE scrape_runs
+      ADD COLUMN export_error TEXT;
+  `);
+};
+
+export const down = (pgm) => {
+  pgm.sql(`
+    ALTER TABLE scrape_runs
+      DROP COLUMN IF EXISTS export_error;
+  `);
+};

--- a/server/src/db/runs.ts
+++ b/server/src/db/runs.ts
@@ -16,6 +16,7 @@ export type RunRow = {
   items_extracted: number;
   tokens_used: number;
   error_message: string | null;
+  export_error: string | null;
   started_at: Date;
   completed_at: Date | null;
 };
@@ -73,7 +74,18 @@ export async function createRun(jobId: string): Promise<RunRow> {
 
 export async function updateRun(
   runId: string,
-  patch: Partial<Pick<RunRow, 'status' | 'urls_scraped' | 'items_extracted' | 'tokens_used' | 'error_message' | 'completed_at'>>,
+  patch: Partial<
+    Pick<
+      RunRow,
+      | 'status'
+      | 'urls_scraped'
+      | 'items_extracted'
+      | 'tokens_used'
+      | 'error_message'
+      | 'export_error'
+      | 'completed_at'
+    >
+  >,
 ): Promise<void> {
   const sets: string[] = [];
   const vals: unknown[] = [];
@@ -86,6 +98,7 @@ export async function updateRun(
   if (patch.items_extracted !== undefined) push('items_extracted', patch.items_extracted);
   if (patch.tokens_used !== undefined) push('tokens_used', patch.tokens_used);
   if (patch.error_message !== undefined) push('error_message', patch.error_message);
+  if (patch.export_error !== undefined) push('export_error', patch.export_error);
   if (patch.completed_at !== undefined) push('completed_at', patch.completed_at);
   if (sets.length === 0) return;
   vals.push(runId);

--- a/server/src/services/job-runner.ts
+++ b/server/src/services/job-runner.ts
@@ -86,20 +86,24 @@ export async function runJob(job: JobRow, existingRunId?: string): Promise<RunSu
     await insertExtractedData(run.id, job.id, allBatches);
 
     // Optional: export to Google Sheets if the job has one linked and the user is connected.
+    let exportError: string | null = null;
     if (job.google_sheet_id && allBatches.length > 0) {
-      try {
-        await updateRun(run.id, { status: 'exporting' });
-        const conn = await findConnection(job.user_id);
-        if (conn) {
+      await updateRun(run.id, { status: 'exporting' });
+      const conn = await findConnection(job.user_id);
+      if (!conn) {
+        exportError = 'Google Sheets export skipped: user has not connected Google.';
+      } else {
+        try {
           await pushRows({
             userId: job.user_id,
             sheetId: job.google_sheet_id,
             tabName: job.sheet_tab_name,
             rows: allBatches.map((b) => b.data),
           });
+        } catch (err) {
+          exportError = err instanceof Error ? err.message : String(err);
+          console.error('[runner] sheets export failed', exportError);
         }
-      } catch (err) {
-        console.error('[runner] sheets export failed', err);
       }
     }
 
@@ -108,6 +112,7 @@ export async function runJob(job: JobRow, existingRunId?: string): Promise<RunSu
       urls_scraped: urlsScraped,
       items_extracted: itemsExtracted,
       tokens_used: tokensUsed,
+      export_error: exportError,
       completed_at: new Date(),
     });
     await getPool().query(`UPDATE scrape_jobs SET last_run_at = now() WHERE id = $1`, [job.id]);

--- a/server/src/services/notification-service.ts
+++ b/server/src/services/notification-service.ts
@@ -48,14 +48,34 @@ function compare(operator: string, lhs: unknown, rhs: number | string): boolean 
   }
 }
 
+/** Cap per-item rules so a huge batch can't flood a user. */
+const PER_RULE_ITEM_CAP = 3;
+
+function capPerItem(
+  rule: NotificationRule,
+  matches: EvaluatedNotification[],
+): EvaluatedNotification[] {
+  if (matches.length <= PER_RULE_ITEM_CAP) return matches;
+  const head = matches.slice(0, PER_RULE_ITEM_CAP);
+  head.push({
+    type: 'change_detected',
+    message: `\u2026and ${matches.length - PER_RULE_ITEM_CAP} more matches for rule "${rule.type}".`,
+  });
+  return head;
+}
+
 export function evaluateRules(job: JobRow, diff: DiffResult): EvaluatedNotification[] {
   const out: EvaluatedNotification[] = [];
   const rules: NotificationRule[] = job.notification_rules;
   const globals = { job_name: job.name };
+  // First run (no predecessor) = "initial inventory", not a change. Skip rules
+  // that only make sense across runs so users don't get flooded on day one.
+  const isFirstRun = diff.previous_run === null;
 
   for (const rule of rules) {
     switch (rule.type) {
       case 'any_change': {
+        if (isFirstRun) break;
         if (diff.added.length > 0 || diff.removed.length > 0 || diff.changed.length > 0) {
           const url = String((diff.added[0] ?? diff.changed[0]?.after ?? diff.removed[0])?.url ?? '');
           out.push({
@@ -66,6 +86,7 @@ export function evaluateRules(job: JobRow, diff: DiffResult): EvaluatedNotificat
         break;
       }
       case 'new_items': {
+        if (isFirstRun) break;
         if (diff.added.length > 0) {
           out.push({
             type: 'change_detected',
@@ -78,6 +99,7 @@ export function evaluateRules(job: JobRow, diff: DiffResult): EvaluatedNotificat
         break;
       }
       case 'removed_items': {
+        if (isFirstRun) break;
         if (diff.removed.length > 0) {
           out.push({
             type: 'change_detected',
@@ -90,12 +112,15 @@ export function evaluateRules(job: JobRow, diff: DiffResult): EvaluatedNotificat
         break;
       }
       case 'field_threshold': {
-        // Check added + changed.after items for the threshold.
+        // Skip on first run: every baseline item would match and spam the user.
+        if (isFirstRun) break;
+        // Only alert on NEW items crossing the threshold, not every existing match.
         const candidates = [...diff.added, ...diff.changed.map((c) => c.after)];
+        const matches: EvaluatedNotification[] = [];
         for (const item of candidates) {
           const value = (item as Record<string, unknown>)[rule.field];
           if (compare(rule.operator, value, rule.value)) {
-            out.push({
+            matches.push({
               type: 'change_detected',
               message: interpolate(
                 rule.message ?? `{job_name}: ${rule.field} is ${value} ({operator} ${rule.value})`,
@@ -110,13 +135,16 @@ export function evaluateRules(job: JobRow, diff: DiffResult): EvaluatedNotificat
             });
           }
         }
+        out.push(...capPerItem(rule, matches));
         break;
       }
       case 'field_change': {
+        // field_change can never fire on first run (no `changed` items yet).
+        const matches: EvaluatedNotification[] = [];
         for (const ch of diff.changed) {
           const match = ch.field_diffs.find((f) => f.field === rule.field);
           if (!match) continue;
-          out.push({
+          matches.push({
             type: 'change_detected',
             message: interpolate(rule.message ?? '{job_name}: {field_name} changed from {old} to {new}', {
               ...globals,
@@ -127,6 +155,7 @@ export function evaluateRules(job: JobRow, diff: DiffResult): EvaluatedNotificat
             }),
           });
         }
+        out.push(...capPerItem(rule, matches));
         break;
       }
     }


### PR DESCRIPTION
## Summary

Three separate things reported from real use:

### 1. Telegram spam on the first run

Scraping books.toscrape.com with a \`price < 30\` rule fired 7 Telegram messages \u2014 one per matching book. A first run has no predecessor, so by definition nothing has \"changed\" \u2014 it's the initial inventory.

- All change-themed rules (\`any_change\`, \`new_items\`, \`removed_items\`, \`field_threshold\`, \`field_change\`) are now skipped when \`diff.previous_run === null\`.
- Per-item rules (\`field_threshold\`, \`field_change\`) are additionally capped at 3 messages per rule per run, collapsing into one \"\u2026and N more matches\" summary. Caps future catalog churn from flooding chats.

### 2. Google Sheets silently didn't update

Runner \`console.error\`'d and moved on. User saw a green completed run, sheet stayed empty.

- New \`scrape_runs.export_error\` column (nullable TEXT, migration included).
- Runner now captures the Sheets error there and keeps the run \`completed\`, because the extraction itself succeeded.
- JobDetail shows a yellow \`\u26a0 export\` badge + an expanded warning row with the exact error per run.

### 3. Users paste full Sheet URLs, not just the ID

Pasted \`https://docs.google.com/spreadsheets/d/XYZ/edit?pli=1&gid=0#gid=0\` goes to the Sheets API, which rejects it. JobForm now extracts the ID from any Sheets URL at paste time.

## Verify

- Unit: \`evaluateRules\` with a \`field_threshold\` rule and 7 matching added items \u2192 0 messages on first run, 4 messages on second run (3 individual + 1 \"\u2026and 4 more\" summary).
- Full Sheets URL in the Sheet ID input is normalized to \`1kbbM5kuyo9a0JVpDEpy3ZN0KzzteXqd6gDiYjz-VZ7M\`.
- A failing export (wrong sheet ID, disconnected Google, etc) now lands on the run as an inline warning; CI migrations job re-verifies up/down/up on Postgres 16.

Closes #43