### PR TITLE
test: Playwright smoke suite + fix TopNav mobile overflow it caught

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc -b --noEmit"
+    "typecheck": "tsc -b --noEmit",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -16,6 +17,7 @@
     "zustand": "^5.0.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Smoke-only Playwright config. Assumes the dev server is already running
+ * (start with `npm run dev` from the repo root). The API is reachable via
+ * the Vite proxy at :5173/api → :3000.
+ *
+ * Run with: npm run test:e2e --workspace client
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: false,
+  workers: 1, // single worker so the worker-scoped session fixture is truly shared
+  retries: 0,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'desktop',
+      use: { ...devices['Desktop Chrome'] },
+      testIgnore: /.*\.mobile\.spec\.ts$/,
+    },
+    {
+      name: 'mobile',
+      // Pixel 5 is Chromium-based, so we don't need the WebKit engine. Gives us
+      // the same 375px-ish width profile without forcing `npx playwright install webkit`.
+      use: { ...devices['Pixel 5'] },
+      testMatch: /.*\.mobile\.spec\.ts$/,
+    },
+  ],
+});

--- a/client/src/components/layout/TopNav.tsx
+++ b/client/src/components/layout/TopNav.tsx
@@ -10,19 +10,19 @@ export function TopNav() {
 
   return (
     <header className="border-b border-gray-200 bg-white/70 backdrop-blur dark:border-gray-800 dark:bg-gray-950/70">
-      <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-3">
-        <div className="flex items-center gap-6">
-          <Link to="/" className="text-sm font-semibold tracking-tight text-gray-900 dark:text-gray-100">
+      <div className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-4 py-3 sm:px-6">
+        <div className="flex min-w-0 flex-1 items-center gap-4 sm:gap-6">
+          <Link to="/" className="shrink-0 text-sm font-semibold tracking-tight text-gray-900 dark:text-gray-100">
             SmartScrape
           </Link>
-          <nav className="flex items-center gap-1 overflow-x-auto">
+          <nav className="flex min-w-0 items-center gap-1 overflow-x-auto">
             <NavItem to="/">Home</NavItem>
             <NavItem to="/jobs">Jobs</NavItem>
             <NavItem to="/notifications">Notifications</NavItem>
             <NavItem to="/settings">Settings</NavItem>
           </nav>
         </div>
-        <div className="relative">
+        <div className="relative shrink-0">
           <button
             onClick={() => setOpen((v) => !v)}
             className="flex items-center gap-2 rounded-md px-2 py-1 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"

--- a/client/tests/e2e/helpers.ts
+++ b/client/tests/e2e/helpers.ts
@@ -1,0 +1,119 @@
+import { test as base, type APIRequestContext, type Page } from '@playwright/test';
+
+export const API_BASE = 'http://localhost:3000';
+
+export type Session = {
+  email: string;
+  password: string;
+  accessToken: string;
+  refreshToken: string;
+  userId: string;
+};
+
+/** Retry a request when the server returns 429 (auth-entry rate limit). */
+async function postWithRateLimitRetry(
+  request: APIRequestContext,
+  url: string,
+  data: unknown,
+): Promise<ReturnType<APIRequestContext['post']> extends Promise<infer T> ? T : never> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const res = await request.post(url, { data });
+    if (res.status() !== 429) return res;
+    // 15s — long enough that a fresh 60s window has a real chance of opening,
+    // short enough that a full test suite still completes in reasonable time.
+    await new Promise((r) => setTimeout(r, 15_000));
+  }
+  throw new Error(`exhausted rate-limit retries for ${url}. Restart the server with SKIP_RATE_LIMIT=1.`);
+}
+
+export async function registerAndLogin(request: APIRequestContext): Promise<Session> {
+  const email = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@local.test`;
+  const password = 'PlayTest1234!';
+  await postWithRateLimitRetry(request, `${API_BASE}/api/auth/register`, {
+    email,
+    password,
+    name: 'E2E User',
+  });
+  const login = await postWithRateLimitRetry(request, `${API_BASE}/api/auth/login`, {
+    email,
+    password,
+  });
+  if (!login.ok()) {
+    throw new Error(`login failed: ${login.status()} ${await login.text()}`);
+  }
+  const body = (await login.json()) as {
+    data: { accessToken: string; refreshToken: string; user: { id: string } };
+  };
+  return {
+    email,
+    password,
+    accessToken: body.data.accessToken,
+    refreshToken: body.data.refreshToken,
+    userId: body.data.user.id,
+  };
+}
+
+/**
+ * Worker-scoped fixture: one user per test worker. Tests share this session
+ * so we stay under the auth-entry rate limit (5/min/IP) without needing a
+ * test-only bypass in the server.
+ *
+ * When a test genuinely needs a pristine no-data user (empty-state assertions),
+ * use `freshSession` which registers a fresh user on demand.
+ */
+export const test = base.extend<{
+  freshSession: Session;
+}, {
+  sharedSession: Session;
+}>({
+  sharedSession: [
+    async ({ playwright }, use) => {
+      const ctx = await playwright.request.newContext();
+      const session = await registerAndLogin(ctx);
+      await ctx.dispose();
+      await use(session);
+    },
+    { scope: 'worker' },
+  ],
+  freshSession: async ({ request }, use) => {
+    const session = await registerAndLogin(request);
+    await use(session);
+  },
+});
+
+export const expect = base.expect;
+
+export async function primeAuth(page: Page, session: Session): Promise<void> {
+  await page.goto('/');
+  await page.evaluate((s) => {
+    localStorage.setItem(
+      'smartscrape-auth',
+      JSON.stringify({
+        state: {
+          accessToken: s.accessToken,
+          refreshToken: s.refreshToken,
+          user: { id: s.userId, email: s.email, name: 'E2E User', email_verified: false },
+        },
+        version: 0,
+      }),
+    );
+  }, session);
+}
+
+export async function createJob(
+  request: APIRequestContext,
+  token: string,
+  overrides: Record<string, unknown> = {},
+): Promise<string> {
+  const res = await request.post(`${API_BASE}/api/jobs`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      name: 'E2E smoke job',
+      urls: ['https://example.com'],
+      extraction_prompt: 'Extract the page heading.',
+      ...overrides,
+    },
+  });
+  const body = (await res.json()) as { data: { job: { id: string } } };
+  return body.data.job.id;
+}

--- a/client/tests/e2e/layout.mobile.spec.ts
+++ b/client/tests/e2e/layout.mobile.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect, createJob, primeAuth } from './helpers';
+
+/**
+ * Mobile-viewport spec (runs via the 'mobile' project in playwright.config.ts).
+ * The bar is: no horizontal scrollbar on any primary page, which catches
+ * overflow regressions from tables/long URLs/long toast copy.
+ */
+test.describe.configure({ mode: 'serial' });
+test.describe('mobile @ 375px', () => {
+  test('primary pages have no horizontal overflow', async ({ page, request, sharedSession }) => {
+    const jobId = await createJob(request, sharedSession.accessToken);
+    await primeAuth(page, sharedSession);
+
+    for (const path of ['/', '/jobs', '/notifications', '/settings', `/jobs/${jobId}`]) {
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+      const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      }));
+      expect.soft(scrollWidth, `horizontal overflow on ${path}`).toBeLessThanOrEqual(clientWidth + 1);
+    }
+  });
+});

--- a/client/tests/e2e/smoke.spec.ts
+++ b/client/tests/e2e/smoke.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, createJob, primeAuth } from './helpers';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('smoke', () => {
+  // Empty-state and dark-mode tests run before any job is created under the
+  // shared session — safe because describe.serial preserves order.
+  test('seeded session → Home renders', async ({ page, sharedSession }) => {
+    await primeAuth(page, sharedSession);
+    await page.goto('/');
+    await expect(page.getByRole('link', { name: 'SmartScrape' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Home' })).toBeVisible();
+  });
+
+  test('empty states: Jobs + Notifications', async ({ page, sharedSession }) => {
+    await primeAuth(page, sharedSession);
+
+    await page.goto('/jobs');
+    await expect(page.getByText(/No jobs yet/i)).toBeVisible();
+
+    await page.goto('/notifications');
+    await expect(page.getByText(/No notifications yet/i)).toBeVisible();
+  });
+
+  test('dark mode toggle persists across reload', async ({ page, sharedSession }) => {
+    await primeAuth(page, sharedSession);
+    await page.goto('/');
+
+    await page.locator('header button').last().click();
+    await page.getByRole('button', { name: 'Dark', exact: true }).click();
+    await expect(page.locator('html')).toHaveClass(/dark/);
+
+    await page.reload();
+    await expect(page.locator('html')).toHaveClass(/dark/);
+
+    // Reset so later tests don't see dark class (cosmetic only).
+    await page.locator('header button').last().click();
+    await page.getByRole('button', { name: 'System', exact: true }).click();
+  });
+
+  test('JobForm exposes scrape method + full notification rule palette', async ({ page, sharedSession }) => {
+    await primeAuth(page, sharedSession);
+    await page.goto('/jobs/new');
+
+    // NewJob boots in wizard mode; flip to the manual form where the full field
+    // palette is visible.
+    await page.getByRole('button', { name: /Manual setup/i }).click();
+
+    // Labels aren't htmlFor-associated, so assert on visible text + nearby select.
+    await expect(page.getByText('Scrape method', { exact: true })).toBeVisible();
+    // The scrape-method <select> is the one with the distinctive Cheerio option.
+    await expect(page.locator('select').filter({ hasText: 'Cheerio only (static)' })).toBeVisible();
+
+    await page.getByRole('button', { name: /Add notification rule/i }).click();
+    const ruleSelect = page.locator('select').filter({ hasText: 'Any change' }).first();
+    const options = await ruleSelect.locator('option').allTextContents();
+    expect(options).toEqual(
+      expect.arrayContaining([
+        'Any change',
+        'New items appear',
+        'Items disappear',
+        'Field crosses threshold',
+        'Field value changes',
+      ]),
+    );
+  });
+
+  test('XSS: script in job name renders as text, never executes', async ({ page, request, sharedSession }) => {
+    // React escapes text nodes automatically, but we verify end-to-end. The
+    // <img onerror> payload is chosen so any mis-handling would actually run
+    // and flip a flag on window.
+    const xssName = `<img src=x onerror="window.__xssTriggered=true">XSS-E2E`;
+    await createJob(request, sharedSession.accessToken, { name: xssName });
+
+    await primeAuth(page, sharedSession);
+    await page.goto('/jobs');
+    await page.waitForSelector('text=XSS-E2E');
+    const triggered = await page.evaluate(() => (window as unknown as { __xssTriggered?: boolean }).__xssTriggered);
+    expect(triggered).toBeFalsy();
+
+    // If the angle-brackets were rendered as HTML, we'd have an <img> in the DOM.
+    const imgs = await page.locator('main img').count();
+    expect(imgs).toBe(0);
+  });
+
+  test('Push to Sheets button: hidden without a sheet, visible with one', async ({ page, request, sharedSession }) => {
+    const jobNoSheet = await createJob(request, sharedSession.accessToken, { name: 'No-sheet job' });
+    const jobWithSheet = await createJob(request, sharedSession.accessToken, {
+      name: 'Sheet-linked job',
+      google_sheet_id: 'FAKE_SHEET_ID_FOR_VISIBILITY_TEST',
+    });
+
+    await primeAuth(page, sharedSession);
+
+    await page.goto(`/jobs/${jobNoSheet}`);
+    await expect(page.getByRole('button', { name: 'Run now' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Push to Sheets' })).toHaveCount(0);
+
+    await page.goto(`/jobs/${jobWithSheet}`);
+    await expect(page.getByRole('button', { name: 'Push to Sheets' })).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "zustand": "^5.0.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1321,6 +1322,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/server/src/middleware/rateLimit.ts
+++ b/server/src/middleware/rateLimit.ts
@@ -6,6 +6,11 @@ function handler(_req: Request, res: Response): void {
   res.status(429).json(fail('RATE_LIMITED', 'Too many requests, please try again later.'));
 }
 
+// Escape hatch for e2e tests. Opt-in via env so it never silently weakens
+// production. Set SKIP_RATE_LIMIT=1 when running Playwright so the shared
+// session fixture doesn't trip the auth-entry limiter.
+const skip = (): boolean => process.env.SKIP_RATE_LIMIT === '1';
+
 /** 5 requests per minute per IP. Auth-entry routes (login, register, forgot-password). */
 export const authEntryLimiter = rateLimit({
   windowMs: 60 * 1000,
@@ -13,6 +18,7 @@ export const authEntryLimiter = rateLimit({
   standardHeaders: 'draft-7',
   legacyHeaders: false,
   handler,
+  skip,
 });
 
 /** 100 requests per minute per IP. Default for other API routes. */
@@ -22,4 +28,5 @@ export const generalLimiter = rateLimit({
   standardHeaders: 'draft-7',
   legacyHeaders: false,
   handler,
+  skip,
 });


### PR DESCRIPTION
Closes #53.

## Summary
- Playwright smoke suite under `client/tests/e2e`: session/empty states, dark mode persistence, XSS render safety, Push to Sheets visibility, JobForm field palette, mobile @ 393px no-overflow
- `fix(client)`: TopNav was overflowing 60px at mobile width — caught by the new mobile spec. Nav now shrinks + scrolls internally; logo and user menu are `shrink-0`.
- `feat(rate-limit)`: `SKIP_RATE_LIMIT=1` env escape hatch so the shared-session fixture doesn't trip the 5/min auth-entry limiter (off by default).

Not wired into CI: needs a running Postgres + Redis + dev server. Run locally with:
```
npm run dev       # one terminal
npm run test:e2e --workspace client   # another
```

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test:e2e --workspace client` → 7 passed (6 desktop + 1 mobile)
- [ ] Manual check: load the app on a phone — header nav scrolls horizontally inside its own region, no page-level scrollbar