### PR TITLE
fix: per-user rate limits + CORS 403 + secret-guard floor + Sheets push limit

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,16 +32,30 @@ app.use(helmet({ contentSecurityPolicy: false, crossOriginEmbedderPolicy: false 
 
 // CORS is locked to APP_URL. Server-to-server callers (no Origin header) and
 // the Google OAuth redirect (same-origin to API) are allowed through.
+// `cb(null, false)` blocks without throwing — the disallowed-origin response
+// is handled below as a clean 403 with our standard envelope.
 app.use(
   cors({
     origin: (origin, cb) => {
       if (!origin) return cb(null, true);
       if (origin === env.appUrl) return cb(null, true);
-      return cb(new Error(`CORS: origin not allowed: ${origin}`));
+      return cb(null, false);
     },
     credentials: true,
   }),
 );
+
+// Explicit reject for cross-origin requests so the client gets a 403 with the
+// standard envelope instead of a CORS-failed fetch the browser can't surface.
+// Same-origin requests have no Origin header and skip this entirely.
+app.use((req, res, next) => {
+  const origin = req.headers.origin;
+  if (origin && origin !== env.appUrl) {
+    res.status(403).json(fail('CORS_FORBIDDEN', `Origin not allowed: ${origin}`));
+    return;
+  }
+  next();
+});
 
 app.use(express.json({ limit: '1mb' }));
 app.use(cookieParser());

--- a/server/src/middleware/rateLimit.ts
+++ b/server/src/middleware/rateLimit.ts
@@ -11,6 +11,22 @@ function handler(_req: Request, res: Response): void {
 // session fixture doesn't trip the auth-entry limiter.
 const skip = (): boolean => process.env.SKIP_RATE_LIMIT === '1';
 
+/**
+ * Use the authenticated user's id as the rate-limit key when the request has
+ * been through requireAuth, otherwise fall back to the IP. With `trust proxy
+ * = 1` the IP is spoofable behind anything other than a single trusted proxy,
+ * so for authenticated routes we strongly prefer the userId.
+ *
+ * IPv6 addresses are normalised by Express's `req.ip` already; we don't try
+ * to bucket /64 subnets here because the per-IP limiter is a fallback for
+ * unauth flows, not the primary defense once we have a userId.
+ */
+function userOrIp(req: Request): string {
+  const userId = (req as Request & { user?: { id?: string } }).user?.id;
+  if (userId) return `u:${userId}`;
+  return `ip:${req.ip ?? 'unknown'}`;
+}
+
 /** 5 requests per minute per IP. Auth-entry routes (login, register, forgot-password). */
 export const authEntryLimiter = rateLimit({
   windowMs: 60 * 1000,
@@ -21,12 +37,56 @@ export const authEntryLimiter = rateLimit({
   skip,
 });
 
-/** 100 requests per minute per IP. Default for other API routes. */
+/** 100 requests per minute per IP. Default for other API routes (mounted before auth). */
 export const generalLimiter = rateLimit({
   windowMs: 60 * 1000,
   limit: 100,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
+  handler,
+  skip,
+});
+
+/** 100 requests per minute per authenticated user. Mount AFTER requireAuth. */
+export const userGeneralLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 100,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  keyGenerator: userOrIp,
+  handler,
+  skip,
+});
+
+/** 10 requests per minute per user. AI setup wizard. */
+export const aiSetupLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 10,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  keyGenerator: userOrIp,
+  handler,
+  skip,
+});
+
+/** 20 manual run triggers per hour per user (in addition to the 100/24h quota). */
+export const runTriggerLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  limit: 20,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  keyGenerator: userOrIp,
+  handler,
+  skip,
+});
+
+/** 10 manual Sheets pushes per minute per user — keeps Google's quota safe. */
+export const sheetsPushLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 10,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  keyGenerator: userOrIp,
   handler,
   skip,
 });

--- a/server/src/routes/dashboard.ts
+++ b/server/src/routes/dashboard.ts
@@ -2,9 +2,11 @@ import { Router } from 'express';
 import { getPool } from '../config/database.js';
 import { ok } from '../lib/response.js';
 import { requireAuth } from '../middleware/auth.js';
+import { userGeneralLimiter } from '../middleware/rateLimit.js';
 
 export const dashboardRouter = Router();
 dashboardRouter.use(requireAuth);
+dashboardRouter.use(userGeneralLimiter);
 
 dashboardRouter.get('/stats', async (req, res) => {
   const userId = req.user!.id;

--- a/server/src/routes/jobs.ts
+++ b/server/src/routes/jobs.ts
@@ -6,6 +6,12 @@ import { fail, ok } from '../lib/response.js';
 import { requireAuth } from '../middleware/auth.js';
 import { validate } from '../middleware/validate.js';
 import {
+  aiSetupLimiter,
+  runTriggerLimiter,
+  sheetsPushLimiter,
+  userGeneralLimiter,
+} from '../middleware/rateLimit.js';
+import {
   createJob,
   deleteJob,
   findJob,
@@ -30,6 +36,8 @@ import { getPool } from '../config/database.js';
 
 export const jobsRouter = Router();
 jobsRouter.use(requireAuth);
+// Per-user general cap (100/min). Specific routes layer tighter limits below.
+jobsRouter.use(userGeneralLimiter);
 
 // ---------- schemas ----------
 
@@ -154,7 +162,7 @@ async function resolveProviderKey(
   }
 }
 
-jobsRouter.post('/ai-setup', validate(aiSetupBody), async (req, res) => {
+jobsRouter.post('/ai-setup', aiSetupLimiter, validate(aiSetupBody), async (req, res) => {
   const body = req.body as z.infer<typeof aiSetupBody>;
   const safety = await assertSafeUrl(body.url);
   if (!safety.ok) {
@@ -194,7 +202,7 @@ jobsRouter.post('/ai-setup', validate(aiSetupBody), async (req, res) => {
   );
 });
 
-jobsRouter.post('/ai-setup/preview', validate(aiPreviewBody), async (req, res) => {
+jobsRouter.post('/ai-setup/preview', aiSetupLimiter, validate(aiPreviewBody), async (req, res) => {
   const body = req.body as z.infer<typeof aiPreviewBody>;
   const safety = await assertSafeUrl(body.url);
   if (!safety.ok) {
@@ -326,7 +334,7 @@ jobsRouter.delete('/:id', validate(idParam, 'params'), async (req, res) => {
   res.status(200).json(ok({ removed: true }));
 });
 
-jobsRouter.post('/:id/run', validate(idParam, 'params'), async (req, res) => {
+jobsRouter.post('/:id/run', runTriggerLimiter, validate(idParam, 'params'), async (req, res) => {
   const { id } = req.params as unknown as z.infer<typeof idParam>;
   const job = await findJob(req.user!.id, id);
   if (!job) {
@@ -391,7 +399,7 @@ jobsRouter.get('/:id/export/csv/:runId', async (req, res) => {
   await sendCsvForRun(res, id, runId, req.user!.id, job.name);
 });
 
-jobsRouter.post('/:id/export/sheets', validate(idParam, 'params'), async (req, res) => {
+jobsRouter.post('/:id/export/sheets', sheetsPushLimiter, validate(idParam, 'params'), async (req, res) => {
   const { id } = req.params as unknown as z.infer<typeof idParam>;
   const job = await findJob(req.user!.id, id);
   if (!job) {

--- a/server/src/routes/notifications.ts
+++ b/server/src/routes/notifications.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { fail, ok } from '../lib/response.js';
 import { requireAuth } from '../middleware/auth.js';
 import { validate } from '../middleware/validate.js';
+import { userGeneralLimiter } from '../middleware/rateLimit.js';
 import { findUserById } from '../db/users.js';
 import { listNotifications } from '../db/notifications.js';
 import { sendEmail } from '../services/email.js';
@@ -10,6 +11,7 @@ import { sendTelegram, getBotSetupInfo } from '../services/telegram.js';
 
 export const notificationsRouter = Router();
 notificationsRouter.use(requireAuth);
+notificationsRouter.use(userGeneralLimiter);
 
 const listQuery = z.object({
   limit: z.coerce.number().int().min(1).max(200).optional(),

--- a/server/src/routes/providers.ts
+++ b/server/src/routes/providers.ts
@@ -5,6 +5,7 @@ import { deleteForUser, findForUser, listByUser, PROVIDERS, upsertForUser } from
 import { fail, ok } from '../lib/response.js';
 import { requireAuth } from '../middleware/auth.js';
 import { validate } from '../middleware/validate.js';
+import { userGeneralLimiter } from '../middleware/rateLimit.js';
 import { testCredentials } from '../services/ai-providers.js';
 
 export const providersRouter = Router();
@@ -21,6 +22,7 @@ const providerParams = z.object({
 });
 
 providersRouter.use(requireAuth);
+providersRouter.use(userGeneralLimiter);
 
 providersRouter.get('/', async (req, res) => {
   const rows = await listByUser(req.user!.id);

--- a/server/src/routes/runs.ts
+++ b/server/src/routes/runs.ts
@@ -3,11 +3,13 @@ import { z } from 'zod';
 import { fail, ok } from '../lib/response.js';
 import { requireAuth } from '../middleware/auth.js';
 import { validate } from '../middleware/validate.js';
+import { userGeneralLimiter } from '../middleware/rateLimit.js';
 import { findRun, listDataForRun, toDTO as toRunDTO } from '../db/runs.js';
 import { diffRun } from '../services/change-detector.js';
 
 export const runsRouter = Router();
 runsRouter.use(requireAuth);
+runsRouter.use(userGeneralLimiter);
 
 const idParam = z.object({ id: z.string().uuid() });
 

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -4,9 +4,11 @@ import { listForUser, upsertMany } from '../db/settings.js';
 import { ok } from '../lib/response.js';
 import { requireAuth } from '../middleware/auth.js';
 import { validate } from '../middleware/validate.js';
+import { userGeneralLimiter } from '../middleware/rateLimit.js';
 
 export const settingsRouter = Router();
 settingsRouter.use(requireAuth);
+settingsRouter.use(userGeneralLimiter);
 
 // Free-form key/value bag, but bound the size of each side so a single bad
 // request can't fill the column. Keys mirror env-style identifiers.

--- a/server/src/services/ai-extractor.ts
+++ b/server/src/services/ai-extractor.ts
@@ -167,11 +167,14 @@ export async function extract(args: ExtractArgs): Promise<ExtractResult> {
           }
         }
       }
-      // Secret leak check
+      // Secret leak check. Skip guards shorter than 16 chars to avoid false
+      // positives — a 6-char placeholder can incidentally match scraped text.
+      // Real provider keys + emails are well above this floor.
       if (args.secretGuards && args.secretGuards.length > 0) {
         const serialized = JSON.stringify(items);
         for (const secret of args.secretGuards) {
-          if (secret && serialized.includes(secret)) {
+          if (!secret || secret.length < 16) continue;
+          if (serialized.includes(secret)) {
             return {
               ok: false,
               error: 'Extracted data contained restricted values; suspected prompt injection.',


### PR DESCRIPTION
Closes #61.

## Summary
- **Per-user rate limiters** — HANDOFF parity. New `userGeneralLimiter` (100/min/user) on every authed router; `aiSetupLimiter` (10/min/user) on `/jobs/ai-setup*`; `runTriggerLimiter` (20/h/user) on `/jobs/:id/run`; `sheetsPushLimiter` (10/min/user) on manual Sheets push.
- **CORS deny path** is now a clean 403 with our standard envelope instead of a thrown 500.
- **Secret-guard min-length floor (16)** — short stored test keys can no longer cause false-positive injection rejections.

## Test plan
- [ ] `npm run typecheck` + `npm run lint` pass
- [ ] Hit `/api/jobs/ai-setup` 11 times in a minute → 11th returns 429 `RATE_LIMITED`
- [ ] Hit `/api/jobs/<id>/run` 21 times in an hour → 21st returns 429
- [ ] CORS: `curl -H 'Origin: http://evil.example' http://localhost:3000/api/health` → 403, not 500
- [ ] CORS: same request without Origin header → 200
- [ ] Stored a real provider key + scraped a page that contains the key string → run still fails with secret-leak; stored a 6-char placeholder → run succeeds even if the placeholder appears in scraped text