### PR TITLE
fix: provider test false-positive + sheet picker UI + push-to-sheets button

### DIFF
--- a/client/src/components/JobForm.tsx
+++ b/client/src/components/JobForm.tsx
@@ -1,7 +1,8 @@
-import { type FormEvent, useState } from 'react';
+import { type FormEvent, useEffect, useState } from 'react';
 import { Alert } from './ui/Alert';
 import { Button } from './ui/Button';
 import { FormField } from './ui/FormField';
+import { api } from '../lib/api';
 import type {
   ExtractionSchema,
   FieldType,
@@ -330,23 +331,19 @@ export function JobForm({ initial, submitLabel, submitting, error, onSubmit, onC
 
       <Section title="Google Sheets (optional)">
         <p className="text-xs text-gray-500 dark:text-gray-400">
-          After each run, extracted rows are appended to the sheet. Connect Google in Settings first, then paste the
-          Sheet ID here.
+          After each run, extracted rows are appended to the sheet. Connect Google in Settings first, then pick a sheet
+          below or paste an ID directly.
         </p>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <FormField
-            label="Sheet ID"
-            value={v.google_sheet_id ?? ''}
-            onChange={(e) => setV({ ...v, google_sheet_id: extractSheetId(e.target.value) })}
-            placeholder="Paste the full URL or just the ID"
-          />
-          <FormField
-            label="Tab name"
-            value={v.sheet_tab_name ?? ''}
-            onChange={(e) => setV({ ...v, sheet_tab_name: e.target.value || null })}
-            placeholder="Sheet1"
-          />
-        </div>
+        <SheetPicker
+          value={v.google_sheet_id ?? ''}
+          onChange={(id) => setV({ ...v, google_sheet_id: id })}
+        />
+        <FormField
+          label="Tab name"
+          value={v.sheet_tab_name ?? ''}
+          onChange={(e) => setV({ ...v, sheet_tab_name: e.target.value || null })}
+          placeholder="Sheet1"
+        />
       </Section>
 
       <Section title="Notifications">
@@ -385,6 +382,95 @@ export function JobForm({ initial, submitLabel, submitting, error, onSubmit, onC
         </Button>
       </div>
     </form>
+  );
+}
+
+type SheetSummary = { id: string; name: string; modifiedTime: string | null; webViewLink: string | null };
+
+/**
+ * Sheet picker: tries to list the user's spreadsheets via /api/google/sheets
+ * (requires the drive.metadata.readonly scope). If that fails (not connected,
+ * missing scope, network error) we gracefully fall back to a manual ID field
+ * so existing users aren't locked out of linking a sheet.
+ */
+function SheetPicker({ value, onChange }: { value: string; onChange: (id: string | null) => void }) {
+  const [sheets, setSheets] = useState<SheetSummary[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const res = await api<{ sheets: SheetSummary[] }>('/api/google/sheets');
+      if (cancelled) return;
+      if (res.success) {
+        setSheets(res.data.sheets);
+      } else {
+        setLoadError(res.error.message);
+      }
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return <p className="text-xs text-gray-500">Loading your sheets…</p>;
+  }
+
+  // Fallback to plain ID field when the picker can't load.
+  if (loadError || !sheets) {
+    return (
+      <div>
+        {loadError && (
+          <p className="mb-2 text-xs text-amber-700 dark:text-amber-400">
+            Couldn't list your sheets ({loadError}). Paste an ID or URL instead.
+          </p>
+        )}
+        <FormField
+          label="Sheet ID or URL"
+          value={value}
+          onChange={(e) => onChange(extractSheetId(e.target.value))}
+          placeholder="Paste the full URL or just the ID"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">Sheet</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value || null)}
+        className="block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"
+      >
+        <option value="">— None —</option>
+        {value && !sheets.some((s) => s.id === value) && (
+          <option value={value}>{`(manually entered) ${value}`}</option>
+        )}
+        {sheets.map((s) => (
+          <option key={s.id} value={s.id}>
+            {s.name}
+          </option>
+        ))}
+      </select>
+      <p className="mt-1 text-xs text-gray-500">
+        Not seeing the sheet you want?{' '}
+        <button
+          type="button"
+          className="text-indigo-600 hover:underline dark:text-indigo-400"
+          onClick={() => {
+            const pasted = window.prompt('Paste the sheet URL or ID');
+            if (pasted) onChange(extractSheetId(pasted));
+          }}
+        >
+          Paste an ID
+        </button>{' '}
+        (e.g. shared-with-you sheets).
+      </p>
+    </div>
   );
 }
 

--- a/client/src/pages/JobDetail.tsx
+++ b/client/src/pages/JobDetail.tsx
@@ -16,6 +16,7 @@ export default function JobDetail() {
   const [error, setError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [runningNow, setRunningNow] = useState(false);
+  const [pushingSheets, setPushingSheets] = useState(false);
   const [openDiff, setOpenDiff] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -55,6 +56,20 @@ export default function JobDetail() {
     } else {
       toast.info('Run queued.');
       void load();
+    }
+  }
+
+  async function pushSheets() {
+    setPushingSheets(true);
+    const res = await api<{ appended: number; runId: string }>(
+      `/api/jobs/${id}/export/sheets`,
+      { method: 'POST' },
+    );
+    setPushingSheets(false);
+    if (!res.success) {
+      toast.error(res.error.message);
+    } else {
+      toast.success(`Appended ${res.data.appended} row${res.data.appended === 1 ? '' : 's'} to Sheets.`);
     }
   }
 
@@ -105,10 +120,15 @@ export default function JobDetail() {
               {job.urls.length} URL{job.urls.length === 1 ? '' : 's'} · {job.schedule ?? 'Manual'} · {job.ai_provider}/{job.ai_model}
             </p>
           </div>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <Button onClick={runNow} loading={runningNow}>
               Run now
             </Button>
+            {job.google_sheet_id && (
+              <Button variant="secondary" loading={pushingSheets} onClick={pushSheets}>
+                Push to Sheets
+              </Button>
+            )}
             <Link to={`/jobs/${job.id}/edit`}>
               <Button variant="secondary">Edit</Button>
             </Link>

--- a/server/src/routes/notifications.ts
+++ b/server/src/routes/notifications.ts
@@ -36,11 +36,21 @@ notificationsRouter.post('/test/email', async (req, res) => {
     return;
   }
   try {
-    await sendEmail({
+    const result = await sendEmail({
       to: user.email,
       subject: '[SmartScrape] Test email',
       text: 'If you received this, your email channel is working.',
     });
+    if (!result.delivered) {
+      res.status(200).json(
+        ok({
+          sent: false,
+          warning:
+            'SMTP is not configured on this server. The test message was written to the server log instead of delivered. Set SMTP_HOST / SMTP_PORT / SMTP_USER / SMTP_PASS to send real email.',
+        }),
+      );
+      return;
+    }
     res.status(200).json(ok({ sent: true }));
   } catch (err) {
     res.status(502).json(fail('EMAIL_FAILED', err instanceof Error ? err.message : 'Email failed'));

--- a/server/src/services/ai-providers.ts
+++ b/server/src/services/ai-providers.ts
@@ -26,9 +26,19 @@ export async function testCredentials(provider: Provider, apiKey: string): Promi
       const client = new Anthropic({ apiKey });
       await client.models.list({ limit: 1 });
     } else {
-      // OpenRouter implements the OpenAI spec.
-      const client = new OpenAI({ apiKey, baseURL: OPENROUTER_BASE_URL });
-      await client.models.list();
+      // OpenRouter's /v1/models is a PUBLIC endpoint — it returns results for
+      // any Authorization header, so we can't use it to validate the key.
+      // /v1/auth/key returns the key's label/usage and requires a valid key.
+      const res = await fetch(`${OPENROUTER_BASE_URL}/auth/key`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      if (!res.ok) {
+        return {
+          ok: false,
+          latencyMs: Date.now() - started,
+          error: res.status === 401 || res.status === 403 ? 'Invalid API key' : `${res.status}: ${res.statusText}`,
+        };
+      }
     }
     return { ok: true, latencyMs: Date.now() - started };
   } catch (err) {

--- a/server/src/services/email.ts
+++ b/server/src/services/email.ts
@@ -8,6 +8,12 @@ type SendArgs = {
   html?: string;
 };
 
+export type SendResult =
+  /** Delivered to SMTP. */
+  | { delivered: true }
+  /** No SMTP configured; message was written to the server log instead. */
+  | { delivered: false; reason: 'smtp_not_configured' };
+
 let cached: Transporter | null = null;
 
 function transporter(): Transporter | null {
@@ -25,12 +31,17 @@ function transporter(): Transporter | null {
   return cached;
 }
 
+export function isSmtpConfigured(): boolean {
+  return Boolean(env.smtp.host);
+}
+
 /**
  * Send an email via SMTP when configured; otherwise log it. The console
  * fallback keeps dev flows (verify email, password reset) working without
- * forcing SMTP setup.
+ * forcing SMTP setup. Returns a discriminant so callers (e.g. the test-email
+ * route) can tell the user their message went to the log, not an inbox.
  */
-export async function sendEmail({ to, subject, text, html }: SendArgs): Promise<void> {
+export async function sendEmail({ to, subject, text, html }: SendArgs): Promise<SendResult> {
   const tx = transporter();
   if (!tx) {
     console.log('[email:dev-console]', {
@@ -39,7 +50,8 @@ export async function sendEmail({ to, subject, text, html }: SendArgs): Promise<
       subject,
       text,
     });
-    return;
+    return { delivered: false, reason: 'smtp_not_configured' };
   }
   await tx.sendMail({ from: env.smtp.from, to, subject, text, html });
+  return { delivered: true };
 }


### PR DESCRIPTION
Follow-ups from post-#50 manual test pass.

## Summary
- **OpenRouter key test was a false positive.** /v1/models is public on OpenRouter; any header passes. Switched to /v1/auth/key (auth-required).
- **Email test no longer claims 'sent' when SMTP isn't configured.** Returns a warning explaining the message went to the server log instead.
- **Push to Sheets button on Job Detail** — only renders when a sheet is linked.
- **Sheet picker in JobForm** — populates from GET /api/google/sheets, gracefully falls back to manual ID entry if the list endpoint fails.

Closes #51

## Test plan
- [ ] Save a deliberately-wrong OpenRouter key → `Test` now reports "Invalid API key" (not success)
- [ ] With SMTP unset, hit `POST /api/notifications/test/email` → response has `sent: false` + `warning` explaining the server log fallback
- [ ] Link a Google sheet to a job → Job Detail shows "Push to Sheets" button → click → toast "Appended N rows"
- [ ] Unlinked job → button is not rendered
- [ ] Edit Job → sheet dropdown lists your spreadsheets → pick one → save
- [ ] Revoke `drive.metadata.readonly` (or disconnect Google) → picker falls back to the pasted-ID field with a clear reason