### PR TITLE
test(e2e): seed real refresh cookie + refreshExpiresAt instead of shim

### DIFF
--- a/client/tests/e2e/helpers.ts
+++ b/client/tests/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { test as base, type APIRequestContext, type Page } from '@playwright/test';
+import { test as base, type APIRequestContext, type Cookie, type Page } from '@playwright/test';
 
 export const API_BASE = 'http://localhost:3000';
 
@@ -6,6 +6,15 @@ export type Session = {
   email: string;
   password: string;
   accessToken: string;
+  /** ISO timestamp from the login response — drives RequireAuth's staleness gate. */
+  refreshExpiresAt: string;
+  /**
+   * Cookies captured from the request context that performed the login,
+   * including the HttpOnly `refreshToken` set by the server. Replayed into
+   * the browser context by `primeAuth` so /api/auth/refresh works in tests
+   * that exercise it.
+   */
+  cookies: Cookie[];
   userId: string;
 };
 
@@ -43,12 +52,18 @@ export async function registerAndLogin(request: APIRequestContext): Promise<Sess
     throw new Error(`login failed: ${login.status()} ${await login.text()}`);
   }
   const body = (await login.json()) as {
-    data: { accessToken: string; user: { id: string } };
+    data: { accessToken: string; refreshExpiresAt: string; user: { id: string } };
   };
+  // Capture the cookies that the request context received from /login —
+  // includes the HttpOnly `refreshToken` we'll replay into the browser
+  // context via primeAuth so /api/auth/refresh works in tests.
+  const storage = await request.storageState();
   return {
     email,
     password,
     accessToken: body.data.accessToken,
+    refreshExpiresAt: body.data.refreshExpiresAt,
+    cookies: storage.cookies,
     userId: body.data.user.id,
   };
 }
@@ -87,13 +102,20 @@ export const test = base.extend<
 export const expect = base.expect;
 
 export async function primeAuth(page: Page, session: Session): Promise<void> {
+  // Replay the real refresh cookie into the browser context. Tests that
+  // exercise /api/auth/refresh now actually have a server-recognized
+  // cookie to send; previously this was missing and a fake 1-hour
+  // refreshExpiresAt was used to dodge RequireAuth's staleness check.
+  if (session.cookies.length > 0) {
+    await page.context().addCookies(session.cookies);
+  }
   await page.addInitScript((s) => {
     localStorage.setItem(
       'smartscrape-auth',
       JSON.stringify({
         state: {
           accessToken: s.accessToken,
-          refreshExpiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          refreshExpiresAt: s.refreshExpiresAt,
           user: { id: s.userId, email: s.email, name: 'E2E User', email_verified: false },
         },
         version: 0,


### PR DESCRIPTION
Closes #94. Refs #82, the audit follow-up tracking issue #83. **Last cleanup item from the smartscrape audit-follow-up backlog.**

## Summary

Commit `7212b50` (the recovery commit after PR #82's broken main) shimmed e2e auth priming with a hardcoded \"1 hour from now\" `refreshExpiresAt` and never seeded a refresh cookie at all. That was enough to keep happy-path tests green, but a test that exercised `/api/auth/refresh` would fail — there's no real cookie in the browser context for the server to find.

## Approach

Real values, not shims:

1. `registerAndLogin` already calls `/api/auth/login`. The response body now has a real `refreshExpiresAt` (since #82) and the response sets a real `Set-Cookie: refreshToken=…; HttpOnly; Path=/api/auth; SameSite=Lax`. Capture both.
2. `await request.storageState()` extracts the cookies that landed in the request context — including the HttpOnly refresh cookie. Stash them on `Session.cookies`.
3. `primeAuth` replays the cookies into the page's browser context with `page.context().addCookies(...)` before priming localStorage. Then writes the real `refreshExpiresAt`, not the 1-hour synthetic.

Future tests that drive a refresh path (e.g. forced 401 → automatic refresh in `client/src/lib/api.ts`) will now work end-to-end — server finds the cookie, rotates it, returns new `accessToken` + new `Set-Cookie`.

## Verification

```
npm run lint                          ✅
npm run typecheck                     ✅
npm run test --workspace server       ✅ 218/218
npm run test --workspace client       ✅ 1/1
npm run format:check                  ✅  (after `prettier --write`)
npm run build                         ✅
```

Plus the existing e2e job exercises `primeAuth` on every test — green CI here means the cookie-add path works for the real Playwright runtime.

## Backward compatibility

`Session` only gained fields. Existing tests read `accessToken` and `userId` only, no changes needed. No public API surface in `helpers.ts` changed shape.

## Test plan

- [x] CI green (especially the `e2e` job)
- [ ] Optional: write a real refresh-flow e2e test now that the plumbing works (separate PR; `Session.cookies` and `Session.refreshExpiresAt` are sufficient)