### PR TITLE
chore: remove dead void jobId + stale refreshToken e2e refs from PR #82

### DIFF
--- a/client/tests/e2e/capture-screenshots.ts
+++ b/client/tests/e2e/capture-screenshots.ts
@@ -17,7 +17,7 @@ const API_BASE = 'http://localhost:3000';
 const UI_BASE = 'http://localhost:5173';
 const OUT_DIR = resolve(process.cwd(), '..', 'docs', 'screenshots');
 
-type Session = { accessToken: string; refreshToken: string; userId: string; email: string };
+type Session = { accessToken: string; userId: string; email: string };
 
 async function api<T>(path: string, init: RequestInit & { token?: string } = {}): Promise<T> {
   const headers: Record<string, string> = { 'content-type': 'application/json' };
@@ -35,13 +35,12 @@ async function seed(): Promise<Session> {
     method: 'POST',
     body: JSON.stringify({ email, password, name: 'Demo' }),
   });
-  const login = await api<{ accessToken: string; refreshToken: string; user: { id: string } }>(
-    '/api/auth/login',
-    { method: 'POST', body: JSON.stringify({ email, password }) },
-  );
+  const login = await api<{ accessToken: string; user: { id: string } }>('/api/auth/login', {
+    method: 'POST',
+    body: JSON.stringify({ email, password }),
+  });
   const session: Session = {
     accessToken: login.accessToken,
-    refreshToken: login.refreshToken,
     userId: login.user.id,
     email,
   };
@@ -99,7 +98,6 @@ async function primeAuth(page: Page, session: Session): Promise<void> {
       JSON.stringify({
         state: {
           accessToken: s.accessToken,
-          refreshToken: s.refreshToken,
           user: { id: s.userId, email: s.email, name: 'Demo', email_verified: false },
         },
         version: 0,

--- a/client/tests/e2e/helpers.ts
+++ b/client/tests/e2e/helpers.ts
@@ -6,7 +6,6 @@ export type Session = {
   email: string;
   password: string;
   accessToken: string;
-  refreshToken: string;
   userId: string;
 };
 
@@ -44,13 +43,12 @@ export async function registerAndLogin(request: APIRequestContext): Promise<Sess
     throw new Error(`login failed: ${login.status()} ${await login.text()}`);
   }
   const body = (await login.json()) as {
-    data: { accessToken: string; refreshToken: string; user: { id: string } };
+    data: { accessToken: string; user: { id: string } };
   };
   return {
     email,
     password,
     accessToken: body.data.accessToken,
-    refreshToken: body.data.refreshToken,
     userId: body.data.user.id,
   };
 }

--- a/server/src/routes/jobs.ts
+++ b/server/src/routes/jobs.ts
@@ -419,7 +419,6 @@ async function sendCsvForRun(
     `attachment; filename="${safeName}-${runId.slice(0, 8)}.csv"`,
   );
   res.status(200).send(csv);
-  void jobId;
 }
 
 jobsRouter.get('/:id/export/csv', validate(idParam, 'params'), async (req, res) => {


### PR DESCRIPTION
Closes #84. Refs #82, the audit follow-up tracking issue #83.

## Summary

Two unrelated leftovers from PR #82's rushed merge, both surfaced by Codex's independent review:

1. **Dead `void jobId`** at `server/src/routes/jobs.ts:422`. Line 407 actually uses `jobId` for the run-belongs-to-job ownership check, so the trailing `void jobId;` silences nothing.
2. **Stale `refreshToken` references** in `client/tests/e2e/helpers.ts` and `client/tests/e2e/capture-screenshots.ts`. PR #82 moved refresh tokens to HttpOnly cookies and stopped returning them in `/login` and `/refresh` response bodies, but the e2e helpers were never cleaned up — they typed the response field as `string` and captured it into `Session.refreshToken`, which has been `undefined` at runtime since #82 landed. Verified by grep that nothing else under `client/` consumes the field.

## Verification

```
npm run lint            ✅
npm run typecheck       ✅
npm run test --workspace server   ✅ 89/89
npm run format:check    ✅
npm run build           ✅
```

(`format:check` initially flagged my edit; ran `prettier --write` on the file — second commit is the prettier-clean version.)

## Discovered during verification — separate issue

While running the gates locally I noticed `npm test --workspace client` fails on main: PR #82 added `Button.smoke.test.tsx` and a `test: vitest` script without a `vitest.config.ts`, so Vitest collides with the Playwright `*.spec.ts` files under `client/tests/e2e/`. CI doesn't catch this because `.github/workflows/ci.yml:17` only runs `npm run test --workspace server`, not `--workspaces`. Filed as #85 — separate small fix, not part of this PR.

## Test plan

- [x] CI green
- [x] Spot-check that the `runs/:id/export/csv/:runId` route still 200s for a valid job/run pair and 404s when `runId` belongs to a different job (the `void jobId` removal is a no-op semantically, but the assertion path is the one #82 added)