### PR TITLE
test(client): scope vitest discovery + run client tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run test --workspace server
+      - run: npm run test --workspace client
       - run: npm run build
 
   audit:

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+// Vitest's default include picks up `**/*.{test,spec}.{ts,tsx,…}`, which
+// collides with the Playwright e2e specs under `tests/e2e/*.spec.ts`.
+// Scope discovery to unit tests under `src/` and explicitly exclude e2e.
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**'],
+  },
+});


### PR DESCRIPTION
Closes #85. Refs #82, the audit follow-up tracking issue #83.

## Summary

PR #82 added `client/src/components/Button.smoke.test.tsx` and a `test: vitest` script in `client/package.json` but no vitest config. With no config, Vitest's default include pattern picks up `**/*.{test,spec}.{ts,tsx,…}` — which collides with the existing Playwright `*.spec.ts` files under `client/tests/e2e/`. Vitest tries to load them, hits Playwright's `test.describe.configure()` at module top level, and crashes.

CI didn't catch it because `.github/workflows/ci.yml` only runs `npm run test --workspace server`, not `--workspaces`.

## Two commits

1. **`test(client): add vitest config scoped to src/**`** — adds `client/vitest.config.ts` with `include: ['src/**/*.{test,spec}.{ts,tsx}']` and `exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**']`. Reuses `@vitejs/plugin-react` for JSX. Defaults to the `node` environment (the existing smoke test only checks `typeof Button === 'function'`, no DOM); a future test that needs `jsdom` can opt in.

2. **`ci: run client unit tests in verify job`** — adds one `- run: npm run test --workspace client` step right after the server-test step. Closes the structural gap that hid the bug.

## Verification

```
npm run format:check                  ✅
npm run lint                          ✅
npm run typecheck                     ✅
npm run test --workspace server       ✅ 178/178
npm run test --workspace client       ✅ 1/1
npm run build                         ✅
```

## Test plan

- [x] CI green (verify job should now show two test steps; both pass)
- [x] Confirm deliberately-broken client test (revert locally, push) fails CI

## Out of scope

- Adding actual client unit tests beyond the existing smoke test (separate effort, larger lift)
- Migrating to jsdom / `@testing-library/react` (only needed once a test actually renders)