### PR TITLE
fix(scraper): bind Playwright cap with proper semaphore + validate env var

### DIFF
--- a/server/src/lib/semaphore.test.ts
+++ b/server/src/lib/semaphore.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { createSemaphore } from './semaphore.js';
+
+describe('createSemaphore', () => {
+  describe('input validation', () => {
+    it('rejects max < 1', () => {
+      expect(() => createSemaphore(0)).toThrow(/positive integer/);
+      expect(() => createSemaphore(-1)).toThrow(/positive integer/);
+    });
+
+    it('rejects non-integer max', () => {
+      expect(() => createSemaphore(1.5)).toThrow(/positive integer/);
+      expect(() => createSemaphore(Number.NaN)).toThrow(/positive integer/);
+      expect(() => createSemaphore(Number.POSITIVE_INFINITY)).toThrow(/positive integer/);
+    });
+  });
+
+  describe('basic acquire / release', () => {
+    it('acquires immediately under cap', async () => {
+      const sem = createSemaphore(2);
+      const release1 = await sem.acquire();
+      expect(sem.inUse()).toBe(1);
+      expect(sem.queued()).toBe(0);
+      const release2 = await sem.acquire();
+      expect(sem.inUse()).toBe(2);
+      expect(sem.queued()).toBe(0);
+      release1();
+      release2();
+      expect(sem.inUse()).toBe(0);
+    });
+
+    it('queues acquires that arrive at cap', async () => {
+      const sem = createSemaphore(1);
+      const release1 = await sem.acquire();
+      // Second acquire must wait — assert by timing it against a release.
+      let acquired2 = false;
+      const acquire2 = sem.acquire().then((release2) => {
+        acquired2 = true;
+        return release2;
+      });
+      // Microtask flush — acquire2 has not yet resolved.
+      await Promise.resolve();
+      expect(acquired2).toBe(false);
+      expect(sem.queued()).toBe(1);
+      release1();
+      const release2 = await acquire2;
+      expect(acquired2).toBe(true);
+      expect(sem.inUse()).toBe(1);
+      release2();
+    });
+
+    it('preserves FIFO order across multiple waiters', async () => {
+      const sem = createSemaphore(1);
+      const order: number[] = [];
+      const release1 = await sem.acquire();
+
+      const waiters = [1, 2, 3, 4].map((id) =>
+        sem.acquire().then((release) => {
+          order.push(id);
+          release();
+        }),
+      );
+
+      // All four are queued behind the held slot.
+      await Promise.resolve();
+      expect(sem.queued()).toBe(4);
+
+      release1();
+      await Promise.all(waiters);
+      expect(order).toEqual([1, 2, 3, 4]);
+    });
+  });
+
+  describe('release semantics', () => {
+    it('double-release is a no-op', async () => {
+      const sem = createSemaphore(1);
+      const release = await sem.acquire();
+      release();
+      expect(sem.inUse()).toBe(0);
+      release(); // must not double-decrement
+      expect(sem.inUse()).toBe(0);
+    });
+
+    it('double-release does not wake an extra waiter', async () => {
+      const sem = createSemaphore(1);
+      const release1 = await sem.acquire();
+
+      const release2Promise = sem.acquire();
+      const release3Promise = sem.acquire();
+      await Promise.resolve();
+      expect(sem.queued()).toBe(2);
+
+      release1();
+      release1(); // double-release: must not wake the third caller too
+
+      const release2 = await release2Promise;
+      // release3 should still be queued.
+      let release3Resolved = false;
+      void release3Promise.then(() => {
+        release3Resolved = true;
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(release3Resolved).toBe(false);
+      expect(sem.queued()).toBe(1);
+
+      release2();
+      const release3 = await release3Promise;
+      release3();
+    });
+  });
+
+  describe('cap is never exceeded under contention', () => {
+    // Regression for the bug fixed in #90: the prior hand-rolled lock
+    // decremented `active` then awaited the queue tail, opening a window
+    // where a fresh `acquire` saw free space and a woken waiter then
+    // re-incremented past the cap.
+    it('observes inUse <= max across many interleaved acquires/releases', async () => {
+      const max = 3;
+      const sem = createSemaphore(max);
+      const observations: number[] = [];
+
+      async function workItem(): Promise<void> {
+        const release = await sem.acquire();
+        observations.push(sem.inUse());
+        // Yield several microtask turns to interleave with other holders.
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        release();
+      }
+
+      await Promise.all(Array.from({ length: 50 }, workItem));
+
+      expect(Math.max(...observations)).toBeLessThanOrEqual(max);
+      expect(sem.inUse()).toBe(0);
+      expect(sem.queued()).toBe(0);
+    });
+
+    it('exactly max are concurrently in section when contended', async () => {
+      const max = 4;
+      const sem = createSemaphore(max);
+      let peak = 0;
+      let inSection = 0;
+
+      async function workItem(): Promise<void> {
+        const release = await sem.acquire();
+        inSection++;
+        peak = Math.max(peak, inSection);
+        await Promise.resolve();
+        await Promise.resolve();
+        inSection--;
+        release();
+      }
+
+      // 20 items competing for 4 slots: peak should reach exactly 4.
+      await Promise.all(Array.from({ length: 20 }, workItem));
+
+      expect(peak).toBe(max);
+      expect(inSection).toBe(0);
+    });
+  });
+});

--- a/server/src/lib/semaphore.ts
+++ b/server/src/lib/semaphore.ts
@@ -1,0 +1,67 @@
+/**
+ * Bounded-concurrency semaphore: at most N holders in the critical section
+ * at once.
+ *
+ * Uses **slot-conservation handoff**: when a holder releases and a waiter is
+ * queued, the slot is handed directly to the waiter — the active count never
+ * visibly drops below the cap during the handoff. The naive alternative
+ * (decrement counter, then wake a waiter who increments back) opens a race
+ * where a fresh `acquire` call landing between those two steps sees free
+ * space and over-fills the cap.
+ *
+ * Each `acquire` resolves with a fresh, single-use `release` closure;
+ * calling it more than once is a no-op.
+ */
+export type Semaphore = {
+  /**
+   * Acquire one slot. Resolves with a single-use `release` function that
+   * MUST be called exactly once when the holder is done with the slot.
+   */
+  acquire(): Promise<() => void>;
+  /** Slots currently held. Diagnostic / test introspection. */
+  inUse(): number;
+  /** Waiters currently queued. Diagnostic / test introspection. */
+  queued(): number;
+};
+
+export function createSemaphore(max: number): Semaphore {
+  if (!Number.isInteger(max) || max < 1) {
+    throw new Error(`createSemaphore: max must be a positive integer (got ${String(max)})`);
+  }
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  function makeRelease(): () => void {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      // Hand off to a queued waiter if any. The slot stays counted-as-in-use
+      // across the handoff so a fresh `acquire` cannot see free space and
+      // over-fill the cap.
+      const next = queue.shift();
+      if (next) {
+        next();
+        return;
+      }
+      active--;
+    };
+  }
+
+  async function acquire(): Promise<() => void> {
+    if (active < max) {
+      active++;
+      return makeRelease();
+    }
+    // Wait for a release to wake us. The slot is reserved for us by the
+    // releaser — we do NOT increment `active` after wake.
+    await new Promise<void>((resolve) => queue.push(resolve));
+    return makeRelease();
+  }
+
+  return {
+    acquire,
+    inUse: () => active,
+    queued: () => queue.length,
+  };
+}

--- a/server/src/services/scraper.ts
+++ b/server/src/services/scraper.ts
@@ -14,7 +14,18 @@ const BROWSER_UA =
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
 const MIN_VISIBLE_TEXT = 200; // below this, fall back to Playwright
 const PER_HOST_DELAY_MS = 2_000;
-const MAX_PLAYWRIGHT_CONTEXTS = Number(process.env.SCRAPER_MAX_PLAYWRIGHT_CONTEXTS ?? '2');
+function readMaxPlaywrightContexts(): number {
+  const raw = process.env.SCRAPER_MAX_PLAYWRIGHT_CONTEXTS;
+  if (raw === undefined || raw === '') return 2;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(
+      `SCRAPER_MAX_PLAYWRIGHT_CONTEXTS must be a positive integer (got ${JSON.stringify(raw)})`,
+    );
+  }
+  return parsed;
+}
+const MAX_PLAYWRIGHT_CONTEXTS = readMaxPlaywrightContexts();
 
 export type ScrapeMethod = 'auto' | 'cheerio' | 'playwright';
 

--- a/server/src/services/scraper.ts
+++ b/server/src/services/scraper.ts
@@ -1,6 +1,7 @@
 import { chromium, type Browser } from 'playwright';
 import { cleanHtml, visibleTextLength } from './html-cleaner.js';
 import { assertSafeUrl } from '../lib/ssrf.js';
+import { createSemaphore } from '../lib/semaphore.js';
 import { isAllowedByRobots } from './robots.js';
 
 const USER_AGENT = 'SmartScrapeBot/0.1 (+https://github.com/9ny4/smartscrape)';
@@ -28,26 +29,7 @@ export type ScrapeResult = {
 };
 
 const lastHitAt = new Map<string, number>();
-let activePlaywrightContexts = 0;
-const playwrightQueue: Array<() => void> = [];
-
-async function acquirePlaywrightSlot(): Promise<() => void> {
-  if (activePlaywrightContexts < MAX_PLAYWRIGHT_CONTEXTS) {
-    activePlaywrightContexts++;
-    return () => {
-      activePlaywrightContexts--;
-      const next = playwrightQueue.shift();
-      if (next) next();
-    };
-  }
-  await new Promise<void>((resolve) => playwrightQueue.push(resolve));
-  activePlaywrightContexts++;
-  return () => {
-    activePlaywrightContexts--;
-    const next = playwrightQueue.shift();
-    if (next) next();
-  };
-}
+const playwrightSlots = createSemaphore(MAX_PLAYWRIGHT_CONTEXTS);
 
 async function throttle(host: string): Promise<void> {
   const last = lastHitAt.get(host) ?? 0;
@@ -191,7 +173,7 @@ async function fetchViaPlaywright(
   url: string,
   http1Only = false,
 ): Promise<{ status: number; body: string; finalUrl: string }> {
-  const release = await acquirePlaywrightSlot();
+  const release = await playwrightSlots.acquire();
   const b = await browser(http1Only);
   const ctx = await b.newContext({
     userAgent: BROWSER_UA,


### PR DESCRIPTION
Closes #90. Refs #82, the audit follow-up tracking issue #83.

## Summary

Two related fixes to `server/src/services/scraper.ts` — the Playwright concurrency cap from PR #82 had a real race that let the cap be exceeded under contention, and the env var that drives it was read without bounds checks.

### 1. The race

`acquirePlaywrightSlot` decremented `activePlaywrightContexts` and *then* awaited the queue tail before re-incrementing. Between those two steps the counter was visibly below the cap — a fresh `acquire` landing in that window saw free space and incremented; the woken waiter then incremented again. Net effect: cap exceedable.

Replaced with a slot-conserving semaphore primitive in a new `server/src/lib/semaphore.ts`. Release hands the slot directly to a queued waiter; the active count never visibly drops below the cap during the handoff.

### 2. The env var

`Number(process.env.SCRAPER_MAX_PLAYWRIGHT_CONTEXTS ?? '2')` accepts NaN, negatives, fractions, and the empty string — each produces a misbehaving cap (NaN → all waiters queue forever; negative → no slots ever available). Replaced with a bounded reader that defaults to 2 when unset/empty and throws a clear contextual error otherwise.

## Three commits

1. **`feat(lib): add createSemaphore with slot-conservation handoff`** — new `lib/semaphore.ts` + `lib/semaphore.test.ts`. 9 tests covering input validation, basic acquire/release, FIFO order across multiple waiters, double-release safety, and (the regression case) cap-not-exceeded under 50- and 20-way contention.

2. **`fix(scraper): use semaphore for Playwright cap (was exceedable)`** — drops `activePlaywrightContexts` / `playwrightQueue` / `acquirePlaywrightSlot`, replaces with `playwrightSlots = createSemaphore(MAX_PLAYWRIGHT_CONTEXTS)`. Call site is `playwrightSlots.acquire()`.

3. **`fix(scraper): validate SCRAPER_MAX_PLAYWRIGHT_CONTEXTS at module load`** — fail-fast reader that rejects NaN / negative / non-integer / zero, defaults to 2 when unset.

## Verification

```
npm run lint                          ✅
npm run typecheck                     ✅
npm run test --workspace server       ✅ 187/187 (was 178; +9 new semaphore tests)
npm run test --workspace client       ✅ 1/1
npm run format:check                  ✅
npm run build                         ✅
```

The semaphore tests are the meaningful runtime signal — `[ipc/semaphore] cap is never exceeded under contention` directly exercises the bug pattern with 50 concurrent acquires/releases and asserts `inUse <= max`.

## Test plan

- [x] CI green
- [ ] Manual: set `SCRAPER_MAX_PLAYWRIGHT_CONTEXTS=invalid` and start the server — should fail with a clear error
- [ ] Manual: set `SCRAPER_MAX_PLAYWRIGHT_CONTEXTS=0` — same fail-fast
- [ ] Optional: load test the scraper with 10+ concurrent requests; observe Playwright contexts never exceed the configured cap