### PR TITLE
fix: tall forms can't scroll to submit button

### DIFF
--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -2,8 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Let the document grow with content so long forms (e.g. the New Job wizard
+   with an expanded rule editor) don't clip the submit button and block scroll.
+   The old rule was `height: 100%`, which pins #root to exactly one viewport
+   and leaves tall pages un-scrollable. */
 html,
 body,
 #root {
-  height: 100%;
+  min-height: 100%;
 }


### PR DESCRIPTION
## Summary

User reported can't reach the \"Create Job\" button after adding a notification rule. Root cause: `html, body, #root { height: 100% }` pinned `#root` to exactly one viewport height, so on pages taller than the fold the document scrollbar never engaged.

Change to `min-height: 100%`. Document grows with content; every page still wraps in a `min-h-screen` div so short-page backgrounds stay full-height.

Closes #45