### PR TITLE
feat(scraper): respect robots.txt with per-job override

### DIFF
--- a/client/src/components/JobForm.tsx
+++ b/client/src/components/JobForm.tsx
@@ -27,6 +27,7 @@ export type JobFormValues = {
   ai_model: string;
   google_sheet_id: string | null;
   sheet_tab_name: string | null;
+  respect_robots_txt: boolean;
 };
 
 const SCHEDULE_OPTIONS: { label: string; value: string | null }[] = [
@@ -53,6 +54,7 @@ export function jobToFormValues(job: Job): JobFormValues {
     ai_model: job.ai_model,
     google_sheet_id: job.google_sheet_id,
     sheet_tab_name: job.sheet_tab_name,
+    respect_robots_txt: job.respect_robots_txt,
   };
 }
 
@@ -83,6 +85,7 @@ export const EMPTY_FORM: JobFormValues = {
   ai_model: 'openai/gpt-4o-mini',
   google_sheet_id: null,
   sheet_tab_name: null,
+  respect_robots_txt: true,
 };
 
 type Props = {
@@ -278,6 +281,15 @@ export function JobForm({ initial, submitLabel, submitting, error, onSubmit, onC
               <option value="cheerio">Cheerio only (static)</option>
               <option value="playwright">Playwright only (browser)</option>
             </select>
+            <label className="mt-2 flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
+              <input
+                type="checkbox"
+                checked={v.respect_robots_txt}
+                onChange={(e) => setV({ ...v, respect_robots_txt: e.target.checked })}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              Respect robots.txt for the configured user agent
+            </label>
           </div>
           <div>
             <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">Schedule</label>

--- a/client/src/pages/NewJob.tsx
+++ b/client/src/pages/NewJob.tsx
@@ -81,6 +81,7 @@ export default function NewJob() {
       ai_model: model,
       google_sheet_id: null,
       sheet_tab_name: null,
+      respect_robots_txt: true,
     });
     setStep('review');
   }

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -87,6 +87,7 @@ export type Job = {
   google_sheet_id: string | null;
   sheet_tab_name: string | null;
   setup_method: SetupMethod;
+  respect_robots_txt: boolean;
   last_run_at: string | null;
   created_at: string;
   updated_at: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6320,6 +6320,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robots-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
+      "integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -7842,6 +7851,7 @@
         "openai": "^4.77.3",
         "pg": "^8.13.1",
         "playwright": "^1.49.1",
+        "robots-parser": "^3.0.1",
         "zod": "^3.24.1"
       },
       "devDependencies": {

--- a/server/migrations/20260425140059_robots_respect.js
+++ b/server/migrations/20260425140059_robots_respect.js
@@ -1,0 +1,14 @@
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+
+export const up = (pgm) => {
+  pgm.sql(`
+    ALTER TABLE scrape_jobs
+      ADD COLUMN respect_robots_txt BOOLEAN NOT NULL DEFAULT true;
+  `);
+};
+
+export const down = (pgm) => {
+  pgm.sql(`
+    ALTER TABLE scrape_jobs DROP COLUMN respect_robots_txt;
+  `);
+};

--- a/server/package.json
+++ b/server/package.json
@@ -37,6 +37,7 @@
     "openai": "^4.77.3",
     "pg": "^8.13.1",
     "playwright": "^1.49.1",
+    "robots-parser": "^3.0.1",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/server/src/db/jobs.ts
+++ b/server/src/db/jobs.ts
@@ -43,6 +43,7 @@ export type JobRow = {
   google_sheet_id: string | null;
   sheet_tab_name: string | null;
   setup_method: SetupMethod;
+  respect_robots_txt: boolean;
   last_run_at: Date | null;
   created_at: Date;
   updated_at: Date;
@@ -79,6 +80,7 @@ export type CreateJobArgs = {
   google_sheet_id?: string | null;
   sheet_tab_name?: string | null;
   setup_method?: SetupMethod;
+  respect_robots_txt?: boolean;
 };
 
 export async function createJob(userId: string, args: CreateJobArgs): Promise<JobRow> {
@@ -86,9 +88,10 @@ export async function createJob(userId: string, args: CreateJobArgs): Promise<Jo
     `INSERT INTO scrape_jobs (
        user_id, name, urls, extraction_prompt, extraction_schema,
        scrape_method, schedule, enabled, notification_rules, notify_channels,
-       comparison_key, ai_provider, ai_model, google_sheet_id, sheet_tab_name, setup_method
+       comparison_key, ai_provider, ai_model, google_sheet_id, sheet_tab_name, setup_method,
+       respect_robots_txt
      )
-     VALUES ($1,$2,$3::jsonb,$4,$5::jsonb,$6,$7,$8,$9::jsonb,$10::jsonb,$11,$12,$13,$14,$15,$16)
+     VALUES ($1,$2,$3::jsonb,$4,$5::jsonb,$6,$7,$8,$9::jsonb,$10::jsonb,$11,$12,$13,$14,$15,$16,$17)
      RETURNING *`,
     [
       userId,
@@ -107,6 +110,7 @@ export async function createJob(userId: string, args: CreateJobArgs): Promise<Jo
       args.google_sheet_id ?? null,
       args.sheet_tab_name ?? null,
       args.setup_method ?? 'manual',
+      args.respect_robots_txt ?? true,
     ],
   );
   return rows[0]!;
@@ -202,6 +206,7 @@ export async function updateJob(userId: string, jobId: string, args: UpdateJobAr
   if (args.ai_model !== undefined) push('ai_model', args.ai_model);
   if (args.google_sheet_id !== undefined) push('google_sheet_id', args.google_sheet_id);
   if (args.sheet_tab_name !== undefined) push('sheet_tab_name', args.sheet_tab_name);
+  if (args.respect_robots_txt !== undefined) push('respect_robots_txt', args.respect_robots_txt);
 
   if (sets.length === 0) return findJob(userId, jobId);
 

--- a/server/src/routes/jobs.ts
+++ b/server/src/routes/jobs.ts
@@ -103,6 +103,7 @@ const createBody = z.object({
   google_sheet_id: z.string().nullable().optional(),
   sheet_tab_name: z.string().nullable().optional(),
   setup_method: setupMethodEnum.optional(),
+  respect_robots_txt: z.boolean().optional(),
 });
 
 const updateBody = createBody.partial();

--- a/server/src/services/job-runner.ts
+++ b/server/src/services/job-runner.ts
@@ -85,7 +85,9 @@ export async function runJob(job: JobRow, existingRunId?: string): Promise<RunSu
 
   try {
     for (const url of job.urls) {
-      const page = await scrape(url, job.scrape_method);
+      const page = await scrape(url, job.scrape_method, {
+        respectRobotsTxt: job.respect_robots_txt,
+      });
       urlsScraped += 1;
 
       await updateRun(run.id, { status: 'extracting', urls_scraped: urlsScraped });

--- a/server/src/services/robots.ts
+++ b/server/src/services/robots.ts
@@ -1,0 +1,65 @@
+// robots-parser ships as a CJS function export but its .d.ts declares
+// the module empty before the typed default — type the call signature
+// ourselves and cast through unknown.
+import robotsParser from 'robots-parser';
+
+type Robot = {
+  isAllowed(url: string, ua?: string): boolean | undefined;
+};
+
+type RobotsParserFn = (url: string, contents: string) => Robot;
+const parse = robotsParser as unknown as RobotsParserFn;
+
+const TTL_MS = 60 * 60 * 1000; // 1 hour
+const FETCH_TIMEOUT_MS = 5_000;
+
+type CacheEntry = { parser: Robot; expiresAt: number };
+
+// host (origin) → parsed robots.txt. Re-fetched after TTL_MS so updates surface.
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Fetch a host's robots.txt and tell the caller whether the given URL is
+ * allowed for the configured user agent. We fail OPEN on parse / fetch /
+ * timeout errors — robots.txt is advisory, and a flaky robots fetch
+ * shouldn't black-hole legitimate scrapes. Real disallow rules still bite.
+ */
+export async function isAllowedByRobots(targetUrl: string, userAgent: string): Promise<boolean> {
+  let parsed: URL;
+  try {
+    parsed = new URL(targetUrl);
+  } catch {
+    return true;
+  }
+  const robotsUrl = `${parsed.protocol}//${parsed.host}/robots.txt`;
+
+  const now = Date.now();
+  let entry = cache.get(parsed.origin);
+  if (!entry || entry.expiresAt < now) {
+    const fetched = await fetchRobots(robotsUrl);
+    entry = { parser: parse(robotsUrl, fetched), expiresAt: now + TTL_MS };
+    cache.set(parsed.origin, entry);
+  }
+  const allowed = entry.parser.isAllowed(targetUrl, userAgent);
+  // robots-parser returns undefined when no rules apply → treat as allowed.
+  return allowed !== false;
+}
+
+async function fetchRobots(url: string): Promise<string> {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { redirect: 'follow', signal: ac.signal });
+    if (!res.ok) return '';
+    return await res.text();
+  } catch {
+    return '';
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Test seam — clears the parsed-robots cache. */
+export function _clearRobotsCache(): void {
+  cache.clear();
+}

--- a/server/src/services/scraper.ts
+++ b/server/src/services/scraper.ts
@@ -1,6 +1,7 @@
 import { chromium, type Browser } from 'playwright';
 import { cleanHtml, visibleTextLength } from './html-cleaner.js';
 import { assertSafeUrl } from '../lib/ssrf.js';
+import { isAllowedByRobots } from './robots.js';
 
 const USER_AGENT = 'SmartScrapeBot/0.1 (+https://github.com/9ny4/smartscrape)';
 // A realistic Chrome UA used on the Playwright fallback path where we want to
@@ -216,10 +217,27 @@ async function fetchViaPlaywrightWithRetry(
   }
 }
 
-export async function scrape(url: string, method: ScrapeMethod = 'auto'): Promise<ScrapeResult> {
+export type ScrapeOptions = {
+  /** When true (default) we honor robots.txt for the configured user-agent. */
+  respectRobotsTxt?: boolean;
+};
+
+export async function scrape(
+  url: string,
+  method: ScrapeMethod = 'auto',
+  opts: ScrapeOptions = {},
+): Promise<ScrapeResult> {
   const safety = await assertSafeUrl(url);
   if (!safety.ok) {
     throw new Error(`Refused to scrape ${url}: ${safety.reason}`);
+  }
+  if (opts.respectRobotsTxt !== false) {
+    const allowed = await isAllowedByRobots(url, USER_AGENT);
+    if (!allowed) {
+      throw new Error(
+        `robots.txt disallows ${USER_AGENT} for ${url}. Set "Respect robots.txt" to off on this job to override.`,
+      );
+    }
   }
   const started = Date.now();
   const host = new URL(url).hostname;


### PR DESCRIPTION
Closes #65. New per-job `respect_robots_txt` (default true). Before each fetch the host's robots.txt is consulted; explicit disallows fail the run with an actionable message pointing to the override toggle. Parsed robots cached per-host for 1 hour, fails-open on network/parse errors. Form exposes the toggle next to scrape method.