### PR TITLE
feat(security): modular requireSameSite middleware + Sec-Fetch-Site defense

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -19,6 +19,7 @@ import { notificationsRouter } from './routes/notifications.js';
 import { providersRouter } from './routes/providers.js';
 import { runsRouter } from './routes/runs.js';
 import { settingsRouter } from './routes/settings.js';
+import { requireSameSite } from './middleware/csrf.js';
 import { generalLimiter } from './middleware/rateLimit.js';
 import { fail } from './lib/response.js';
 
@@ -48,17 +49,11 @@ app.use(
   }),
 );
 
-// Explicit reject for cross-origin requests so the client gets a 403 with the
-// standard envelope instead of a CORS-failed fetch the browser can't surface.
-// Same-origin requests have no Origin header and skip this entirely.
-app.use((req, res, next) => {
-  const origin = req.headers.origin;
-  if (origin && origin !== env.appUrl) {
-    res.status(403).json(fail('CORS_FORBIDDEN', `Origin not allowed: ${origin}`));
-    return;
-  }
-  next();
-});
+// Belt-and-suspenders CSRF guard: short-circuits cross-origin /
+// cross-site requests with 403 *before* the route handler runs. CORS
+// only gates the response from being read; the request still hits the
+// handler and side effects execute. See server/src/middleware/csrf.ts.
+app.use(requireSameSite);
 
 app.use(express.json({ limit: '1mb' }));
 app.use(cookieParser());

--- a/server/src/middleware/csrf.test.ts
+++ b/server/src/middleware/csrf.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
+import { requireSameSite } from './csrf.js';
+import { env } from '../config/env.js';
+
+type ExecResult = {
+  statusCode: number | null;
+  jsonBody: unknown;
+  calledNext: boolean;
+};
+
+function exec(headers: Record<string, string> = {}, method = 'POST'): ExecResult {
+  const req = { headers, method } as unknown as Request;
+  const out: ExecResult = { statusCode: null, jsonBody: null, calledNext: false };
+  const res = {
+    status(n: number) {
+      out.statusCode = n;
+      return this;
+    },
+    json(payload: unknown) {
+      out.jsonBody = payload;
+      return this;
+    },
+  } as unknown as Response;
+  const next: NextFunction = () => {
+    out.calledNext = true;
+  };
+  requireSameSite(req, res, next);
+  return out;
+}
+
+describe('requireSameSite', () => {
+  it('passes when no headers are present (curl / server-to-server)', () => {
+    const out = exec({});
+    expect(out.calledNext).toBe(true);
+    expect(out.statusCode).toBeNull();
+  });
+
+  it('passes when Origin matches env.appUrl', () => {
+    const out = exec({ origin: env.appUrl });
+    expect(out.calledNext).toBe(true);
+    expect(out.statusCode).toBeNull();
+  });
+
+  it('rejects 403 when Origin is set and does not match env.appUrl', () => {
+    const out = exec({ origin: 'https://attacker.example.com' });
+    expect(out.calledNext).toBe(false);
+    expect(out.statusCode).toBe(403);
+    expect(out.jsonBody).toMatchObject({
+      success: false,
+      error: { code: 'FORBIDDEN_ORIGIN' },
+    });
+  });
+
+  it('passes when Origin header is the empty string (defensive parsing)', () => {
+    const out = exec({ origin: '' });
+    expect(out.calledNext).toBe(true);
+  });
+
+  it('rejects 403 when Sec-Fetch-Site is cross-site', () => {
+    const out = exec({ 'sec-fetch-site': 'cross-site' });
+    expect(out.calledNext).toBe(false);
+    expect(out.statusCode).toBe(403);
+    expect(out.jsonBody).toMatchObject({
+      success: false,
+      error: { code: 'FORBIDDEN_SITE' },
+    });
+  });
+
+  it('passes when Sec-Fetch-Site is same-origin', () => {
+    const out = exec({ 'sec-fetch-site': 'same-origin' });
+    expect(out.calledNext).toBe(true);
+  });
+
+  it('passes when Sec-Fetch-Site is same-site', () => {
+    const out = exec({ 'sec-fetch-site': 'same-site' });
+    expect(out.calledNext).toBe(true);
+  });
+
+  it('passes when Sec-Fetch-Site is none (top-level navigation)', () => {
+    const out = exec({ 'sec-fetch-site': 'none' });
+    expect(out.calledNext).toBe(true);
+  });
+
+  it('rejects when both signals point cross-site (Origin wins, returns FORBIDDEN_ORIGIN)', () => {
+    const out = exec({
+      origin: 'https://attacker.example.com',
+      'sec-fetch-site': 'cross-site',
+    });
+    expect(out.calledNext).toBe(false);
+    expect(out.statusCode).toBe(403);
+    // Origin check runs first, so the more specific code is returned.
+    expect(out.jsonBody).toMatchObject({
+      success: false,
+      error: { code: 'FORBIDDEN_ORIGIN' },
+    });
+  });
+
+  it('passes OPTIONS preflight regardless of Origin (CORS owns it)', () => {
+    const out = exec(
+      { origin: 'https://attacker.example.com', 'sec-fetch-site': 'cross-site' },
+      'OPTIONS',
+    );
+    expect(out.calledNext).toBe(true);
+    expect(out.statusCode).toBeNull();
+  });
+
+  it('applies to all non-OPTIONS methods (GET, POST, PATCH, DELETE)', () => {
+    for (const method of ['GET', 'POST', 'PATCH', 'DELETE'] as const) {
+      const out = exec({ origin: 'https://attacker.example.com' }, method);
+      expect(out.calledNext, `method=${method}`).toBe(false);
+      expect(out.statusCode, `method=${method}`).toBe(403);
+    }
+  });
+});

--- a/server/src/middleware/csrf.ts
+++ b/server/src/middleware/csrf.ts
@@ -1,0 +1,47 @@
+import type { NextFunction, Request, Response } from 'express';
+import { env } from '../config/env.js';
+import { fail } from '../lib/response.js';
+
+/**
+ * CSRF defense for cookie-authenticated state changes.
+ *
+ * CORS only controls whether the *response* is readable to JavaScript — a
+ * cross-site form-encoded POST is a \"simple request\" that skips preflight,
+ * so the request still reaches the route handler and side effects (revoke
+ * session, rotate token, log out) execute regardless. We need to short-
+ * circuit cross-site requests *before* the route runs.
+ *
+ * Two independent signals are checked:
+ *
+ *  - `Origin`: every browser-driven cross-origin request carries this.
+ *    If present and not equal to `env.appUrl`, reject.
+ *  - `Sec-Fetch-Site`: modern browsers add this metadata. If `cross-site`,
+ *    reject. (Defense in depth alongside Origin — independent header,
+ *    harder to lose simultaneously to a config drift or browser bug.)
+ *
+ * No headers present = server-to-server / curl / Playwright
+ * `request.newContext()`. None of those can be CSRF-exploited (no automatic
+ * cookie attachment from a victim's browser), so they pass through.
+ *
+ * `OPTIONS` preflight passes through; CORS owns that surface.
+ */
+export function requireSameSite(req: Request, res: Response, next: NextFunction): void {
+  if (req.method === 'OPTIONS') {
+    next();
+    return;
+  }
+
+  const origin = req.headers.origin;
+  if (typeof origin === 'string' && origin !== '' && origin !== env.appUrl) {
+    res.status(403).json(fail('FORBIDDEN_ORIGIN', `Origin not allowed: ${origin}`));
+    return;
+  }
+
+  const fetchSite = req.headers['sec-fetch-site'];
+  if (fetchSite === 'cross-site') {
+    res.status(403).json(fail('FORBIDDEN_SITE', 'Cross-site request blocked'));
+    return;
+  }
+
+  next();
+}


### PR DESCRIPTION
Closes #92. Refs #82, the audit follow-up tracking issue #83.

## Summary

The audit (and Codex's review of #82) flagged the project as \"relying entirely on `SameSite=Lax`\" for CSRF protection. **That was wrong** — `server/src/index.ts:54-61` already short-circuited cross-origin requests with 403 when `Origin` was set and didn't match `env.appUrl`. The actual gap was narrower:

1. The check was inline, anonymous, with the misleading code `CORS_FORBIDDEN` (CORS already ran above).
2. It had no parallel `Sec-Fetch-Site` check.
3. No CI signal pinned the security boundary — a future refactor that dropped the check would not fail any test.

Issue #92 was updated mid-implementation to reflect this corrected scope.

## Two commits

1. **`feat(middleware): add requireSameSite — Origin + Sec-Fetch-Site CSRF guard`** — new `server/src/middleware/csrf.ts` and `csrf.test.ts`. 11 tests cover same-origin pass, cross-origin reject, every `Sec-Fetch-Site` value (`none`, `same-origin`, `same-site`, `cross-site`), `OPTIONS` preflight bypass (CORS owns it), and method coverage (GET / POST / PATCH / DELETE).

2. **`feat(server): mount requireSameSite, drop inline Origin guard`** — replaces the inline block in `index.ts` with `app.use(requireSameSite)`. Error code rename `CORS_FORBIDDEN` → `FORBIDDEN_ORIGIN` (verified by grep that no client / test consumes the old code). Cross-site requests now also get rejected via the new `FORBIDDEN_SITE` code.

## Why CORS isn't enough on its own

CORS only controls whether the *response* is readable to JavaScript. A cross-site form-encoded POST is a \"simple request\" that skips preflight, so the request still reaches the handler and side effects (revoke session, rotate token, log out) execute regardless of CORS. The pre-route 403 short-circuits before the handler runs.

## Verification

```
npm run lint                          ✅
npm run typecheck                     ✅
npm run test --workspace server       ✅ 207/207 (+11 new csrf tests, +9 vitest discovery)
npm run test --workspace client       ✅ 1/1
npm run format:check                  ✅
npm run build                         ✅
```

## Backward compatibility

Identical behavior to the previous inline check, plus one strict addition:

- Browser SPA (matching Origin) → pass, unchanged.
- Playwright `playwright.request.newContext()` (no headers) → pass, unchanged.
- Real browser via Playwright (matching Origin) → pass, unchanged.
- curl / Postman / server-to-server (no headers) → pass, unchanged.
- Cross-origin browser POST → 403, unchanged.
- Hypothetical request with `Sec-Fetch-Site: cross-site` but no Origin → **now 403 (was: pass)**. In practice no real browser sends one without the other; this catches custom HTTP libs that mimic browsers selectively.

## Out of scope

- CSRF token (synchronizer / double-submit) — heavier machinery, requires SPA cooperation. Not needed given the existing Origin check (now hardened) is correct for the threat model.
- Subdomain hardening (cookie `domain` attribute) — separate posture concern.

## Test plan

- [x] CI green
- [ ] Manual: `curl -X POST -H 'Origin: https://attacker.example.com' http://localhost:3000/api/auth/refresh` returns 403 with `FORBIDDEN_ORIGIN`
- [ ] Manual: `curl -X POST -H 'Sec-Fetch-Site: cross-site' http://localhost:3000/api/auth/refresh` returns 403 with `FORBIDDEN_SITE`
- [ ] Manual: SPA happy paths (login / refresh / logout / job CRUD) still work — Origin matches `env.appUrl`