### PR TITLE
build: enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Normalize text files to LF in the repo, regardless of the contributor's
+# core.autocrlf setting. Prettier/EditorConfig expect LF; without this rule
+# Windows checkouts get CRLF and `npm run format:check` fails locally even
+# though CI is green. Binaries below are explicitly excluded so they don't
+# get text-treated.
+
+* text=auto eol=lf
+
+# Binary
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.pdf   binary
+*.zip   binary
+*.gz    binary
+*.woff  binary
+*.woff2 binary


### PR DESCRIPTION
Closes #71. Adds `.gitattributes` with `* text=auto eol=lf` so Windows contributors with `core.autocrlf=true` don't get CRLF on disk that breaks local `npm run format:check`. Binaries explicitly excluded. Existing Windows working trees need a one-time `git rm --cached -r . && git reset --hard` to pick up the change.