### PR TITLE
fix: Google scope mismatch surfacing + one-shot summaries on first run

### DIFF
--- a/server/migrations/20260425000002_google_scope.js
+++ b/server/migrations/20260425000002_google_scope.js
@@ -1,0 +1,15 @@
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+
+export const up = (pgm) => {
+  pgm.sql(`
+    ALTER TABLE google_connections
+      ADD COLUMN scope TEXT;
+  `);
+};
+
+export const down = (pgm) => {
+  pgm.sql(`
+    ALTER TABLE google_connections
+      DROP COLUMN IF EXISTS scope;
+  `);
+};

--- a/server/src/db/googleConnections.ts
+++ b/server/src/db/googleConnections.ts
@@ -7,6 +7,7 @@ export type GoogleConnectionRow = {
   refresh_token_encrypted: string;
   token_expires_at: Date | null;
   connected_email: string | null;
+  scope: string | null;
   created_at: Date;
   updated_at: Date;
 };
@@ -25,16 +26,18 @@ export async function upsertConnection(args: {
   refreshTokenEncrypted: string;
   tokenExpiresAt: Date | null;
   connectedEmail: string | null;
+  scope: string | null;
 }): Promise<GoogleConnectionRow> {
   const { rows } = await getPool().query<GoogleConnectionRow>(
     `INSERT INTO google_connections
-       (user_id, access_token_encrypted, refresh_token_encrypted, token_expires_at, connected_email)
-     VALUES ($1, $2, $3, $4, $5)
+       (user_id, access_token_encrypted, refresh_token_encrypted, token_expires_at, connected_email, scope)
+     VALUES ($1, $2, $3, $4, $5, $6)
      ON CONFLICT (user_id)
        DO UPDATE SET access_token_encrypted = EXCLUDED.access_token_encrypted,
                      refresh_token_encrypted = EXCLUDED.refresh_token_encrypted,
                      token_expires_at = EXCLUDED.token_expires_at,
-                     connected_email = EXCLUDED.connected_email
+                     connected_email = EXCLUDED.connected_email,
+                     scope = EXCLUDED.scope
      RETURNING *`,
     [
       args.userId,
@@ -42,6 +45,7 @@ export async function upsertConnection(args: {
       args.refreshTokenEncrypted,
       args.tokenExpiresAt,
       args.connectedEmail,
+      args.scope,
     ],
   );
   return rows[0]!;

--- a/server/src/services/google-sheets.ts
+++ b/server/src/services/google-sheets.ts
@@ -8,11 +8,14 @@ import {
   upsertConnection,
 } from '../db/googleConnections.js';
 
+export const SHEETS_SCOPE = 'https://www.googleapis.com/auth/spreadsheets';
+const USERINFO_EMAIL_SCOPE = 'https://www.googleapis.com/auth/userinfo.email';
+
 // Minimal scopes: write sheets + read user's email to display which account is connected.
-export const SHEETS_SCOPES = [
-  'https://www.googleapis.com/auth/spreadsheets',
-  'https://www.googleapis.com/auth/userinfo.email',
-];
+export const SHEETS_SCOPES = [SHEETS_SCOPE, USERINFO_EMAIL_SCOPE];
+
+const RECONNECT_HINT =
+  'Disconnect Google in Settings and reconnect to grant the Sheets permission.';
 
 function clientConfig() {
   const id = process.env.GOOGLE_CLIENT_ID ?? '';
@@ -68,6 +71,16 @@ export async function exchangeAndStore(userId: string, code: string): Promise<{ 
   const client = oauthClient();
   const { tokens } = await client.getToken(code);
   if (!tokens.access_token) throw new Error('Google did not return an access token');
+
+  const grantedScope = typeof tokens.scope === 'string' ? tokens.scope : '';
+  const scopes = new Set(grantedScope.split(/\s+/).filter(Boolean));
+  if (!scopes.has(SHEETS_SCOPE)) {
+    throw new Error(
+      `Google did not grant the Sheets scope (${SHEETS_SCOPE}). Granted: ${grantedScope || '(none)'}. ` +
+        `Check the OAuth consent screen in the Google Cloud project and ensure spreadsheets is listed, then try again.`,
+    );
+  }
+
   if (!tokens.refresh_token) {
     // On re-auth Google omits refresh_token. If we already have one stored, reuse it.
     const existing = await findConnection(userId);
@@ -89,6 +102,7 @@ export async function exchangeAndStore(userId: string, code: string): Promise<{ 
     refreshTokenEncrypted: encrypt(tokens.refresh_token),
     tokenExpiresAt: tokens.expiry_date ? new Date(tokens.expiry_date) : null,
     connectedEmail: email,
+    scope: grantedScope,
   });
 
   return { email };
@@ -137,6 +151,14 @@ export async function pushRows(args: {
   rows: Record<string, unknown>[];
 }): Promise<{ appended: number }> {
   if (args.rows.length === 0) return { appended: 0 };
+  // Fail fast with an actionable message when the stored scope is missing the
+  // write permission. Otherwise the Sheets API returns an opaque 403.
+  const conn = await findConnection(args.userId);
+  if (conn && conn.scope !== null && !conn.scope.split(/\s+/).includes(SHEETS_SCOPE)) {
+    throw new Error(
+      `Stored Google credentials are missing the Sheets scope. ${RECONNECT_HINT}`,
+    );
+  }
   const client = await authedClient(args.userId);
   const sheets = google.sheets({ version: 'v4', auth: client });
   const tab = args.tabName && args.tabName.length > 0 ? args.tabName : 'Sheet1';

--- a/server/src/services/notification-service.ts
+++ b/server/src/services/notification-service.ts
@@ -75,30 +75,40 @@ export function evaluateRules(job: JobRow, diff: DiffResult): EvaluatedNotificat
   for (const rule of rules) {
     switch (rule.type) {
       case 'any_change': {
-        if (isFirstRun) break;
+        // One-shot, summary-style rule. OK to fire on the first run ("initial inventory").
         if (diff.added.length > 0 || diff.removed.length > 0 || diff.changed.length > 0) {
           const url = String((diff.added[0] ?? diff.changed[0]?.after ?? diff.removed[0])?.url ?? '');
           out.push({
             type: 'change_detected',
-            message: interpolate(rule.message ?? 'Data changed on {job_name}', { ...globals, url }),
+            message: interpolate(
+              rule.message ?? (isFirstRun ? 'First run for {job_name}: {count} items' : 'Data changed on {job_name}'),
+              {
+                ...globals,
+                url,
+                count: diff.added.length + diff.changed.length + diff.removed.length,
+              },
+            ),
           });
         }
         break;
       }
       case 'new_items': {
-        if (isFirstRun) break;
         if (diff.added.length > 0) {
           out.push({
             type: 'change_detected',
-            message: interpolate(rule.message ?? 'Found {count} new items on {job_name}', {
-              ...globals,
-              count: diff.added.length,
-            }),
+            message: interpolate(
+              rule.message ?? (isFirstRun ? 'First run for {job_name}: {count} items' : 'Found {count} new items on {job_name}'),
+              {
+                ...globals,
+                count: diff.added.length,
+              },
+            ),
           });
         }
         break;
       }
       case 'removed_items': {
+        // Logically can't fire on a first run (nothing to remove from).
         if (isFirstRun) break;
         if (diff.removed.length > 0) {
           out.push({


### PR DESCRIPTION
## Summary

User hit both `Request had insufficient authentication scopes` on Sheets export and a quiet Telegram channel on subsequent runs of a static site.

### Google scopes

After `getToken()` we now parse `tokens.scope` and verify `spreadsheets` is present. Throwing immediately with \u201cGoogle did not grant the Sheets scope \u2026 check the OAuth consent screen and try again\u201d instead of letting the 403 leak out of Sheets at write time. The granted scope string is stored on a new `google_connections.scope` column (migration included) so `pushRows()` can fail fast with a \u201cdisconnect and reconnect\u201d message when the stored token is missing permission.

### First-run notifications

PR #44 silenced all change-themed rules on the first run to stop per-item spam. That was over-broad: on a fresh job with no subsequent changes, summary rules (`any_change`, `new_items`) never fired, so users saw nothing.

Now:
- `any_change` / `new_items` fire once on the first run with an \u201cInitial inventory: N items\u201d style summary.
- `removed_items` stays silent (can\u2019t remove from nothing).
- `field_threshold` / `field_change` stay silent on first run - they\u2019re the spam-prone ones.
- Per-rule cap from PR #44 is still in place.

### Verify

Unit on evaluateRules:
- First run, 7 items added \u2192 2 messages (new_items summary + any_change summary). field_threshold with `price < 30` = 0 messages.
- Second run, 0 changes \u2192 0 messages.
- Third run, 1 new book at \u00a315 \u2192 3 messages (new_items summary + any_change summary + 1 field_threshold match).

### Action for the user

To actually see a sheet export work, disconnect Google in Settings and reconnect. The new consent will include `spreadsheets` (or fail loudly if the Cloud consent screen hasn\u2019t listed it).

Closes #47