### PR TITLE
test: vitest unit suite for ssrf, cron, csv, ai-extractor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - run: npm run format:check
       - run: npm run lint
       - run: npm run typecheck
+      - run: npm run test --workspace server
       - run: npm run build
 
   audit:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1680,6 +1680,13 @@
       "resolved": "server",
       "link": true
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1745,6 +1752,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -1771,6 +1789,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2187,6 +2212,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2350,6 +2488,16 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2677,6 +2825,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3265,6 +3423,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3586,6 +3751,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3612,6 +3787,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -4856,6 +5041,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5363,6 +5558,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -5602,6 +5808,13 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg": {
@@ -6617,6 +6830,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6648,6 +6868,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -6662,6 +6889,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -6812,6 +7046,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -6827,6 +7078,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7622,6 +7883,96 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -7694,6 +8045,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -7862,7 +8230,8 @@
         "@types/nodemailer": "^6.4.17",
         "@types/pg": "^8.11.10",
         "tsx": "^4.19.2",
-        "typescript": "^5.7.3"
+        "typescript": "^5.7.3",
+        "vitest": "^4.1.5"
       }
     },
     "server/node_modules/cron-parser": {

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,8 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.scripts.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "migrate": "node --import tsx/esm scripts/migrate.ts",
     "migrate:up": "npm run migrate -- up",
     "migrate:down": "npm run migrate -- down",
@@ -48,6 +50,7 @@
     "@types/nodemailer": "^6.4.17",
     "@types/pg": "^8.11.10",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/server/src/lib/cron.test.ts
+++ b/server/src/lib/cron.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { validateCron } from './cron.js';
+
+describe('validateCron', () => {
+  it.each([
+    '0 9 * * *', // daily at 09:00
+    '0 * * * *', // hourly
+    '*/5 * * * *', // every 5 minutes
+    '0 0 1 * *', // monthly
+    '0 9 * * 1', // weekly on Monday
+  ])('accepts %s', (expr) => {
+    expect(validateCron(expr).ok).toBe(true);
+  });
+
+  it.each(['', 'definitely not cron', '60 * * * *', 'every-minute', '* * *'])(
+    'rejects invalid expression %s',
+    (expr) => {
+      const r = validateCron(expr);
+      expect(r.ok).toBe(false);
+    },
+  );
+
+  it('rejects schedules that fire faster than the 60s floor', () => {
+    // Six fields = seconds-precision cron. Every-second.
+    const r = validateCron('* * * * * *');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toMatch(/too frequently/i);
+      expect(r.reason).toMatch(/60s/);
+    }
+  });
+
+  it('accepts every-minute (the boundary)', () => {
+    expect(validateCron('* * * * *').ok).toBe(true);
+  });
+
+  it('reason field is populated on rejection', () => {
+    const r = validateCron('not cron');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason.length).toBeGreaterThan(0);
+  });
+});

--- a/server/src/lib/cron.ts
+++ b/server/src/lib/cron.ts
@@ -10,6 +10,12 @@ export type CronCheckResult = { ok: true } | { ok: false; reason: string };
  * flood BullMQ and drain provider quota.
  */
 export function validateCron(expr: string): CronCheckResult {
+  // The route layer treats empty/null as "no schedule". Anything that reaches
+  // validateCron should be a real expression — reject empty explicitly so the
+  // function can't be silently called with no input.
+  if (typeof expr !== 'string' || expr.trim().length === 0) {
+    return { ok: false, reason: 'Invalid cron' };
+  }
   let it: ReturnType<typeof CronExpressionParser.parse>;
   try {
     it = CronExpressionParser.parse(expr);

--- a/server/src/lib/csv.test.ts
+++ b/server/src/lib/csv.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { toCsv } from './csv.js';
+
+describe('toCsv', () => {
+  it('returns empty string for no rows', () => {
+    expect(toCsv([])).toBe('');
+  });
+
+  it('writes a header row from union of keys in the first peek rows', () => {
+    const out = toCsv([{ a: 1, b: 2 }]);
+    const lines = out.split('\r\n');
+    expect(lines[0]).toBe('a,b');
+    expect(lines[1]).toBe('1,2');
+  });
+
+  it('quotes values that contain commas, quotes, or newlines', () => {
+    const out = toCsv([{ s: 'a,b' }, { s: 'with "quote"' }, { s: 'two\nlines' }]);
+    expect(out).toContain('"a,b"');
+    expect(out).toContain('"with ""quote"""');
+    expect(out).toContain('"two\nlines"');
+  });
+
+  it('serialises objects and arrays as JSON', () => {
+    const out = toCsv([{ data: { k: 'v' } }, { data: [1, 2] }]);
+    // Object/array serialisations contain commas → end up quoted.
+    expect(out).toContain('"{""k"":""v""}"');
+    expect(out).toContain('"[1,2]"');
+  });
+
+  describe('formula-injection neutralization', () => {
+    // Each leading char Excel/Sheets interprets as a formula: = + - @ \t \r
+    it.each([
+      ['=cmd|"/c calc"!A1', '\'=cmd|"/c calc"!A1'],
+      ['+danger', "'+danger"],
+      ['-1+1', "'-1+1"],
+      ['@SUM(A1:A2)', "'@SUM(A1:A2)"],
+      ['\ttabbed', "'\ttabbed"],
+      ['\rcarriage', "'\rcarriage"],
+    ])('prefixes leading %s with apostrophe', (input, expected) => {
+      const out = toCsv([{ field: input }]);
+      // Header line is "field\r\n", second is the neutralized value (possibly quoted).
+      const valueLine = out.split('\r\n')[1] ?? '';
+      // Strip outer quotes if the field was wrapped due to special chars.
+      const unwrapped =
+        valueLine.startsWith('"') && valueLine.endsWith('"')
+          ? valueLine.slice(1, -1).replace(/""/g, '"')
+          : valueLine;
+      expect(unwrapped).toBe(expected);
+    });
+
+    it('does NOT neutralize values where the formula char is mid-string', () => {
+      const out = toCsv([{ s: 'price=10' }]);
+      expect(out).toContain('price=10');
+      expect(out).not.toContain("'price=10");
+    });
+
+    it('null and undefined become empty cells, not neutralized', () => {
+      const out = toCsv([{ a: null, b: undefined, c: '' }]);
+      const line = out.split('\r\n')[1];
+      expect(line).toBe(',,');
+    });
+  });
+
+  it('keys missing from a row become empty cells (sparse rows)', () => {
+    const out = toCsv([{ a: 1, b: 2 }, { a: 3 }]);
+    const lines = out.split('\r\n');
+    expect(lines[0]).toBe('a,b');
+    expect(lines[1]).toBe('1,2');
+    expect(lines[2]).toBe('3,');
+  });
+});

--- a/server/src/lib/ssrf.test.ts
+++ b/server/src/lib/ssrf.test.ts
@@ -80,7 +80,11 @@ describe('assertSafeUrl', () => {
     if (!r.ok) expect(r.reason).toMatch(/private/i);
   });
 
-  it('rejects localhost by name even if DNS would succeed', async () => {
+  it('rejects localhost by name', async () => {
+    // Whether localhost resolves to 127.0.0.1 (Windows / dev box with IPv6
+    // enabled) or fails to resolve at all (some CI containers without local
+    // resolver), the result is the same: `ok: false`. We don't assert on the
+    // reason text — it's an implementation detail.
     const r = await assertSafeUrl('http://localhost');
     expect(r.ok).toBe(false);
   });

--- a/server/src/lib/ssrf.test.ts
+++ b/server/src/lib/ssrf.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { _internal, assertSafeUrl } from './ssrf.js';
+
+const { isPrivateIp } = _internal;
+
+describe('isPrivateIp (IPv4)', () => {
+  it.each([
+    '10.0.0.1',
+    '10.255.255.255',
+    '127.0.0.1',
+    '127.10.20.30',
+    '169.254.1.1',
+    '169.254.169.254', // cloud metadata
+    '172.16.0.1',
+    '172.31.255.254',
+    '192.168.0.1',
+    '192.168.255.255',
+    '0.0.0.0',
+    '224.0.0.1', // multicast
+    '255.255.255.255',
+  ])('flags %s as private', (ip) => {
+    expect(isPrivateIp(ip)).toBe(true);
+  });
+
+  it.each([
+    '8.8.8.8',
+    '1.1.1.1',
+    '172.15.0.1', // just outside 172.16/12
+    '172.32.0.1',
+    '93.184.216.34', // example.com
+  ])('treats %s as public', (ip) => {
+    expect(isPrivateIp(ip)).toBe(false);
+  });
+});
+
+describe('isPrivateIp (IPv6)', () => {
+  it.each(['::1', '::', 'fc00::1', 'fd12:3456::1', 'fe80::1', 'feab::1'])(
+    'flags %s as private',
+    (ip) => {
+      expect(isPrivateIp(ip)).toBe(true);
+    },
+  );
+
+  it.each(['2001:4860:4860::8888', '2606:4700:4700::1111'])('treats %s as public', (ip) => {
+    expect(isPrivateIp(ip)).toBe(false);
+  });
+
+  it('flags IPv4-mapped private addresses', () => {
+    expect(isPrivateIp('::ffff:10.0.0.1')).toBe(true);
+    expect(isPrivateIp('::ffff:127.0.0.1')).toBe(true);
+  });
+
+  it('treats IPv4-mapped public addresses as public', () => {
+    expect(isPrivateIp('::ffff:8.8.8.8')).toBe(false);
+  });
+});
+
+describe('assertSafeUrl', () => {
+  it('rejects non-http(s) protocols', async () => {
+    expect((await assertSafeUrl('file:///etc/passwd')).ok).toBe(false);
+    expect((await assertSafeUrl('javascript:alert(1)')).ok).toBe(false);
+    expect((await assertSafeUrl('ftp://example.com')).ok).toBe(false);
+  });
+
+  it('rejects malformed URLs', async () => {
+    expect((await assertSafeUrl('not a url')).ok).toBe(false);
+    expect((await assertSafeUrl('')).ok).toBe(false);
+  });
+
+  it.each([
+    'http://127.0.0.1',
+    'http://127.0.0.1:8080/foo',
+    'http://10.0.0.1',
+    'http://169.254.169.254/latest/meta-data/',
+    'http://192.168.1.1',
+    'http://[::1]',
+  ])('rejects literal private IP %s', async (url) => {
+    const r = await assertSafeUrl(url);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/private/i);
+  });
+
+  it('rejects localhost by name even if DNS would succeed', async () => {
+    const r = await assertSafeUrl('http://localhost');
+    expect(r.ok).toBe(false);
+  });
+
+  it('accepts a literal public IP', async () => {
+    const r = await assertSafeUrl('http://93.184.216.34/');
+    expect(r.ok).toBe(true);
+  });
+});

--- a/server/src/lib/ssrf.ts
+++ b/server/src/lib/ssrf.ts
@@ -64,9 +64,10 @@ export async function assertSafeUrl(input: string): Promise<UrlCheckResult> {
   }
   // Node's URL keeps the brackets on IPv6 hostnames (e.g. `[::1]`), but
   // net.isIP wants the bare address. Strip them before any check.
-  const hostname = url.hostname.startsWith('[') && url.hostname.endsWith(']')
-    ? url.hostname.slice(1, -1)
-    : url.hostname;
+  const hostname =
+    url.hostname.startsWith('[') && url.hostname.endsWith(']')
+      ? url.hostname.slice(1, -1)
+      : url.hostname;
   if (!hostname) return { ok: false, reason: 'Missing hostname' };
 
   // Literal IPs: check directly.

--- a/server/src/lib/ssrf.ts
+++ b/server/src/lib/ssrf.ts
@@ -62,7 +62,11 @@ export async function assertSafeUrl(input: string): Promise<UrlCheckResult> {
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
     return { ok: false, reason: 'Only http and https URLs are supported' };
   }
-  const hostname = url.hostname;
+  // Node's URL keeps the brackets on IPv6 hostnames (e.g. `[::1]`), but
+  // net.isIP wants the bare address. Strip them before any check.
+  const hostname = url.hostname.startsWith('[') && url.hostname.endsWith(']')
+    ? url.hostname.slice(1, -1)
+    : url.hostname;
   if (!hostname) return { ok: false, reason: 'Missing hostname' };
 
   // Literal IPs: check directly.

--- a/server/src/services/ai-extractor.test.ts
+++ b/server/src/services/ai-extractor.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import { hashItem, parseItems, validateExtractedItems } from './ai-extractor.js';
+
+describe('parseItems', () => {
+  it('parses a raw JSON array', () => {
+    expect(parseItems('[{"a":1},{"a":2}]')).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  it('strips ```json ... ``` fences', () => {
+    expect(parseItems('```json\n[{"a":1}]\n```')).toEqual([{ a: 1 }]);
+    expect(parseItems('```\n[{"a":1}]\n```')).toEqual([{ a: 1 }]);
+  });
+
+  it('unwraps an object with items / data / results / rows key', () => {
+    expect(parseItems('{"items":[{"a":1}]}')).toEqual([{ a: 1 }]);
+    expect(parseItems('{"data":[{"a":1}]}')).toEqual([{ a: 1 }]);
+    expect(parseItems('{"results":[{"a":1}]}')).toEqual([{ a: 1 }]);
+    expect(parseItems('{"rows":[{"a":1}]}')).toEqual([{ a: 1 }]);
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseItems('not json')).toBeNull();
+    expect(parseItems('{not: valid}')).toBeNull();
+    expect(parseItems('')).toBeNull();
+  });
+
+  it('returns null for non-array root with no recognized wrapper key', () => {
+    expect(parseItems('{"foo":[{"a":1}]}')).toBeNull();
+    expect(parseItems('"a string"')).toBeNull();
+    expect(parseItems('42')).toBeNull();
+  });
+});
+
+describe('hashItem', () => {
+  it('returns a hex SHA-256', () => {
+    const h = hashItem({ a: 1 });
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic for the same JSON shape', () => {
+    expect(hashItem({ a: 1 })).toBe(hashItem({ a: 1 }));
+  });
+
+  it('changes when the value changes', () => {
+    expect(hashItem({ a: 1 })).not.toBe(hashItem({ a: 2 }));
+  });
+});
+
+describe('validateExtractedItems', () => {
+  const SIZE = 16_384;
+
+  describe('schema type check', () => {
+    it('passes when every field matches the declared type', () => {
+      const r = validateExtractedItems([{ name: 'x', price: 9.99, in_stock: true }], {
+        extractionSchema: { name: 'string', price: 'number', in_stock: 'boolean' },
+        sizeCap: SIZE,
+      });
+      expect(r.ok).toBe(true);
+    });
+
+    it('fails on string-where-number', () => {
+      const r = validateExtractedItems([{ price: '9.99' }], {
+        extractionSchema: { price: 'number' },
+        sizeCap: SIZE,
+      });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/price.*number/i);
+    });
+
+    it('treats null/undefined as permissive (optional fields)', () => {
+      const r = validateExtractedItems([{ price: null }, { price: undefined }], {
+        extractionSchema: { price: 'number' },
+        sizeCap: SIZE,
+      });
+      expect(r.ok).toBe(true);
+    });
+
+    it('rejects non-finite numbers', () => {
+      const r = validateExtractedItems([{ price: NaN }], {
+        extractionSchema: { price: 'number' },
+        sizeCap: SIZE,
+      });
+      expect(r.ok).toBe(false);
+    });
+
+    it('distinguishes object from array for type=object', () => {
+      const ok = validateExtractedItems([{ meta: { k: 'v' } }], {
+        extractionSchema: { meta: 'object' },
+        sizeCap: SIZE,
+      });
+      expect(ok.ok).toBe(true);
+      const bad = validateExtractedItems([{ meta: [1, 2] }], {
+        extractionSchema: { meta: 'object' },
+        sizeCap: SIZE,
+      });
+      expect(bad.ok).toBe(false);
+    });
+  });
+
+  describe('secret-leak guard', () => {
+    const longKey = 'sk-or-v1-abcdefghijklmnopqrstuvwxyz';
+    const shortKey = 'short'; // < 16 chars
+
+    it('rejects items containing a real-length API key', () => {
+      const r = validateExtractedItems([{ note: `My token: ${longKey} oops` }], {
+        apiKeyGuards: [longKey],
+        sizeCap: SIZE,
+      });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/restricted/i);
+    });
+
+    it('skips API-key guards shorter than the 16-char floor (false-positive prevention)', () => {
+      const r = validateExtractedItems(
+        [{ note: `text containing ${shortKey} as legitimate content` }],
+        { apiKeyGuards: [shortKey], sizeCap: SIZE },
+      );
+      expect(r.ok).toBe(true);
+    });
+
+    it('rejects items containing a short email (no length floor on emails)', () => {
+      const r = validateExtractedItems([{ note: 'contact: a@b.co for details' }], {
+        emailGuards: ['a@b.co'],
+        sizeCap: SIZE,
+      });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/restricted/i);
+    });
+
+    it('passes when neither guard list contains a substring of the items', () => {
+      const r = validateExtractedItems([{ note: 'innocuous content' }], {
+        apiKeyGuards: [longKey],
+        emailGuards: ['user@example.com'],
+        sizeCap: SIZE,
+      });
+      expect(r.ok).toBe(true);
+    });
+
+    it('ignores empty / undefined guard entries', () => {
+      const r = validateExtractedItems([{ note: 'x' }], {
+        apiKeyGuards: ['', longKey],
+        emailGuards: [''],
+        sizeCap: SIZE,
+      });
+      expect(r.ok).toBe(true);
+    });
+  });
+
+  describe('size cap', () => {
+    it('rejects items larger than the cap', () => {
+      const huge = 'x'.repeat(200);
+      const r = validateExtractedItems([{ blob: huge }], { sizeCap: 100 });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/size cap/i);
+    });
+
+    it('accepts items at or below the cap', () => {
+      const r = validateExtractedItems([{ blob: 'x' }], { sizeCap: 100 });
+      expect(r.ok).toBe(true);
+    });
+  });
+
+  describe('sanitize (HTML escaping)', () => {
+    it('escapes HTML in string leaves', () => {
+      const r = validateExtractedItems([{ name: '<script>alert(1)</script>' }], { sizeCap: SIZE });
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        const cleaned = String(r.items[0]!.name);
+        expect(cleaned).not.toContain('<script>');
+        expect(cleaned).toContain('&lt;script&gt;');
+      }
+    });
+
+    it('recurses into arrays and nested objects', () => {
+      const r = validateExtractedItems([{ tags: ['<b>', '<i>'], meta: { html: '<p>x</p>' } }], {
+        sizeCap: SIZE,
+      });
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        const item = r.items[0]!;
+        expect(JSON.stringify(item)).not.toContain('<b>');
+        expect(JSON.stringify(item)).toContain('&lt;b&gt;');
+      }
+    });
+
+    it('leaves non-string leaves alone', () => {
+      const r = validateExtractedItems([{ price: 9.99, in_stock: true, tags: null }], {
+        sizeCap: SIZE,
+      });
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.items[0]).toEqual({ price: 9.99, in_stock: true, tags: null });
+      }
+    });
+  });
+});

--- a/server/src/services/ai-extractor.ts
+++ b/server/src/services/ai-extractor.ts
@@ -135,6 +135,70 @@ export function hashItem(item: unknown): string {
   return createHash('sha256').update(JSON.stringify(item)).digest('hex');
 }
 
+export type ValidateOptions = {
+  extractionSchema?: ExtractionSchema;
+  apiKeyGuards?: string[];
+  emailGuards?: string[];
+  sizeCap: number;
+};
+
+export type ValidateResult =
+  | { ok: true; items: Record<string, unknown>[] }
+  | { ok: false; error: string };
+
+/**
+ * Pure (no I/O) validation pass over a parsed AI response. Splitting this
+ * out of `extract` lets us unit-test the security-critical paths — schema
+ * mismatch, secret-leak, item-size cap — without making real model calls.
+ */
+export function validateExtractedItems(
+  items: Record<string, unknown>[],
+  opts: ValidateOptions,
+): ValidateResult {
+  // Schema type check
+  if (opts.extractionSchema) {
+    for (const item of items) {
+      for (const [field, t] of Object.entries(opts.extractionSchema)) {
+        if (!typeMatches(item[field], t)) {
+          return { ok: false, error: `Field "${field}" has the wrong type (expected ${t})` };
+        }
+      }
+    }
+  }
+
+  // Secret leak check. API keys are length-floored (16 chars) to avoid
+  // false-positive matches on short placeholders; emails skip the floor
+  // because the @-and-dot pattern keeps false-positive risk near zero.
+  const guards: string[] = [];
+  for (const k of opts.apiKeyGuards ?? []) {
+    if (k && k.length >= API_KEY_GUARD_MIN_LENGTH) guards.push(k);
+  }
+  for (const e of opts.emailGuards ?? []) {
+    if (e) guards.push(e);
+  }
+  if (guards.length > 0) {
+    const serialized = JSON.stringify(items);
+    for (const secret of guards) {
+      if (serialized.includes(secret)) {
+        return {
+          ok: false,
+          error: 'Extracted data contained restricted values; suspected prompt injection.',
+        };
+      }
+    }
+  }
+
+  // Size cap
+  for (const item of items) {
+    if (JSON.stringify(item).length > opts.sizeCap) {
+      return { ok: false, error: `Extracted item exceeds size cap of ${opts.sizeCap} bytes` };
+    }
+  }
+
+  const cleanItems = items.map((i) => sanitize(i) as Record<string, unknown>);
+  return { ok: true, items: cleanItems };
+}
+
 export async function extract(args: ExtractArgs): Promise<ExtractResult> {
   const sizeCap = args.itemSizeCap ?? 16_384;
   const messages: ChatMessage[] = [
@@ -165,57 +229,16 @@ export async function extract(args: ExtractArgs): Promise<ExtractResult> {
 
     const items = parseItems(rawText);
     if (items !== null) {
-      // Schema type check
-      if (args.extractionSchema) {
-        for (const item of items) {
-          for (const [field, t] of Object.entries(args.extractionSchema)) {
-            if (!typeMatches(item[field], t)) {
-              return {
-                ok: false,
-                error: `Field "${field}" has the wrong type (expected ${t})`,
-                usage,
-                rawText,
-              };
-            }
-          }
-        }
+      const validated = validateExtractedItems(items, {
+        extractionSchema: args.extractionSchema,
+        apiKeyGuards: args.apiKeyGuards,
+        emailGuards: args.emailGuards,
+        sizeCap,
+      });
+      if (!validated.ok) {
+        return { ok: false, error: validated.error, usage, rawText };
       }
-      // Secret leak check. API keys are length-floored (16) to avoid
-      // false-positive matches on short placeholders; emails are not floored
-      // because the @-and-dot pattern keeps false-positive risk near zero.
-      const guards: string[] = [];
-      for (const k of args.apiKeyGuards ?? []) {
-        if (k && k.length >= API_KEY_GUARD_MIN_LENGTH) guards.push(k);
-      }
-      for (const e of args.emailGuards ?? []) {
-        if (e) guards.push(e);
-      }
-      if (guards.length > 0) {
-        const serialized = JSON.stringify(items);
-        for (const secret of guards) {
-          if (serialized.includes(secret)) {
-            return {
-              ok: false,
-              error: 'Extracted data contained restricted values; suspected prompt injection.',
-              usage,
-              rawText,
-            };
-          }
-        }
-      }
-      // Size cap
-      for (const item of items) {
-        if (JSON.stringify(item).length > sizeCap) {
-          return {
-            ok: false,
-            error: `Extracted item exceeds size cap of ${sizeCap} bytes`,
-            usage,
-            rawText,
-          };
-        }
-      }
-      const cleanItems = items.map((i) => sanitize(i) as Record<string, unknown>);
-      return { ok: true, items: cleanItems, usage: usage!, rawText };
+      return { ok: true, items: validated.items, usage: usage!, rawText };
     }
 
     // Retry once with stricter instructions if the first parse failed.


### PR DESCRIPTION
Closes #73. 87 tests locking in the security-critical hardening from #60/#62/#68. `validateExtractedItems` extracted from `extract()` so the schema / secret-leak / size-cap paths can be tested without real AI calls. `npm run test --workspace server` runs in the CI verify job.