### PR TITLE
feat(auth): finish HttpOnly cookie migration — cookie-only /refresh + /logout

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -58,10 +58,6 @@ const loginSchema = z.object({
   password: z.string().min(1).max(200),
 });
 
-const refreshSchema = z.object({
-  refreshToken: z.string().min(10).optional(),
-});
-
 const verifyEmailSchema = z.object({
   token: z.string().min(10),
 });
@@ -188,10 +184,13 @@ authRouter.post('/login', authEntryLimiter, validate(loginSchema), async (req, r
   );
 });
 
-authRouter.post('/refresh', validate(refreshSchema), async (req, res) => {
-  const { refreshToken } = req.body as z.infer<typeof refreshSchema>;
-  const cookieToken = req.cookies?.refreshToken;
-  const presentedToken = refreshToken ?? cookieToken;
+authRouter.post('/refresh', async (req, res) => {
+  // Cookie-only since the HttpOnly migration in #82. The previous JSON-body
+  // fallback was preserved for backward compatibility but defeated the
+  // migration's point — an XSS-captured token could still be replayed via
+  // body. The current client (`client/src/lib/api.ts`) uses
+  // `credentials: 'include'` and never sends the token in the body.
+  const presentedToken: string | undefined = req.cookies?.refreshToken;
   if (!presentedToken) {
     res.status(401).json(fail('INVALID_REFRESH', 'Refresh token is invalid or expired'));
     return;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -214,6 +214,22 @@ authRouter.post('/refresh', async (req, res) => {
     .json(ok({ accessToken: session.accessToken, refreshExpiresAt: session.refreshExpiresAt }));
 });
 
+authRouter.post('/logout', async (req, res) => {
+  // Idempotent: revoke the cookie's refresh token if it maps to an active
+  // row, then always clear the cookie and return 200. We never leak whether
+  // the presented token was valid — every call returns the same shape so
+  // an attacker can't probe token validity through this endpoint.
+  const cookieToken: string | undefined = req.cookies?.refreshToken;
+  if (cookieToken) {
+    const row = await findActiveByHash(hashToken(cookieToken));
+    if (row) {
+      await revokeById(row.id);
+    }
+  }
+  clearRefreshCookie(res);
+  res.status(200).json(ok({ logout: true }));
+});
+
 authRouter.post(
   '/forgot-password',
   authEntryLimiter,


### PR DESCRIPTION
Closes #88. Refs #82, the audit follow-up tracking issue #83.

## Summary

Two of the security-relevant residuals from audit #81 / PR #82, bundled because they both complete the HttpOnly cookie migration.

### 1. `/refresh` is now cookie-only

PR #82 moved the refresh token to an `HttpOnly` cookie, but kept the JSON-body fallback alive. That defeated the migration's purpose: a renderer XSS that exfiltrated the token before #82 (or any client cache that still has it in `localStorage`) could continue to authenticate via body even though the cookie is `HttpOnly`.

The current client (`client/src/lib/api.ts`) already calls `/refresh` with `credentials: 'include'` and no body, so removing the fallback is safe — the legitimate caller is already cookie-only.

- Drop `refreshSchema` and the `validate(refreshSchema)` middleware.
- Read only `req.cookies?.refreshToken`.
- 401 path unchanged.

### 2. `POST /api/auth/logout`

Until now the only way to revoke a session was `DELETE /api/auth/me`, which also deletes the user account. There was no \"sign out, leave the account intact\" path — clearing the access token client-side left a valid `HttpOnly` refresh cookie sitting in the browser until natural expiry.

The new endpoint:
- Reads `req.cookies?.refreshToken`. If present and maps to an active row, calls `revokeById(row.id)`.
- Always calls `clearRefreshCookie(res)` and returns 200 with `{ logout: true }`, regardless of whether a row was found. The endpoint cannot be probed for token validity.

Mirrors the pattern in `DELETE /api/auth/me` (which already does `revokeAllForUser` + `clearRefreshCookie`).

## Verification

```
npm run lint                          ✅
npm run typecheck                     ✅
npm run test --workspace server       ✅ 178/178
npm run test --workspace client       ✅ 1/1
npm run format:check                  ✅
npm run build                         ✅
```

`gh issue develop` 504'd when I tried to open this branch from #88, so the branch was created locally instead — the issue auto-link won't show the branch in the GitHub UI's "Development" sidebar, but `Closes #88` in this body wires it up on merge.

## Out of scope

- **HTTP integration tests** for `/refresh` and `/logout`. The repo has no `supertest` / `request(app)` scaffolding; adding it would dwarf the actual security fixes. The e2e Playwright job exercises login implicitly. Explicit auth-route tests should land alongside whichever PR introduces the test scaffolding.
- **A client-side `logout()` action** wired into `useAuth` / a sign-out button. The endpoint exists now; the UI work is its own concern.
- **CSRF / `Origin` / `Sec-Fetch-Site` checks** — separate item in #83.

## Test plan

- [x] CI green
- [ ] Manual: from devtools, `fetch('/api/auth/refresh', { method: 'POST', body: JSON.stringify({refreshToken: '<old token>'}), headers: {'Content-Type': 'application/json'} })` should now return 401 even with a previously-valid token in the body.
- [ ] Manual: `fetch('/api/auth/logout', { method: 'POST', credentials: 'include' })` should return `{ success: true, data: { logout: true } }`, the cookie should be cleared, and a subsequent `/refresh` should return 401.