### PR TITLE
release: 0.9.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartscrape/client",
-  "version": "0.0.1",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smartscrape",
-  "version": "0.0.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smartscrape",
-      "version": "0.0.1",
+      "version": "0.9.0",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "@smartscrape/client",
-      "version": "0.0.1",
+      "version": "0.9.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -8196,7 +8196,7 @@
     },
     "server": {
       "name": "@smartscrape/server",
-      "version": "0.0.1",
+      "version": "0.9.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.40.1",
         "@types/cookie-parser": "^1.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartscrape",
-  "version": "0.0.1",
+  "version": "0.9.0",
   "private": true,
   "description": "AI-powered self-hosted web scraping with structured extraction, change detection, and notifications.",
   "license": "MIT",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartscrape/server",
-  "version": "0.0.1",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Closes #79. All three workspace package.json files bumped 0.0.1 → 0.9.0. Tag + GitHub release follow merge.