### PR TITLE
fix: robots.txt SSRF, missing per-user limiters, email-aware guards

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -26,7 +26,7 @@ import { signAccessToken, REFRESH_TTL_MS } from '../lib/jwt.js';
 import { generateToken, hashToken } from '../lib/tokens.js';
 import { fail, ok } from '../lib/response.js';
 import { validate } from '../middleware/validate.js';
-import { authEntryLimiter } from '../middleware/rateLimit.js';
+import { authEntryLimiter, userGeneralLimiter } from '../middleware/rateLimit.js';
 import { requireAuth } from '../middleware/auth.js';
 import { sendEmail } from '../services/email.js';
 
@@ -217,7 +217,7 @@ authRouter.post('/reset-password', validate(resetPasswordSchema), async (req, re
   res.status(200).json(ok({ reset: true }));
 });
 
-authRouter.get('/me', requireAuth, async (req, res) => {
+authRouter.get('/me', requireAuth, userGeneralLimiter, async (req, res) => {
   const user = await findUserById(req.user!.id);
   if (!user) {
     res.status(404).json(fail('NOT_FOUND', 'User not found'));
@@ -226,7 +226,7 @@ authRouter.get('/me', requireAuth, async (req, res) => {
   res.status(200).json(ok({ user: toPublic(user) }));
 });
 
-authRouter.patch('/me', requireAuth, validate(updateProfileSchema), async (req, res) => {
+authRouter.patch('/me', requireAuth, userGeneralLimiter, validate(updateProfileSchema), async (req, res) => {
   const input = req.body as z.infer<typeof updateProfileSchema>;
   const updated = await updateProfile(req.user!.id, {
     name: input.name,
@@ -235,7 +235,7 @@ authRouter.patch('/me', requireAuth, validate(updateProfileSchema), async (req, 
   res.status(200).json(ok({ user: toPublic(updated) }));
 });
 
-authRouter.delete('/me', requireAuth, async (req, res) => {
+authRouter.delete('/me', requireAuth, userGeneralLimiter, async (req, res) => {
   await revokeAllForUser(req.user!.id);
   await deleteUser(req.user!.id);
   res.status(200).json(ok({ deleted: true }));

--- a/server/src/routes/google.ts
+++ b/server/src/routes/google.ts
@@ -3,6 +3,7 @@ import { env } from '../config/env.js';
 import { deleteConnection, findConnection } from '../db/googleConnections.js';
 import { fail, ok } from '../lib/response.js';
 import { requireAuth } from '../middleware/auth.js';
+import { userGeneralLimiter } from '../middleware/rateLimit.js';
 import { z } from 'zod';
 import {
   buildAuthUrl,
@@ -21,7 +22,7 @@ const NONCE_COOKIE_MAX_AGE_MS = 10 * 60 * 1000; // matches state expiry
 
 export const googleRouter = Router();
 
-googleRouter.get('/status', requireAuth, async (req, res) => {
+googleRouter.get('/status', requireAuth, userGeneralLimiter,async (req, res) => {
   const conn = await findConnection(req.user!.id);
   res.status(200).json(
     ok({
@@ -33,7 +34,7 @@ googleRouter.get('/status', requireAuth, async (req, res) => {
   );
 });
 
-googleRouter.get('/connect', requireAuth, (req, res) => {
+googleRouter.get('/connect', requireAuth, userGeneralLimiter,(req, res) => {
   if (!isConfigured()) {
     res.status(400).json(fail('NOT_CONFIGURED', 'Google OAuth is not configured on this server'));
     return;
@@ -100,7 +101,7 @@ googleRouter.get('/callback', async (req, res) => {
   }
 });
 
-googleRouter.delete('/disconnect', requireAuth, async (req, res) => {
+googleRouter.delete('/disconnect', requireAuth, userGeneralLimiter,async (req, res) => {
   await revokeConnection(req.user!.id);
   await deleteConnection(req.user!.id);
   res.status(200).json(ok({ disconnected: true }));
@@ -111,6 +112,7 @@ const sheetsListQuery = z.object({ q: z.string().max(200).optional() });
 googleRouter.get(
   '/sheets',
   requireAuth,
+  userGeneralLimiter,
   validate(sheetsListQuery, 'query'),
   async (req, res) => {
     const conn = await findConnection(req.user!.id);

--- a/server/src/services/ai-extractor.ts
+++ b/server/src/services/ai-extractor.ts
@@ -4,6 +4,16 @@ import type { Provider } from '../db/apiKeys.js';
 
 export type ExtractionSchema = Record<string, 'string' | 'number' | 'boolean' | 'array' | 'object'>;
 
+/**
+ * Two flavours of leak guard:
+ *   - `apiKeyGuards`: long, high-entropy strings (provider keys, tokens). We
+ *     length-floor these to 16 chars so a short test/placeholder key can't
+ *     cause false-positive injection rejections by appearing as a substring
+ *     of legitimately-scraped text.
+ *   - `emailGuards`: user emails, which can be as short as `a@b.co`. The `@`
+ *     plus dot in the local form makes false positives vanishingly unlikely,
+ *     so no floor is applied — short emails still get exact-substring guarded.
+ */
 export type ExtractArgs = {
   provider: Provider;
   apiKey: string;
@@ -11,11 +21,13 @@ export type ExtractArgs = {
   cleanedHtml: string;
   extractionPrompt: string;
   extractionSchema?: ExtractionSchema;
-  /** Values we refuse to echo (stored secrets, the user's email, etc). */
-  secretGuards?: string[];
+  apiKeyGuards?: string[];
+  emailGuards?: string[];
   /** Cap for each extracted item's serialized size, default 16 KB. */
   itemSizeCap?: number;
 };
+
+const API_KEY_GUARD_MIN_LENGTH = 16;
 
 export type ExtractResult =
   | { ok: true; items: Record<string, unknown>[]; usage: ChatUsage; rawText: string }
@@ -167,13 +179,19 @@ export async function extract(args: ExtractArgs): Promise<ExtractResult> {
           }
         }
       }
-      // Secret leak check. Skip guards shorter than 16 chars to avoid false
-      // positives — a 6-char placeholder can incidentally match scraped text.
-      // Real provider keys + emails are well above this floor.
-      if (args.secretGuards && args.secretGuards.length > 0) {
+      // Secret leak check. API keys are length-floored (16) to avoid
+      // false-positive matches on short placeholders; emails are not floored
+      // because the @-and-dot pattern keeps false-positive risk near zero.
+      const guards: string[] = [];
+      for (const k of args.apiKeyGuards ?? []) {
+        if (k && k.length >= API_KEY_GUARD_MIN_LENGTH) guards.push(k);
+      }
+      for (const e of args.emailGuards ?? []) {
+        if (e) guards.push(e);
+      }
+      if (guards.length > 0) {
         const serialized = JSON.stringify(items);
-        for (const secret of args.secretGuards) {
-          if (!secret || secret.length < 16) continue;
+        for (const secret of guards) {
           if (serialized.includes(secret)) {
             return {
               ok: false,

--- a/server/src/services/job-runner.ts
+++ b/server/src/services/job-runner.ts
@@ -60,17 +60,17 @@ export async function runJob(job: JobRow, existingRunId?: string): Promise<RunSu
     return { runId: run.id, jobId: job.id, status: 'failed', itemsExtracted: 0, tokensUsed: 0, error: err };
   }
 
-  // Build the secret guard list once per run: any value that surfacing in AI
-  // output would suggest a prompt-injection compromise. Includes the user's
-  // email and every stored provider key, regardless of which one is used.
-  const secretGuards: string[] = [];
+  // Build the leak-guard lists once per run. Split by type so the API-key
+  // length floor doesn't disable email detection for short addresses.
+  const apiKeyGuards: string[] = [];
+  const emailGuards: string[] = [];
   const user = await findUserById(job.user_id);
-  if (user?.email) secretGuards.push(user.email);
+  if (user?.email) emailGuards.push(user.email);
   for (const p of PROVIDERS) {
     const row = await findApiKey(job.user_id, p);
     if (!row) continue;
     try {
-      secretGuards.push(decrypt(row.api_key_encrypted));
+      apiKeyGuards.push(decrypt(row.api_key_encrypted));
     } catch {
       // ignore — un-decryptable keys can't leak
     }
@@ -99,7 +99,8 @@ export async function runJob(job: JobRow, existingRunId?: string): Promise<RunSu
         cleanedHtml: page.cleaned,
         extractionPrompt: job.extraction_prompt,
         extractionSchema: job.extraction_schema ?? undefined,
-        secretGuards,
+        apiKeyGuards,
+        emailGuards,
       });
 
       if (!result.ok) {

--- a/server/src/services/robots.ts
+++ b/server/src/services/robots.ts
@@ -2,6 +2,7 @@
 // the module empty before the typed default — type the call signature
 // ourselves and cast through unknown.
 import robotsParser from 'robots-parser';
+import { assertSafeUrl } from '../lib/ssrf.js';
 
 type Robot = {
   isAllowed(url: string, ua?: string): boolean | undefined;
@@ -12,6 +13,8 @@ const parse = robotsParser as unknown as RobotsParserFn;
 
 const TTL_MS = 60 * 60 * 1000; // 1 hour
 const FETCH_TIMEOUT_MS = 5_000;
+const MAX_ROBOTS_BYTES = 512 * 1024; // 512 KB — robots.txt above this is pathological
+const MAX_REDIRECTS = 5;
 
 type CacheEntry = { parser: Robot; expiresAt: number };
 
@@ -45,13 +48,49 @@ export async function isAllowedByRobots(targetUrl: string, userAgent: string): P
   return allowed !== false;
 }
 
+/**
+ * Fetch robots.txt with the same SSRF discipline as the main scraper:
+ *   - manual redirect handling, re-validate every hop with assertSafeUrl
+ *   - cap body size so a malicious robots.txt can't DoS us
+ *
+ * Without this, a public site whose /robots.txt 302s to http://169.254.169.254/
+ * would let the robots fetch reach the metadata endpoint even though the
+ * scraper proper now refuses redirects to private IPs.
+ */
 async function fetchRobots(url: string): Promise<string> {
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), FETCH_TIMEOUT_MS);
   try {
-    const res = await fetch(url, { redirect: 'follow', signal: ac.signal });
-    if (!res.ok) return '';
-    return await res.text();
+    let currentUrl = url;
+    let res: Response | undefined;
+    for (let hop = 0; hop < MAX_REDIRECTS; hop++) {
+      const safety = await assertSafeUrl(currentUrl);
+      if (!safety.ok) return '';
+      res = await fetch(currentUrl, { redirect: 'manual', signal: ac.signal });
+      if (res.status >= 300 && res.status < 400) {
+        const next = res.headers.get('location');
+        if (!next) break;
+        currentUrl = new URL(next, currentUrl).toString();
+        continue;
+      }
+      break;
+    }
+    if (!res || !res.ok || !res.body) return '';
+    const reader = res.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > MAX_ROBOTS_BYTES) {
+        void reader.cancel();
+        return '';
+      }
+      chunks.push(value);
+    }
+    return Buffer.concat(chunks.map((c) => Buffer.from(c.buffer, c.byteOffset, c.byteLength))).toString('utf8');
   } catch {
     return '';
   } finally {


### PR DESCRIPTION
Closes #67. Round 3 of post-review hardening.

## Summary
- **robots.txt redirect-safe + size-capped.** Same discipline as #60's main fetch — manual redirects, assertSafeUrl per hop, 512 KB body cap, fail-open on errors. Closes the gap where a public site's /robots.txt could 302 to a private IP.
- **Per-user limiter on Google + auth /me.** Trust-proxy=1 makes IP spoofable, so the user-keyed limiter is the real defense.
- **Split leak guards.** apiKeyGuards keep the 16-char floor (false-positive risk on short placeholders); emailGuards skip the floor (the @+dot pattern keeps false-positive rate near zero, so short emails like `a@b.co` are now actually guarded).

## Test plan
- [ ] CI green (verify, audit, migrations, e2e)
- [ ] `npm audit --audit-level=moderate` reports 0 vulnerabilities
- [ ] Manual: a controlled host whose /robots.txt 302s to http://127.0.0.1 → robots check returns "" (fail-open), scrape proceeds without reaching localhost
- [ ] Manual: register an account with a 6-char email → scrape a page containing that email → run fails with "restricted values; suspected prompt injection"
- [ ] Manual: hit GET /api/google/status 101 times in a minute → 101st returns 429