### PR TITLE
feat(cli): headless CLI client for the REST API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ test-results/
 .vscode/
 !.vscode/extensions.json
 .idea/
+.tmp/

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ node cli/dist/index.js results <job-id> --json
 node cli/dist/index.js export <job-id> --csv > out.csv
 ```
 
-Every command supports `--json`, `--quiet`, `--url`, `--token`. Exit codes: `0` success, `1` generic, `2` auth, `3` not found, `4` validation. See [cli/README.md](cli/README.md) for the full command list.
+Every command supports `--json`, `--quiet`, `--server-url`, `--token`. Exit codes: `0` success, `1` generic, `2` auth, `3` not found, `4` validation. See [cli/README.md](cli/README.md) for the full command list.
 
 ## How a run works
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,27 @@ Create an account, add at least one AI provider key under **Settings → AI Prov
 | `npm run test:e2e --workspace client` | Playwright smoke suite (requires dev server running) |
 | `npm run docs:screenshots --workspace client` | Regenerate the README screenshots |
 
+## CLI
+
+`@smartscrape/cli` is a headless client for the REST API — built so cron jobs, scripts, and external agents can drive SmartScrape without a browser. Source lives in [`cli/`](cli).
+
+```bash
+# Build the CLI workspace
+npm install
+npm run -w @smartscrape/cli build
+
+# Sign in (writes ~/.smartscrape/config.json) — or set SMARTSCRAPE_URL + SMARTSCRAPE_TOKEN
+node cli/dist/index.js auth login --url http://localhost:3000 --email you@example.com --password '...'
+
+# Drive everything
+node cli/dist/index.js jobs list --json
+node cli/dist/index.js jobs run <job-id> --wait --json
+node cli/dist/index.js results <job-id> --json
+node cli/dist/index.js export <job-id> --csv > out.csv
+```
+
+Every command supports `--json`, `--quiet`, `--url`, `--token`. Exit codes: `0` success, `1` generic, `2` auth, `3` not found, `4` validation. See [cli/README.md](cli/README.md) for the full command list.
+
 ## How a run works
 
 1. You hit **Run now** (or cron fires the job).
@@ -186,6 +207,7 @@ Create an account, add at least one AI provider key under **Settings → AI Prov
 smartscrape/
   server/    # Express + TS API, migrations, BullMQ worker
   client/    # React + Vite + Tailwind SPA + Playwright smoke tests
+  cli/       # Headless CLI client (commander + native fetch)
   docs/      # Screenshots, assets
   docker-compose.yml     # Postgres 16 + Redis 7 for local dev
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,47 @@
+# SmartScrape CLI
+
+Headless command-line client for the SmartScrape REST API. Built so external
+agents (OpenClaw, cron jobs, scripts) can drive SmartScrape without a browser.
+
+## Install (within the monorepo)
+
+```bash
+npm install
+npm run -w @smartscrape/cli build
+node cli/dist/index.js --help
+```
+
+Once published or linked, the `smartscrape` binary is available globally.
+
+## Configure
+
+The CLI reads `SMARTSCRAPE_URL` and `SMARTSCRAPE_TOKEN` from the environment, or
+falls back to `~/.smartscrape/config.json` written by `auth login`.
+
+```bash
+# Interactive login (writes config + refresh cookie)
+smartscrape auth login --url http://localhost:3000 --email you@example.com --password '...'
+
+# Non-interactive — env-only (preferred for cron/agents)
+export SMARTSCRAPE_URL=http://localhost:3000
+export SMARTSCRAPE_TOKEN=eyJhbGciOiJIUzI1NiIs...
+smartscrape jobs list --json
+```
+
+## Commands
+
+```
+auth login | logout | whoami
+jobs list | show <id> | create | edit <id> | delete <id> | toggle <id> | run <id>
+runs show <id> | data <id> | diff <id>
+results <job-id>            # latest run's data
+export <job-id> --csv | --json | --sheets
+settings show | set <key=value> | unset <key>
+providers list | set --provider <p> --key <k> | test <p> | delete <p>
+notifications test email | telegram
+dashboard stats
+```
+
+Every command supports `--json` (raw JSON to stdout) and `--quiet` (suppress
+non-error output). Exit codes: `0` success, `1` generic error, `2` auth failure,
+`3` not found, `4` validation error.

--- a/cli/README.md
+++ b/cli/README.md
@@ -43,5 +43,6 @@ dashboard stats
 ```
 
 Every command supports `--json` (raw JSON to stdout) and `--quiet` (suppress
-non-error output). Exit codes: `0` success, `1` generic error, `2` auth failure,
+non-error output), plus `--server-url` and `--token` for per-invocation
+overrides. Exit codes: `0` success, `1` generic error, `2` auth failure,
 `3` not found, `4` validation error.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@smartscrape/cli",
+  "version": "0.9.0",
+  "private": true,
+  "type": "module",
+  "description": "Command-line client for SmartScrape — drives the REST API headlessly for cron and agent automation.",
+  "main": "dist/index.js",
+  "bin": {
+    "smartscrape": "dist/index.js"
+  },
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "cli-table3": "^0.6.5",
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3",
+    "vitest": "^4.1.5"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -103,7 +103,11 @@ export function extractRefreshCookie(setCookieHeader: string): string | null {
 export function createClient(overrides?: { url?: string; token?: string }): ApiClient {
   const session = resolveSession(overrides);
 
-  async function doFetch(path: string, opts: RequestOpts = {}, token: string | null): Promise<Response> {
+  async function doFetch(
+    path: string,
+    opts: RequestOpts = {},
+    token: string | null,
+  ): Promise<Response> {
     const url = buildUrl(session.url, path, opts.query);
     const headers: Record<string, string> = {
       accept: 'application/json',
@@ -144,10 +148,7 @@ export function createClient(overrides?: { url?: string; token?: string }): ApiC
           EXIT.ERROR,
         );
       }
-      throw new CliError(
-        `Request to ${path} failed: HTTP ${res.status}`,
-        statusToExit(res.status),
-      );
+      throw new CliError(`Request to ${path} failed: HTTP ${res.status}`, statusToExit(res.status));
     }
     let parsed: ApiResponse<T>;
     try {
@@ -156,7 +157,11 @@ export function createClient(overrides?: { url?: string; token?: string }): ApiC
       throw new CliError(`Invalid JSON from ${path}`, EXIT.ERROR);
     }
     if (!res.ok || !parsed.success) {
-      throw apiErrorToCli(res.status, parsed.success === false ? parsed.error : null, `HTTP ${res.status}`);
+      throw apiErrorToCli(
+        res.status,
+        parsed.success === false ? parsed.error : null,
+        `HTTP ${res.status}`,
+      );
     }
     return parsed.data;
   }

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -1,0 +1,175 @@
+import { CliError, EXIT } from './output.js';
+import { loadConfig, resolveSession, saveConfig, type ResolvedSession } from './config.js';
+import type { ApiError, ApiResponse } from './types.js';
+
+export type RequestOpts = {
+  method?: string;
+  body?: unknown;
+  query?: Record<string, string | number | boolean | undefined>;
+  /**
+   * If true, do not attempt the standard JWT refresh flow on 401. Used by
+   * /auth/login itself and by /auth/refresh to avoid re-entrant loops.
+   */
+  noAutoRefresh?: boolean;
+  /**
+   * If true, return the raw Response so callers can read headers (Set-Cookie,
+   * Content-Disposition) or non-JSON bodies (CSV).
+   */
+  raw?: boolean;
+  /**
+   * Extra headers to forward (mostly used for the refresh-cookie replay).
+   */
+  headers?: Record<string, string>;
+};
+
+export type ApiClient = {
+  session: ResolvedSession;
+  request: <T>(path: string, opts?: RequestOpts) => Promise<T>;
+  requestRaw: (path: string, opts?: RequestOpts) => Promise<Response>;
+};
+
+function buildUrl(base: string, path: string, query?: RequestOpts['query']): string {
+  const u = new URL(path.startsWith('/') ? path : `/${path}`, base);
+  if (query) {
+    for (const [k, v] of Object.entries(query)) {
+      if (v !== undefined && v !== null) u.searchParams.set(k, String(v));
+    }
+  }
+  return u.toString();
+}
+
+function statusToExit(status: number): number {
+  if (status === 401 || status === 403) return EXIT.AUTH;
+  if (status === 404) return EXIT.NOT_FOUND;
+  if (status === 400 || status === 422) return EXIT.VALIDATION;
+  return EXIT.ERROR;
+}
+
+function apiErrorToCli(status: number, err: ApiError | null, fallback: string): CliError {
+  const message = err?.message ?? fallback;
+  return new CliError(message, statusToExit(status), err?.code);
+}
+
+/**
+ * Attempt the cookie-only refresh flow once and persist the new pair. Returns
+ * the new access token on success, or null if refresh failed (caller should
+ * surface the original 401).
+ */
+async function tryRefresh(session: ResolvedSession): Promise<string | null> {
+  if (!session.refreshCookie) return null;
+  const url = buildUrl(session.url, '/api/auth/refresh');
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        cookie: session.refreshCookie,
+      },
+    });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+  const setCookie = res.headers.get('set-cookie');
+  let body: ApiResponse<{ accessToken: string; refreshExpiresAt: string }>;
+  try {
+    body = (await res.json()) as ApiResponse<{ accessToken: string; refreshExpiresAt: string }>;
+  } catch {
+    return null;
+  }
+  if (!body.success) return null;
+  const stored = loadConfig();
+  stored.accessToken = body.data.accessToken;
+  stored.refreshExpiresAt = body.data.refreshExpiresAt;
+  if (setCookie) stored.refreshCookie = extractRefreshCookie(setCookie);
+  saveConfig(stored);
+  return body.data.accessToken;
+}
+
+/**
+ * The server's Set-Cookie header looks like:
+ *   refreshToken=...; Path=/; HttpOnly; SameSite=Strict; Expires=...
+ * We only need the `name=value` pair to replay. Strip attributes.
+ */
+export function extractRefreshCookie(setCookieHeader: string): string | null {
+  // Multiple Set-Cookie values can be comma-joined by some fetch implementations.
+  // node:fetch concatenates them with ", " — but commas inside Expires dates
+  // make naive splitting unsafe. Instead, find the refreshToken segment.
+  const match = setCookieHeader.match(/refreshToken=[^;,\s]+/);
+  return match ? match[0] : null;
+}
+
+export function createClient(overrides?: { url?: string; token?: string }): ApiClient {
+  const session = resolveSession(overrides);
+
+  async function doFetch(path: string, opts: RequestOpts = {}, token: string | null): Promise<Response> {
+    const url = buildUrl(session.url, path, opts.query);
+    const headers: Record<string, string> = {
+      accept: 'application/json',
+      ...(opts.headers ?? {}),
+    };
+    if (token) headers['authorization'] = `Bearer ${token}`;
+    let body: string | undefined;
+    if (opts.body !== undefined) {
+      headers['content-type'] = 'application/json';
+      body = JSON.stringify(opts.body);
+    }
+    return fetch(url, { method: opts.method ?? 'GET', headers, body });
+  }
+
+  async function requestRaw(path: string, opts: RequestOpts = {}): Promise<Response> {
+    let token = session.token;
+    let res = await doFetch(path, opts, token);
+    if (res.status === 401 && !opts.noAutoRefresh && session.refreshCookie) {
+      const refreshed = await tryRefresh(session);
+      if (refreshed) {
+        token = refreshed;
+        session.token = refreshed;
+        res = await doFetch(path, opts, token);
+      }
+    }
+    return res;
+  }
+
+  async function request<T>(path: string, opts: RequestOpts = {}): Promise<T> {
+    const res = await requestRaw(path, opts);
+    const ct = res.headers.get('content-type') ?? '';
+    if (!ct.includes('application/json')) {
+      if (res.ok) {
+        // Caller asked for JSON but server returned something else (e.g. CSV).
+        // Force them to use raw mode.
+        throw new CliError(
+          `Expected JSON response from ${path} but received ${ct || 'unknown'}`,
+          EXIT.ERROR,
+        );
+      }
+      throw new CliError(
+        `Request to ${path} failed: HTTP ${res.status}`,
+        statusToExit(res.status),
+      );
+    }
+    let parsed: ApiResponse<T>;
+    try {
+      parsed = (await res.json()) as ApiResponse<T>;
+    } catch {
+      throw new CliError(`Invalid JSON from ${path}`, EXIT.ERROR);
+    }
+    if (!res.ok || !parsed.success) {
+      throw apiErrorToCli(res.status, parsed.success === false ? parsed.error : null, `HTTP ${res.status}`);
+    }
+    return parsed.data;
+  }
+
+  return { session, request, requestRaw };
+}
+
+export function requireToken(client: ApiClient): void {
+  if (!client.session.token) {
+    throw new CliError(
+      "Not signed in. Run 'smartscrape auth login' or set SMARTSCRAPE_TOKEN.",
+      EXIT.AUTH,
+      'NO_TOKEN',
+    );
+  }
+}

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -1,14 +1,7 @@
 import { Command } from 'commander';
 import { createClient, extractRefreshCookie } from '../api.js';
 import { clearConfig, configFilePath, loadConfig, saveConfig } from '../config.js';
-import {
-  CliError,
-  EXIT,
-  emitJson,
-  emitText,
-  runCommand,
-  type GlobalFlags,
-} from '../output.js';
+import { CliError, EXIT, emitJson, emitText, runCommand, type GlobalFlags } from '../output.js';
 import type { ApiResponse, UserPublic } from '../types.js';
 
 type LoginResponse = {

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -95,7 +95,7 @@ export function authCommand(getFlags: () => GlobalFlags): Command {
     .action(async () => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         if (!client.session.token) {
           throw new CliError(
             "Not signed in. Run 'smartscrape auth login' or set SMARTSCRAPE_TOKEN.",

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -1,0 +1,126 @@
+import { Command } from 'commander';
+import { createClient, extractRefreshCookie } from '../api.js';
+import { clearConfig, configFilePath, loadConfig, saveConfig } from '../config.js';
+import {
+  CliError,
+  EXIT,
+  emitJson,
+  emitText,
+  runCommand,
+  type GlobalFlags,
+} from '../output.js';
+import type { ApiResponse, UserPublic } from '../types.js';
+
+type LoginResponse = {
+  user: UserPublic;
+  accessToken: string;
+  refreshExpiresAt: string;
+};
+
+export function authCommand(getFlags: () => GlobalFlags): Command {
+  const auth = new Command('auth').description('Authenticate against a SmartScrape server');
+
+  auth
+    .command('login')
+    .description('Sign in with email + password and persist a token to ~/.smartscrape/config.json')
+    .requiredOption('--email <email>', 'Account email')
+    .requiredOption('--password <password>', 'Account password')
+    .option('--url <url>', 'Server URL (default: http://localhost:3000 or $SMARTSCRAPE_URL)')
+    .action(async (opts: { email: string; password: string; url?: string }) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const url = opts.url ?? process.env.SMARTSCRAPE_URL ?? loadConfig().url;
+        const target = new URL('/api/auth/login', url).toString();
+        const res = await fetch(target, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', accept: 'application/json' },
+          body: JSON.stringify({ email: opts.email, password: opts.password }),
+        });
+        const body = (await res.json().catch(() => null)) as ApiResponse<LoginResponse> | null;
+        if (!res.ok || !body || !body.success) {
+          const code = body && !body.success ? body.error.code : 'LOGIN_FAILED';
+          const message =
+            body && !body.success ? body.error.message : `Login failed (HTTP ${res.status})`;
+          throw new CliError(message, res.status === 401 ? EXIT.AUTH : EXIT.ERROR, code);
+        }
+        const setCookie = res.headers.get('set-cookie');
+        const refreshCookie = setCookie ? extractRefreshCookie(setCookie) : null;
+        saveConfig({
+          url: url.replace(/\/$/, ''),
+          accessToken: body.data.accessToken,
+          refreshCookie,
+          refreshExpiresAt: body.data.refreshExpiresAt,
+          email: body.data.user.email,
+        });
+        if (flags.json) {
+          emitJson(
+            {
+              email: body.data.user.email,
+              configPath: configFilePath(),
+              refreshExpiresAt: body.data.refreshExpiresAt,
+            },
+            flags,
+          );
+        } else {
+          emitText(
+            `Signed in as ${body.data.user.email}. Config written to ${configFilePath()}.`,
+            flags,
+          );
+        }
+      });
+    });
+
+  auth
+    .command('logout')
+    .description('Revoke the refresh token on the server and clear local config')
+    .action(async () => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const stored = loadConfig();
+        if (stored.refreshCookie) {
+          try {
+            await fetch(new URL('/api/auth/logout', stored.url).toString(), {
+              method: 'POST',
+              headers: {
+                accept: 'application/json',
+                cookie: stored.refreshCookie,
+              },
+            });
+          } catch {
+            // best-effort revoke; we still clear the local config below
+          }
+        }
+        clearConfig();
+        if (flags.json) emitJson({ loggedOut: true }, flags);
+        else emitText('Signed out and cleared local config.', flags);
+      });
+    });
+
+  auth
+    .command('whoami')
+    .description('Show the currently authenticated user')
+    .action(async () => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({ url: flags.url, token: flags.token });
+        if (!client.session.token) {
+          throw new CliError(
+            "Not signed in. Run 'smartscrape auth login' or set SMARTSCRAPE_TOKEN.",
+            EXIT.AUTH,
+            'NO_TOKEN',
+          );
+        }
+        const data = await client.request<{ user: UserPublic }>('/api/auth/me');
+        if (flags.json) {
+          emitJson(data.user, flags);
+        } else {
+          emitText(
+            `${data.user.email}${data.user.name ? ` (${data.user.name})` : ''} — verified: ${data.user.email_verified}`,
+            flags,
+          );
+        }
+      });
+    });
+
+  return auth;
+}

--- a/cli/src/commands/dashboard.ts
+++ b/cli/src/commands/dashboard.ts
@@ -12,7 +12,7 @@ export function dashboardCommand(getFlags: () => GlobalFlags): Command {
     .action(async () => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<DashboardStats>('/api/dashboard/stats');
         if (flags.json) emitJson(data, flags);

--- a/cli/src/commands/dashboard.ts
+++ b/cli/src/commands/dashboard.ts
@@ -1,0 +1,33 @@
+import { Command } from 'commander';
+import { createClient, requireToken } from '../api.js';
+import { emitJson, emitText, runCommand, type GlobalFlags } from '../output.js';
+import type { DashboardStats } from '../types.js';
+
+export function dashboardCommand(getFlags: () => GlobalFlags): Command {
+  const dash = new Command('dashboard').description('Snapshot of activity across all jobs');
+
+  dash
+    .command('stats')
+    .description('Active jobs, runs today, items tracked, changes this week')
+    .action(async () => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<DashboardStats>('/api/dashboard/stats');
+        if (flags.json) emitJson(data, flags);
+        else
+          emitText(
+            [
+              `Active jobs:        ${data.active_jobs}`,
+              `Runs today:         ${data.runs_today}`,
+              `Items tracked:      ${data.items_tracked}`,
+              `Changes this week:  ${data.changes_this_week}`,
+            ].join('\n'),
+            flags,
+          );
+      });
+    });
+
+  return dash;
+}

--- a/cli/src/commands/export.ts
+++ b/cli/src/commands/export.ts
@@ -1,13 +1,6 @@
 import { Command } from 'commander';
 import { createClient, requireToken } from '../api.js';
-import {
-  CliError,
-  EXIT,
-  emitJson,
-  emitText,
-  runCommand,
-  type GlobalFlags,
-} from '../output.js';
+import { CliError, EXIT, emitJson, emitText, runCommand, type GlobalFlags } from '../output.js';
 import type { ExtractedDataDTO, RunDTO } from '../types.js';
 
 /**
@@ -20,7 +13,7 @@ export function exportCommand(getFlags: () => GlobalFlags): Command {
     .argument('<jobId>')
     .option('--csv', 'Stream the server-rendered CSV to stdout')
     .option('--json', 'Print the extracted-data rows as JSON')
-    .option('--sheets', 'Push the latest run to the job\'s linked Google Sheet')
+    .option('--sheets', "Push the latest run to the job's linked Google Sheet")
     .option('--run-id <id>', 'Use a specific run instead of the latest completed one')
     .action(
       async (
@@ -78,7 +71,9 @@ export function exportCommand(getFlags: () => GlobalFlags): Command {
           }
 
           // JSON path — fetch raw rows via /api/runs/:id/data.
-          const data = await client.request<{ data: ExtractedDataDTO[] }>(`/api/runs/${runId}/data`);
+          const data = await client.request<{ data: ExtractedDataDTO[] }>(
+            `/api/runs/${runId}/data`,
+          );
           process.stdout.write(JSON.stringify(data.data, null, 2) + '\n');
         });
       },

--- a/cli/src/commands/export.ts
+++ b/cli/src/commands/export.ts
@@ -30,7 +30,7 @@ export function exportCommand(getFlags: () => GlobalFlags): Command {
               'BAD_TARGET',
             );
           }
-          const client = createClient({ url: flags.url, token: flags.token });
+          const client = createClient({ url: flags.serverUrl, token: flags.token });
           requireToken(client);
 
           if (opts.sheets) {

--- a/cli/src/commands/export.ts
+++ b/cli/src/commands/export.ts
@@ -1,0 +1,86 @@
+import { Command } from 'commander';
+import { createClient, requireToken } from '../api.js';
+import {
+  CliError,
+  EXIT,
+  emitJson,
+  emitText,
+  runCommand,
+  type GlobalFlags,
+} from '../output.js';
+import type { ExtractedDataDTO, RunDTO } from '../types.js';
+
+/**
+ * Export the latest run's data as CSV (server-rendered), JSON (rows), or push
+ * to the linked Google Sheet. Mutually exclusive flags — one must be set.
+ */
+export function exportCommand(getFlags: () => GlobalFlags): Command {
+  return new Command('export')
+    .description('Export the latest run for a job to CSV, JSON, or the linked Google Sheet')
+    .argument('<jobId>')
+    .option('--csv', 'Stream the server-rendered CSV to stdout')
+    .option('--json', 'Print the extracted-data rows as JSON')
+    .option('--sheets', 'Push the latest run to the job\'s linked Google Sheet')
+    .option('--run-id <id>', 'Use a specific run instead of the latest completed one')
+    .action(
+      async (
+        jobId: string,
+        opts: { csv?: boolean; json?: boolean; sheets?: boolean; runId?: string },
+      ) => {
+        const flags = getFlags();
+        await runCommand(flags, async () => {
+          const targets = [opts.csv, opts.json, opts.sheets].filter(Boolean).length;
+          if (targets !== 1) {
+            throw new CliError(
+              'Specify exactly one of --csv, --json, or --sheets',
+              EXIT.VALIDATION,
+              'BAD_TARGET',
+            );
+          }
+          const client = createClient({ url: flags.url, token: flags.token });
+          requireToken(client);
+
+          if (opts.sheets) {
+            const data = await client.request<{ appended: number; runId: string }>(
+              `/api/jobs/${jobId}/export/sheets`,
+              { method: 'POST' },
+            );
+            if (flags.json) emitJson(data, flags);
+            else emitText(`Appended ${data.appended} row(s) from run ${data.runId}`, flags);
+            return;
+          }
+
+          // Resolve the run id once for both CSV and JSON paths.
+          let runId = opts.runId;
+          if (!runId) {
+            const list = await client.request<{ runs: RunDTO[] }>(`/api/jobs/${jobId}/runs`);
+            const latest = list.runs.find((r) => r.status === 'completed') ?? list.runs[0];
+            if (!latest) throw new CliError('No runs yet', EXIT.NOT_FOUND, 'NO_RUNS');
+            runId = latest.id;
+          }
+
+          if (opts.csv) {
+            const path = opts.runId
+              ? `/api/jobs/${jobId}/export/csv/${runId}`
+              : `/api/jobs/${jobId}/export/csv`;
+            const res = await client.requestRaw(path);
+            if (!res.ok) {
+              throw new CliError(
+                `CSV export failed (HTTP ${res.status})`,
+                res.status === 404 ? EXIT.NOT_FOUND : EXIT.ERROR,
+              );
+            }
+            const text = await res.text();
+            // Always write to stdout — pipe to a file from the shell. --quiet
+            // doesn't suppress data output, only status messages.
+            process.stdout.write(text);
+            return;
+          }
+
+          // JSON path — fetch raw rows via /api/runs/:id/data.
+          const data = await client.request<{ data: ExtractedDataDTO[] }>(`/api/runs/${runId}/data`);
+          process.stdout.write(JSON.stringify(data.data, null, 2) + '\n');
+        });
+      },
+    );
+}

--- a/cli/src/commands/jobs.ts
+++ b/cli/src/commands/jobs.ts
@@ -76,14 +76,12 @@ function parseSchedule(input: string | undefined): string | null | undefined {
   return input;
 }
 
-function buildCreateBody(opts: Record<string, string | string[] | boolean | undefined>): CreateInput {
+function buildCreateBody(
+  opts: Record<string, string | string[] | boolean | undefined>,
+): CreateInput {
   const urls = (opts.url as string[] | undefined) ?? [];
   if (urls.length === 0) {
-    throw new CliError(
-      'At least one --url is required',
-      EXIT.VALIDATION,
-      'MISSING_URL',
-    );
+    throw new CliError('At least one --url is required', EXIT.VALIDATION, 'MISSING_URL');
   }
   const body: CreateInput = {
     name: String(opts.name),
@@ -105,7 +103,9 @@ function buildCreateBody(opts: Record<string, string | string[] | boolean | unde
       | undefined;
   }
   if (opts.channels !== undefined) {
-    body.notify_channels = (opts.channels as string).split(',').map((s) => s.trim()) as NotifyChannel[];
+    body.notify_channels = (opts.channels as string)
+      .split(',')
+      .map((s) => s.trim()) as NotifyChannel[];
   }
   if (opts.comparisonKey !== undefined) body.comparison_key = String(opts.comparisonKey);
   if (opts.provider !== undefined) body.ai_provider = opts.provider as Provider;

--- a/cli/src/commands/jobs.ts
+++ b/cli/src/commands/jobs.ts
@@ -135,7 +135,7 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (opts: { filter: string; limit: number; offset: number }) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<{ items: JobListItem[]; total: number }>('/api/jobs', {
           query: { filter: opts.filter, limit: opts.limit, offset: opts.offset },
@@ -169,7 +169,7 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (id: string) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<{ job: JobDTO }>(`/api/jobs/${id}`);
         if (flags.json) {
@@ -221,7 +221,7 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     const flags = getFlags();
     await runCommand(flags, async () => {
       const body = buildCreateBody(opts);
-      const client = createClient({ url: flags.url, token: flags.token });
+      const client = createClient({ url: flags.serverUrl, token: flags.token });
       requireToken(client);
       const data = await client.request<{ job: JobDTO }>('/api/jobs', {
         method: 'POST',
@@ -284,7 +284,7 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
             'NO_PATCH',
           );
         }
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<{ job: JobDTO }>(`/api/jobs/${id}`, {
           method: 'PATCH',
@@ -301,7 +301,7 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (id: string) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<{ job: JobDTO }>(`/api/jobs/${id}/toggle`, {
           method: 'PATCH',
@@ -325,7 +325,7 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
             'CONFIRM_REQUIRED',
           );
         }
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<{ removed: boolean }>(`/api/jobs/${id}`, {
           method: 'DELETE',
@@ -343,7 +343,7 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (id: string, opts: { wait?: boolean; timeout: number }) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const triggered = await client.request<{ run: RunDTO }>(`/api/jobs/${id}/run`, {
           method: 'POST',

--- a/cli/src/commands/jobs.ts
+++ b/cli/src/commands/jobs.ts
@@ -1,0 +1,370 @@
+import { Command } from 'commander';
+import { readFileSync } from 'node:fs';
+import { createClient, requireToken } from '../api.js';
+import {
+  CliError,
+  EXIT,
+  ageString,
+  emitJson,
+  emitText,
+  renderTable,
+  runCommand,
+  shortId,
+  type GlobalFlags,
+} from '../output.js';
+import type {
+  JobDTO,
+  JobListItem,
+  NotificationRule,
+  NotifyChannel,
+  Provider,
+  RunDTO,
+  ScrapeMethod,
+} from '../types.js';
+
+type CreateInput = {
+  name: string;
+  urls: string[];
+  extraction_prompt: string;
+  extraction_schema?: Record<string, 'string' | 'number' | 'boolean' | 'array' | 'object'> | null;
+  scrape_method?: ScrapeMethod;
+  schedule?: string | null;
+  enabled?: boolean;
+  notification_rules?: NotificationRule[];
+  notify_channels?: NotifyChannel[];
+  comparison_key?: string | null;
+  ai_provider?: Provider;
+  ai_model?: string;
+  google_sheet_id?: string | null;
+  sheet_tab_name?: string | null;
+  setup_method?: 'manual' | 'ai';
+  respect_robots_txt?: boolean;
+};
+
+function readJsonFromOpt(value: string | undefined, label: string): unknown {
+  if (value === undefined) return undefined;
+  let raw = value;
+  if (raw.startsWith('@')) {
+    const path = raw.slice(1);
+    try {
+      raw = readFileSync(path, 'utf8');
+    } catch (err) {
+      throw new CliError(
+        `Could not read ${label} file '${path}': ${err instanceof Error ? err.message : err}`,
+        EXIT.VALIDATION,
+        'BAD_INPUT',
+      );
+    }
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new CliError(
+      `Invalid JSON for ${label}: ${err instanceof Error ? err.message : err}`,
+      EXIT.VALIDATION,
+      'BAD_INPUT',
+    );
+  }
+}
+
+function parseSchedule(input: string | undefined): string | null | undefined {
+  if (input === undefined) return undefined;
+  if (input === 'none' || input === '') return null;
+  if (input === 'hourly') return '0 * * * *';
+  if (input === 'daily') return '0 9 * * *';
+  if (input === 'weekly') return '0 9 * * 1';
+  return input;
+}
+
+function buildCreateBody(opts: Record<string, string | string[] | boolean | undefined>): CreateInput {
+  const urls = (opts.url as string[] | undefined) ?? [];
+  if (urls.length === 0) {
+    throw new CliError(
+      'At least one --url is required',
+      EXIT.VALIDATION,
+      'MISSING_URL',
+    );
+  }
+  const body: CreateInput = {
+    name: String(opts.name),
+    urls,
+    extraction_prompt: String(opts.prompt ?? ''),
+  };
+  if (opts.schema !== undefined) {
+    body.extraction_schema = readJsonFromOpt(opts.schema as string, '--schema') as
+      | CreateInput['extraction_schema']
+      | undefined;
+  }
+  if (opts.method !== undefined) body.scrape_method = opts.method as ScrapeMethod;
+  const sched = parseSchedule(opts.schedule as string | undefined);
+  if (sched !== undefined) body.schedule = sched;
+  if (opts.disabled === true) body.enabled = false;
+  if (opts.rules !== undefined) {
+    body.notification_rules = readJsonFromOpt(opts.rules as string, '--rules') as
+      | NotificationRule[]
+      | undefined;
+  }
+  if (opts.channels !== undefined) {
+    body.notify_channels = (opts.channels as string).split(',').map((s) => s.trim()) as NotifyChannel[];
+  }
+  if (opts.comparisonKey !== undefined) body.comparison_key = String(opts.comparisonKey);
+  if (opts.provider !== undefined) body.ai_provider = opts.provider as Provider;
+  if (opts.model !== undefined) body.ai_model = String(opts.model);
+  if (opts.sheetId !== undefined) body.google_sheet_id = String(opts.sheetId);
+  if (opts.sheetTab !== undefined) body.sheet_tab_name = String(opts.sheetTab);
+  if (opts.respectRobots !== undefined) body.respect_robots_txt = Boolean(opts.respectRobots);
+  return body;
+}
+
+function statusBadge(job: JobListItem): string {
+  if (!job.enabled) return 'paused';
+  if (job.last_run_status === 'failed') return 'failed';
+  if (job.last_run_status) return `active (${job.last_run_status})`;
+  return 'active';
+}
+
+export function jobsCommand(getFlags: () => GlobalFlags): Command {
+  const jobs = new Command('jobs').description('Manage scrape jobs');
+
+  jobs
+    .command('list')
+    .description('List jobs for the authenticated user')
+    .option('--filter <filter>', 'all|active|paused|failed', 'all')
+    .option('--limit <n>', 'Max rows to return', (v) => parseInt(v, 10), 50)
+    .option('--offset <n>', 'Skip the first N rows', (v) => parseInt(v, 10), 0)
+    .action(async (opts: { filter: string; limit: number; offset: number }) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<{ items: JobListItem[]; total: number }>('/api/jobs', {
+          query: { filter: opts.filter, limit: opts.limit, offset: opts.offset },
+        });
+        if (flags.json) {
+          emitJson(data, flags);
+          return;
+        }
+        const rows = data.items.map((j) => [
+          shortId(j.id),
+          j.name,
+          statusBadge(j),
+          j.schedule ?? 'manual',
+          ageString(j.last_run_at),
+          j.last_run_items ?? '—',
+        ]);
+        emitText(
+          renderTable({
+            head: ['ID', 'Name', 'Status', 'Schedule', 'Last run', 'Items'],
+            rows,
+          }),
+          flags,
+        );
+        emitText(`Total: ${data.total}`, flags);
+      });
+    });
+
+  jobs
+    .command('show <id>')
+    .description('Show a single job')
+    .action(async (id: string) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<{ job: JobDTO }>(`/api/jobs/${id}`);
+        if (flags.json) {
+          emitJson(data.job, flags);
+          return;
+        }
+        const j = data.job;
+        emitText(
+          [
+            `ID:           ${j.id}`,
+            `Name:         ${j.name}`,
+            `Enabled:      ${j.enabled}`,
+            `Schedule:     ${j.schedule ?? 'manual'}`,
+            `Method:       ${j.scrape_method}`,
+            `URLs:`,
+            ...j.urls.map((u) => `  - ${u}`),
+            `Prompt:       ${j.extraction_prompt}`,
+            `AI:           ${j.ai_provider} / ${j.ai_model}`,
+            `Compare key:  ${j.comparison_key ?? '(data hash)'}`,
+            `Channels:     ${j.notify_channels.join(', ') || '(none)'}`,
+            `Rules:        ${j.notification_rules.length}`,
+            `Last run:     ${j.last_run_at ?? 'never'}`,
+            `Created:      ${j.created_at}`,
+          ].join('\n'),
+          flags,
+        );
+      });
+    });
+
+  const create = jobs
+    .command('create')
+    .description('Create a new job (manual setup — use the webapp wizard for AI-assisted setup)')
+    .requiredOption('--name <name>', 'Display name')
+    .requiredOption('--url <url...>', 'Page to scrape (repeatable for multiple URLs)')
+    .requiredOption('--prompt <text>', 'Extraction prompt (what to pull off the page)')
+    .option('--schema <json|@file>', 'Optional extraction schema as JSON or @path')
+    .option('--method <auto|cheerio|playwright>', 'Scrape method', 'auto')
+    .option('--schedule <cron|hourly|daily|weekly|none>', 'Cron expression or preset')
+    .option('--disabled', 'Create the job in a paused state')
+    .option('--rules <json|@file>', 'Notification rules array as JSON or @path')
+    .option('--channels <list>', 'Comma-separated channels: email,telegram')
+    .option('--comparison-key <field>', 'Field used to match rows across runs')
+    .option('--provider <openai|anthropic|openrouter>', 'AI provider')
+    .option('--model <id>', 'AI model id, e.g. openai/gpt-4o-mini')
+    .option('--sheet-id <id>', 'Linked Google Sheet ID')
+    .option('--sheet-tab <name>', 'Tab name within the sheet')
+    .option('--no-respect-robots', 'Ignore robots.txt for this job');
+  create.action(async (opts: Record<string, string | string[] | boolean | undefined>) => {
+    const flags = getFlags();
+    await runCommand(flags, async () => {
+      const body = buildCreateBody(opts);
+      const client = createClient({ url: flags.url, token: flags.token });
+      requireToken(client);
+      const data = await client.request<{ job: JobDTO }>('/api/jobs', {
+        method: 'POST',
+        body,
+      });
+      if (flags.json) emitJson(data.job, flags);
+      else emitText(`Created job ${data.job.id} (${data.job.name})`, flags);
+    });
+  });
+
+  jobs
+    .command('edit <id>')
+    .description('Update fields on an existing job (only flags you pass are sent)')
+    .option('--name <name>', 'Display name')
+    .option('--prompt <text>', 'Extraction prompt')
+    .option('--schema <json|@file>', 'Extraction schema as JSON or @path')
+    .option('--method <auto|cheerio|playwright>', 'Scrape method')
+    .option('--schedule <cron|hourly|daily|weekly|none>', 'Cron expression or preset')
+    .option('--rules <json|@file>', 'Notification rules array')
+    .option('--channels <list>', 'Comma-separated channels: email,telegram')
+    .option('--comparison-key <field>', 'Field used to match rows across runs')
+    .option('--provider <openai|anthropic|openrouter>', 'AI provider')
+    .option('--model <id>', 'AI model id')
+    .option('--sheet-id <id>', 'Linked Google Sheet ID')
+    .option('--sheet-tab <name>', 'Tab name within the sheet')
+    .action(async (id: string, opts: Record<string, string | boolean | undefined>) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const patch: Partial<CreateInput> = {};
+        if (opts.name !== undefined) patch.name = String(opts.name);
+        if (opts.prompt !== undefined) patch.extraction_prompt = String(opts.prompt);
+        if (opts.schema !== undefined) {
+          patch.extraction_schema = readJsonFromOpt(opts.schema as string, '--schema') as
+            | CreateInput['extraction_schema']
+            | undefined;
+        }
+        if (opts.method !== undefined) patch.scrape_method = opts.method as ScrapeMethod;
+        const sched = parseSchedule(opts.schedule as string | undefined);
+        if (sched !== undefined) patch.schedule = sched;
+        if (opts.rules !== undefined) {
+          patch.notification_rules = readJsonFromOpt(opts.rules as string, '--rules') as
+            | NotificationRule[]
+            | undefined;
+        }
+        if (opts.channels !== undefined) {
+          patch.notify_channels = String(opts.channels)
+            .split(',')
+            .map((s) => s.trim()) as NotifyChannel[];
+        }
+        if (opts.comparisonKey !== undefined) patch.comparison_key = String(opts.comparisonKey);
+        if (opts.provider !== undefined) patch.ai_provider = opts.provider as Provider;
+        if (opts.model !== undefined) patch.ai_model = String(opts.model);
+        if (opts.sheetId !== undefined) patch.google_sheet_id = String(opts.sheetId);
+        if (opts.sheetTab !== undefined) patch.sheet_tab_name = String(opts.sheetTab);
+
+        if (Object.keys(patch).length === 0) {
+          throw new CliError(
+            'Pass at least one field to update (e.g. --name, --schedule, --prompt).',
+            EXIT.VALIDATION,
+            'NO_PATCH',
+          );
+        }
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<{ job: JobDTO }>(`/api/jobs/${id}`, {
+          method: 'PATCH',
+          body: patch,
+        });
+        if (flags.json) emitJson(data.job, flags);
+        else emitText(`Updated job ${data.job.id}`, flags);
+      });
+    });
+
+  jobs
+    .command('toggle <id>')
+    .description('Flip the enabled flag — paused jobs become active and vice versa')
+    .action(async (id: string) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<{ job: JobDTO }>(`/api/jobs/${id}/toggle`, {
+          method: 'PATCH',
+        });
+        if (flags.json) emitJson(data.job, flags);
+        else emitText(`Job ${data.job.id} → ${data.job.enabled ? 'active' : 'paused'}`, flags);
+      });
+    });
+
+  jobs
+    .command('delete <id>')
+    .description('Permanently delete a job and its scheduled runs')
+    .option('--confirm', 'Required: confirm the deletion (no interactive prompt)')
+    .action(async (id: string, opts: { confirm?: boolean }) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        if (!opts.confirm) {
+          throw new CliError(
+            'Refusing to delete without --confirm flag',
+            EXIT.VALIDATION,
+            'CONFIRM_REQUIRED',
+          );
+        }
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<{ removed: boolean }>(`/api/jobs/${id}`, {
+          method: 'DELETE',
+        });
+        if (flags.json) emitJson({ id, removed: data.removed }, flags);
+        else emitText(`Deleted job ${id}`, flags);
+      });
+    });
+
+  jobs
+    .command('run <id>')
+    .description('Trigger an immediate run; queues the job and returns the run row')
+    .option('--wait', 'Poll until the run reaches a terminal state, then exit')
+    .option('--timeout <s>', 'Max seconds to wait when --wait is set', (v) => parseInt(v, 10), 300)
+    .action(async (id: string, opts: { wait?: boolean; timeout: number }) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const triggered = await client.request<{ run: RunDTO }>(`/api/jobs/${id}/run`, {
+          method: 'POST',
+        });
+        let final = triggered.run;
+        if (opts.wait) {
+          const deadline = Date.now() + opts.timeout * 1000;
+          // Poll the run endpoint at a modest interval — server-side rate
+          // limits don't kick in for the per-run reads, but we don't need to
+          // hammer either.
+          while (Date.now() < deadline) {
+            const cur = await client.request<{ run: RunDTO }>(`/api/runs/${final.id}`);
+            final = cur.run;
+            if (final.status === 'completed' || final.status === 'failed') break;
+            await new Promise((r) => setTimeout(r, 2000));
+          }
+        }
+        if (flags.json) emitJson(final, flags);
+        else emitText(`Run ${final.id} → ${final.status} (items: ${final.items_extracted})`, flags);
+      });
+    });
+
+  return jobs;
+}

--- a/cli/src/commands/notifications.ts
+++ b/cli/src/commands/notifications.ts
@@ -1,13 +1,6 @@
 import { Command } from 'commander';
 import { createClient, requireToken } from '../api.js';
-import {
-  CliError,
-  EXIT,
-  emitJson,
-  emitText,
-  runCommand,
-  type GlobalFlags,
-} from '../output.js';
+import { CliError, EXIT, emitJson, emitText, runCommand, type GlobalFlags } from '../output.js';
 
 export function notificationsCommand(getFlags: () => GlobalFlags): Command {
   const notif = new Command('notifications').description('Test and inspect notification channels');

--- a/cli/src/commands/notifications.ts
+++ b/cli/src/commands/notifications.ts
@@ -1,0 +1,39 @@
+import { Command } from 'commander';
+import { createClient, requireToken } from '../api.js';
+import {
+  CliError,
+  EXIT,
+  emitJson,
+  emitText,
+  runCommand,
+  type GlobalFlags,
+} from '../output.js';
+
+export function notificationsCommand(getFlags: () => GlobalFlags): Command {
+  const notif = new Command('notifications').description('Test and inspect notification channels');
+
+  notif
+    .command('test <channel>')
+    .description("Send a test notification on 'email' or 'telegram'")
+    .action(async (channel: string) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        if (channel !== 'email' && channel !== 'telegram') {
+          throw new CliError(
+            "Channel must be 'email' or 'telegram'",
+            EXIT.VALIDATION,
+            'BAD_CHANNEL',
+          );
+        }
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<unknown>(`/api/notifications/test/${channel}`, {
+          method: 'POST',
+        });
+        if (flags.json) emitJson(data, flags);
+        else emitText(JSON.stringify(data, null, 2), flags);
+      });
+    });
+
+  return notif;
+}

--- a/cli/src/commands/notifications.ts
+++ b/cli/src/commands/notifications.ts
@@ -18,7 +18,7 @@ export function notificationsCommand(getFlags: () => GlobalFlags): Command {
             'BAD_CHANNEL',
           );
         }
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<unknown>(`/api/notifications/test/${channel}`, {
           method: 'POST',

--- a/cli/src/commands/providers.ts
+++ b/cli/src/commands/providers.ts
@@ -1,0 +1,107 @@
+import { Command } from 'commander';
+import { createClient, requireToken } from '../api.js';
+import {
+  CliError,
+  EXIT,
+  emitJson,
+  emitText,
+  renderTable,
+  runCommand,
+  type GlobalFlags,
+} from '../output.js';
+import type { Provider, ProviderRow } from '../types.js';
+
+const VALID_PROVIDERS = new Set<Provider>(['openai', 'anthropic', 'openrouter']);
+
+function asProvider(value: string): Provider {
+  if (!VALID_PROVIDERS.has(value as Provider)) {
+    throw new CliError(
+      `Unknown provider '${value}'. Use one of: openai, anthropic, openrouter`,
+      EXIT.VALIDATION,
+      'BAD_PROVIDER',
+    );
+  }
+  return value as Provider;
+}
+
+export function providersCommand(getFlags: () => GlobalFlags): Command {
+  const providers = new Command('providers').description(
+    'Manage AI provider API keys (openai / anthropic / openrouter)',
+  );
+
+  providers
+    .command('list')
+    .description('List configured providers (keys are never returned)')
+    .action(async () => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<{ providers: ProviderRow[] }>('/api/providers');
+        if (flags.json) emitJson(data.providers, flags);
+        else
+          emitText(
+            renderTable({
+              head: ['Provider', 'Created', 'Updated'],
+              rows: data.providers.map((p) => [p.provider, p.created_at, p.updated_at]),
+            }),
+            flags,
+          );
+      });
+    });
+
+  providers
+    .command('set')
+    .description('Store or replace the API key for a provider')
+    .requiredOption('--provider <provider>', 'openai|anthropic|openrouter')
+    .requiredOption('--key <key>', 'API key (use a shell here-string to avoid history capture)')
+    .action(async (opts: { provider: string; key: string }) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const provider = asProvider(opts.provider);
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<{ provider: ProviderRow }>('/api/providers', {
+          method: 'POST',
+          body: { provider, apiKey: opts.key },
+        });
+        if (flags.json) emitJson(data.provider, flags);
+        else emitText(`Saved ${provider} key`, flags);
+      });
+    });
+
+  providers
+    .command('test <provider>')
+    .description('Round-trip a real auth call against the provider using the stored key')
+    .action(async (provider: string) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const p = asProvider(provider);
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<unknown>(`/api/providers/${p}/test`, { method: 'POST' });
+        if (flags.json) emitJson(data, flags);
+        else emitText(JSON.stringify(data, null, 2), flags);
+      });
+    });
+
+  providers
+    .command('delete <provider>')
+    .description('Remove the stored API key for a provider')
+    .action(async (provider: string) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const p = asProvider(provider);
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<{ provider: string; removed: boolean }>(
+          `/api/providers/${p}`,
+          { method: 'DELETE' },
+        );
+        if (flags.json) emitJson(data, flags);
+        else emitText(`Removed ${p} key`, flags);
+      });
+    });
+
+  return providers;
+}

--- a/cli/src/commands/providers.ts
+++ b/cli/src/commands/providers.ts
@@ -35,7 +35,7 @@ export function providersCommand(getFlags: () => GlobalFlags): Command {
     .action(async () => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<{ providers: ProviderRow[] }>('/api/providers');
         if (flags.json) emitJson(data.providers, flags);
@@ -59,7 +59,7 @@ export function providersCommand(getFlags: () => GlobalFlags): Command {
       const flags = getFlags();
       await runCommand(flags, async () => {
         const provider = asProvider(opts.provider);
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<{ provider: ProviderRow }>('/api/providers', {
           method: 'POST',
@@ -77,7 +77,7 @@ export function providersCommand(getFlags: () => GlobalFlags): Command {
       const flags = getFlags();
       await runCommand(flags, async () => {
         const p = asProvider(provider);
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<unknown>(`/api/providers/${p}/test`, { method: 'POST' });
         if (flags.json) emitJson(data, flags);
@@ -92,7 +92,7 @@ export function providersCommand(getFlags: () => GlobalFlags): Command {
       const flags = getFlags();
       await runCommand(flags, async () => {
         const p = asProvider(provider);
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<{ provider: string; removed: boolean }>(
           `/api/providers/${p}`,

--- a/cli/src/commands/results.ts
+++ b/cli/src/commands/results.ts
@@ -45,9 +45,10 @@ export function resultsCommand(getFlags: () => GlobalFlags): Command {
           emitText('(no rows)', flags);
           return;
         }
-        const fields = Array.from(
-          new Set(data.data.flatMap((row) => Object.keys(row.data))),
-        ).slice(0, 6);
+        const fields = Array.from(new Set(data.data.flatMap((row) => Object.keys(row.data)))).slice(
+          0,
+          6,
+        );
         const rows = data.data.map((row) => [
           row.source_url,
           ...fields.map((f) => {

--- a/cli/src/commands/results.ts
+++ b/cli/src/commands/results.ts
@@ -25,7 +25,7 @@ export function resultsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (jobId: string, opts: { runId?: string; format: string }) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         let runId = opts.runId;
         if (!runId) {

--- a/cli/src/commands/results.ts
+++ b/cli/src/commands/results.ts
@@ -1,0 +1,62 @@
+import { Command } from 'commander';
+import { createClient, requireToken } from '../api.js';
+import {
+  CliError,
+  EXIT,
+  emitJson,
+  emitText,
+  renderTable,
+  runCommand,
+  type GlobalFlags,
+} from '../output.js';
+import type { ExtractedDataDTO, RunDTO } from '../types.js';
+
+/**
+ * `smartscrape results <jobId>` — convenience wrapper that resolves the latest
+ * completed run for a job (or the run id passed via --run-id) and prints its
+ * data. Avoids the two-step "list runs, then read data" dance.
+ */
+export function resultsCommand(getFlags: () => GlobalFlags): Command {
+  return new Command('results')
+    .description('Show extracted data from a job — defaults to its latest completed run')
+    .argument('<jobId>')
+    .option('--run-id <id>', 'Read a specific run instead of the latest')
+    .option('--format <fmt>', 'json|table (default: table; --json overrides)', 'table')
+    .action(async (jobId: string, opts: { runId?: string; format: string }) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        let runId = opts.runId;
+        if (!runId) {
+          const list = await client.request<{ runs: RunDTO[] }>(`/api/jobs/${jobId}/runs`);
+          const latestCompleted = list.runs.find((r) => r.status === 'completed') ?? list.runs[0];
+          if (!latestCompleted) {
+            throw new CliError('No runs yet for this job', EXIT.NOT_FOUND, 'NO_RUNS');
+          }
+          runId = latestCompleted.id;
+        }
+        const data = await client.request<{ data: ExtractedDataDTO[] }>(`/api/runs/${runId}/data`);
+        if (flags.json || opts.format === 'json') {
+          emitJson(data.data, flags);
+          return;
+        }
+        if (data.data.length === 0) {
+          emitText('(no rows)', flags);
+          return;
+        }
+        const fields = Array.from(
+          new Set(data.data.flatMap((row) => Object.keys(row.data))),
+        ).slice(0, 6);
+        const rows = data.data.map((row) => [
+          row.source_url,
+          ...fields.map((f) => {
+            const v = row.data[f];
+            if (v === null || v === undefined) return '';
+            return typeof v === 'object' ? JSON.stringify(v) : String(v);
+          }),
+        ]);
+        emitText(renderTable({ head: ['Source', ...fields], rows }), flags);
+      });
+    });
+}

--- a/cli/src/commands/runs.ts
+++ b/cli/src/commands/runs.ts
@@ -95,9 +95,10 @@ export function runsCommand(getFlags: () => GlobalFlags): Command {
           emitText('(no rows)', flags);
           return;
         }
-        const fields = Array.from(
-          new Set(data.data.flatMap((row) => Object.keys(row.data))),
-        ).slice(0, 6);
+        const fields = Array.from(new Set(data.data.flatMap((row) => Object.keys(row.data)))).slice(
+          0,
+          6,
+        );
         const head = ['Source', ...fields];
         const rows = data.data.map((row) => [
           row.source_url,
@@ -142,7 +143,10 @@ export function runsCommand(getFlags: () => GlobalFlags): Command {
           for (const c of d.changed.slice(0, 10)) {
             emitText(`\n• ${c.key ?? '(no key)'}`, flags);
             for (const fd of c.field_diffs) {
-              emitText(`    ${fd.field}: ${JSON.stringify(fd.old)} → ${JSON.stringify(fd.new)}`, flags);
+              emitText(
+                `    ${fd.field}: ${JSON.stringify(fd.old)} → ${JSON.stringify(fd.new)}`,
+                flags,
+              );
             }
           }
         }

--- a/cli/src/commands/runs.ts
+++ b/cli/src/commands/runs.ts
@@ -1,0 +1,153 @@
+import { Command } from 'commander';
+import { createClient, requireToken } from '../api.js';
+import {
+  ageString,
+  emitJson,
+  emitText,
+  renderTable,
+  runCommand,
+  shortId,
+  type GlobalFlags,
+} from '../output.js';
+import type { DiffResult, ExtractedDataDTO, RunDTO } from '../types.js';
+
+export function runsCommand(getFlags: () => GlobalFlags): Command {
+  const runs = new Command('runs').description('Inspect runs and their results');
+
+  runs
+    .command('list <jobId>')
+    .description('List runs for a job (newest first)')
+    .action(async (jobId: string) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<{ runs: RunDTO[] }>(`/api/jobs/${jobId}/runs`);
+        if (flags.json) {
+          emitJson(data.runs, flags);
+          return;
+        }
+        emitText(
+          renderTable({
+            head: ['Run', 'Status', 'Items', 'Tokens', 'Started', 'Completed'],
+            rows: data.runs.map((r) => [
+              shortId(r.id),
+              r.status,
+              r.items_extracted,
+              r.tokens_used,
+              ageString(r.started_at),
+              r.completed_at ? ageString(r.completed_at) : '—',
+            ]),
+          }),
+          flags,
+        );
+      });
+    });
+
+  runs
+    .command('show <id>')
+    .description('Show a single run')
+    .action(async (id: string) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<{ run: RunDTO }>(`/api/runs/${id}`);
+        if (flags.json) {
+          emitJson(data.run, flags);
+          return;
+        }
+        const r = data.run;
+        emitText(
+          [
+            `ID:          ${r.id}`,
+            `Job:         ${r.job_id}`,
+            `Status:      ${r.status}`,
+            `URLs:        ${r.urls_scraped}`,
+            `Items:       ${r.items_extracted}`,
+            `Tokens:      ${r.tokens_used}`,
+            `Started:     ${r.started_at}`,
+            `Completed:   ${r.completed_at ?? '—'}`,
+            r.error_message ? `Error:       ${r.error_message}` : '',
+            r.export_error ? `ExportErr:   ${r.export_error}` : '',
+          ]
+            .filter(Boolean)
+            .join('\n'),
+          flags,
+        );
+      });
+    });
+
+  runs
+    .command('data <id>')
+    .description('List extracted data rows for a single run')
+    .action(async (id: string) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<{ data: ExtractedDataDTO[] }>(`/api/runs/${id}/data`);
+        if (flags.json) {
+          emitJson(data.data, flags);
+          return;
+        }
+        if (data.data.length === 0) {
+          emitText('(no rows)', flags);
+          return;
+        }
+        const fields = Array.from(
+          new Set(data.data.flatMap((row) => Object.keys(row.data))),
+        ).slice(0, 6);
+        const head = ['Source', ...fields];
+        const rows = data.data.map((row) => [
+          row.source_url,
+          ...fields.map((f) => {
+            const v = row.data[f];
+            if (v === null || v === undefined) return '';
+            return typeof v === 'object' ? JSON.stringify(v) : String(v);
+          }),
+        ]);
+        emitText(renderTable({ head, rows }), flags);
+        emitText(`Total rows: ${data.data.length}`, flags);
+      });
+    });
+
+  runs
+    .command('diff <id>')
+    .description('Show added/removed/changed rows vs the previous completed run')
+    .action(async (id: string) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<{ diff: DiffResult }>(`/api/runs/${id}/diff`);
+        if (flags.json) {
+          emitJson(data.diff, flags);
+          return;
+        }
+        const d = data.diff;
+        emitText(
+          [
+            `Current:   ${d.current_run.id}  (${d.current_run.started_at})`,
+            `Previous:  ${d.previous_run?.id ?? '(none — first run)'}`,
+            `Compare:   ${d.comparison_key ?? '(content hash)'}`,
+            ``,
+            `Added:     ${d.added.length}`,
+            `Removed:   ${d.removed.length}`,
+            `Changed:   ${d.changed.length}`,
+          ].join('\n'),
+          flags,
+        );
+        if (d.changed.length > 0) {
+          for (const c of d.changed.slice(0, 10)) {
+            emitText(`\n• ${c.key ?? '(no key)'}`, flags);
+            for (const fd of c.field_diffs) {
+              emitText(`    ${fd.field}: ${JSON.stringify(fd.old)} → ${JSON.stringify(fd.new)}`, flags);
+            }
+          }
+        }
+      });
+    });
+
+  return runs;
+}

--- a/cli/src/commands/runs.ts
+++ b/cli/src/commands/runs.ts
@@ -20,7 +20,7 @@ export function runsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (jobId: string) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<{ runs: RunDTO[] }>(`/api/jobs/${jobId}/runs`);
         if (flags.json) {
@@ -50,7 +50,7 @@ export function runsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (id: string) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<{ run: RunDTO }>(`/api/runs/${id}`);
         if (flags.json) {
@@ -84,7 +84,7 @@ export function runsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (id: string) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<{ data: ExtractedDataDTO[] }>(`/api/runs/${id}/data`);
         if (flags.json) {
@@ -119,7 +119,7 @@ export function runsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (id: string) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<{ diff: DiffResult }>(`/api/runs/${id}/diff`);
         if (flags.json) {

--- a/cli/src/commands/settings.ts
+++ b/cli/src/commands/settings.ts
@@ -48,11 +48,7 @@ export function settingsCommand(getFlags: () => GlobalFlags): Command {
         for (const p of pairs) {
           const idx = p.indexOf('=');
           if (idx === -1)
-            throw new CliError(
-              `Bad pair '${p}' — use key=value`,
-              EXIT.VALIDATION,
-              'BAD_PAIR',
-            );
+            throw new CliError(`Bad pair '${p}' — use key=value`, EXIT.VALIDATION, 'BAD_PAIR');
           patch[p.slice(0, idx)] = p.slice(idx + 1);
         }
         const client = createClient({ url: flags.url, token: flags.token });

--- a/cli/src/commands/settings.ts
+++ b/cli/src/commands/settings.ts
@@ -23,7 +23,7 @@ export function settingsCommand(getFlags: () => GlobalFlags): Command {
     .action(async () => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<SettingsResponse>('/api/settings');
         if (flags.json) emitJson(data.settings, flags);
@@ -51,7 +51,7 @@ export function settingsCommand(getFlags: () => GlobalFlags): Command {
             throw new CliError(`Bad pair '${p}' — use key=value`, EXIT.VALIDATION, 'BAD_PAIR');
           patch[p.slice(0, idx)] = p.slice(idx + 1);
         }
-        const client = createClient({ url: flags.url, token: flags.token });
+        const client = createClient({ url: flags.serverUrl, token: flags.token });
         requireToken(client);
         const data = await client.request<SettingsResponse>('/api/settings', {
           method: 'PATCH',

--- a/cli/src/commands/settings.ts
+++ b/cli/src/commands/settings.ts
@@ -1,0 +1,70 @@
+import { Command } from 'commander';
+import { createClient, requireToken } from '../api.js';
+import {
+  CliError,
+  EXIT,
+  emitJson,
+  emitText,
+  renderTable,
+  runCommand,
+  type GlobalFlags,
+} from '../output.js';
+
+type SettingsResponse = { settings: Record<string, string> };
+
+export function settingsCommand(getFlags: () => GlobalFlags): Command {
+  const settings = new Command('settings').description(
+    'Read and write the per-user free-form settings bag',
+  );
+
+  settings
+    .command('show')
+    .description('Print all settings as a table or JSON')
+    .action(async () => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<SettingsResponse>('/api/settings');
+        if (flags.json) emitJson(data.settings, flags);
+        else
+          emitText(
+            renderTable({
+              head: ['Key', 'Value'],
+              rows: Object.entries(data.settings).map(([k, v]) => [k, v]),
+            }),
+            flags,
+          );
+      });
+    });
+
+  settings
+    .command('set <pairs...>')
+    .description("Set one or more settings — each pair is 'key=value'")
+    .action(async (pairs: string[]) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const patch: Record<string, string> = {};
+        for (const p of pairs) {
+          const idx = p.indexOf('=');
+          if (idx === -1)
+            throw new CliError(
+              `Bad pair '${p}' — use key=value`,
+              EXIT.VALIDATION,
+              'BAD_PAIR',
+            );
+          patch[p.slice(0, idx)] = p.slice(idx + 1);
+        }
+        const client = createClient({ url: flags.url, token: flags.token });
+        requireToken(client);
+        const data = await client.request<SettingsResponse>('/api/settings', {
+          method: 'PATCH',
+          body: patch,
+        });
+        if (flags.json) emitJson(data.settings, flags);
+        else emitText(`Updated ${Object.keys(patch).length} setting(s)`, flags);
+      });
+    });
+
+  return settings;
+}

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,0 +1,79 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync, unlinkSync } from 'node:fs';
+import { homedir, platform } from 'node:os';
+import { join } from 'node:path';
+
+export type StoredConfig = {
+  url: string;
+  accessToken: string | null;
+  refreshCookie: string | null;
+  refreshExpiresAt: string | null;
+  email: string | null;
+};
+
+const CONFIG_DIR = join(homedir(), '.smartscrape');
+const CONFIG_FILE = join(CONFIG_DIR, 'config.json');
+
+const DEFAULT: StoredConfig = {
+  url: 'http://localhost:3000',
+  accessToken: null,
+  refreshCookie: null,
+  refreshExpiresAt: null,
+  email: null,
+};
+
+export function loadConfig(): StoredConfig {
+  if (!existsSync(CONFIG_FILE)) return { ...DEFAULT };
+  try {
+    const raw = readFileSync(CONFIG_FILE, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<StoredConfig>;
+    return { ...DEFAULT, ...parsed };
+  } catch {
+    return { ...DEFAULT };
+  }
+}
+
+export function saveConfig(cfg: StoredConfig): void {
+  if (!existsSync(CONFIG_DIR)) {
+    mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  }
+  writeFileSync(CONFIG_FILE, JSON.stringify(cfg, null, 2), { mode: 0o600 });
+  // chmod is a no-op on Windows; tighten on POSIX where it matters.
+  if (platform() !== 'win32') {
+    try {
+      chmodSync(CONFIG_FILE, 0o600);
+    } catch {
+      // tolerate non-POSIX filesystems
+    }
+  }
+}
+
+export function clearConfig(): void {
+  if (existsSync(CONFIG_FILE)) unlinkSync(CONFIG_FILE);
+}
+
+export type ResolvedSession = {
+  url: string;
+  token: string | null;
+  refreshCookie: string | null;
+  email: string | null;
+};
+
+/**
+ * Layer env vars on top of the stored config. Env wins so cron jobs and agents
+ * can override without touching ~/.smartscrape/config.json.
+ */
+export function resolveSession(overrides?: { url?: string; token?: string }): ResolvedSession {
+  const stored = loadConfig();
+  const url = overrides?.url ?? process.env.SMARTSCRAPE_URL ?? stored.url;
+  const token = overrides?.token ?? process.env.SMARTSCRAPE_TOKEN ?? stored.accessToken;
+  return {
+    url: url.replace(/\/$/, ''),
+    token: token ?? null,
+    refreshCookie: stored.refreshCookie,
+    email: stored.email,
+  };
+}
+
+export function configFilePath(): string {
+  return CONFIG_FILE;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -18,7 +18,7 @@ program
   .version('0.9.0')
   .option('--json', 'Emit JSON instead of formatted tables')
   .option('--quiet', 'Suppress non-error output (data still goes to stdout)')
-  .option('--url <url>', 'Override the server URL (also: SMARTSCRAPE_URL env)')
+  .option('--server-url <url>', 'Override the SmartScrape server URL (also: SMARTSCRAPE_URL env)')
   .option('--token <token>', 'Override the access token (also: SMARTSCRAPE_TOKEN env)');
 
 // Commands read flags via a getter so children resolve them after parsing.

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { authCommand } from './commands/auth.js';
+import { dashboardCommand } from './commands/dashboard.js';
+import { exportCommand } from './commands/export.js';
+import { jobsCommand } from './commands/jobs.js';
+import { notificationsCommand } from './commands/notifications.js';
+import { providersCommand } from './commands/providers.js';
+import { resultsCommand } from './commands/results.js';
+import { runsCommand } from './commands/runs.js';
+import { settingsCommand } from './commands/settings.js';
+import type { GlobalFlags } from './output.js';
+
+const program = new Command();
+program
+  .name('smartscrape')
+  .description('SmartScrape CLI — drive the REST API from cron, scripts, and agents')
+  .version('0.9.0')
+  .option('--json', 'Emit JSON instead of formatted tables')
+  .option('--quiet', 'Suppress non-error output (data still goes to stdout)')
+  .option('--url <url>', 'Override the server URL (also: SMARTSCRAPE_URL env)')
+  .option('--token <token>', 'Override the access token (also: SMARTSCRAPE_TOKEN env)');
+
+// Commands read flags via a getter so children resolve them after parsing.
+const getFlags = (): GlobalFlags => program.opts<GlobalFlags>();
+
+program.addCommand(authCommand(getFlags));
+program.addCommand(jobsCommand(getFlags));
+program.addCommand(runsCommand(getFlags));
+program.addCommand(resultsCommand(getFlags));
+program.addCommand(exportCommand(getFlags));
+program.addCommand(providersCommand(getFlags));
+program.addCommand(settingsCommand(getFlags));
+program.addCommand(notificationsCommand(getFlags));
+program.addCommand(dashboardCommand(getFlags));
+
+program.parseAsync(process.argv).catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`Error: ${message}\n`);
+  process.exit(1);
+});

--- a/cli/src/output.ts
+++ b/cli/src/output.ts
@@ -76,8 +76,11 @@ export async function runCommand(
     if (err instanceof CliError) {
       if (isJson(flags)) {
         process.stdout.write(
-          JSON.stringify({ success: false, error: { code: err.code ?? 'CLI_ERROR', message: err.message } }, null, 2) +
-            '\n',
+          JSON.stringify(
+            { success: false, error: { code: err.code ?? 'CLI_ERROR', message: err.message } },
+            null,
+            2,
+          ) + '\n',
         );
       } else {
         emitError(`Error: ${err.message}`);

--- a/cli/src/output.ts
+++ b/cli/src/output.ts
@@ -1,0 +1,115 @@
+import Table from 'cli-table3';
+
+// Exit codes shared across every command.
+export const EXIT = {
+  OK: 0,
+  ERROR: 1,
+  AUTH: 2,
+  NOT_FOUND: 3,
+  VALIDATION: 4,
+} as const;
+
+export type GlobalFlags = {
+  json?: boolean;
+  quiet?: boolean;
+  url?: string;
+  token?: string;
+};
+
+export class CliError extends Error {
+  constructor(
+    message: string,
+    public exitCode: number = EXIT.ERROR,
+    public code?: string,
+  ) {
+    super(message);
+    this.name = 'CliError';
+  }
+}
+
+function isQuiet(flags: GlobalFlags | undefined): boolean {
+  return Boolean(flags?.quiet);
+}
+
+function isJson(flags: GlobalFlags | undefined): boolean {
+  return Boolean(flags?.json);
+}
+
+export function emitJson(value: unknown, flags?: GlobalFlags): void {
+  if (isQuiet(flags)) return;
+  process.stdout.write(JSON.stringify(value, null, 2) + '\n');
+}
+
+export function emitText(text: string, flags?: GlobalFlags): void {
+  if (isQuiet(flags)) return;
+  process.stdout.write(text + (text.endsWith('\n') ? '' : '\n'));
+}
+
+export function emitError(message: string): void {
+  process.stderr.write(message + (message.endsWith('\n') ? '' : '\n'));
+}
+
+export type TableSpec = {
+  head: string[];
+  rows: (string | number | null | undefined)[][];
+};
+
+export function renderTable(spec: TableSpec): string {
+  const t = new Table({ head: spec.head, style: { head: [] } });
+  for (const row of spec.rows) {
+    t.push(row.map((c) => (c === null || c === undefined ? '' : String(c))));
+  }
+  return t.toString();
+}
+
+/**
+ * Run an async command body and translate thrown CliErrors into stderr+exit.
+ * Centralises the "every command needs the same try/catch" boilerplate.
+ */
+export async function runCommand(
+  flags: GlobalFlags | undefined,
+  body: () => Promise<void>,
+): Promise<void> {
+  try {
+    await body();
+  } catch (err) {
+    if (err instanceof CliError) {
+      if (isJson(flags)) {
+        process.stdout.write(
+          JSON.stringify({ success: false, error: { code: err.code ?? 'CLI_ERROR', message: err.message } }, null, 2) +
+            '\n',
+        );
+      } else {
+        emitError(`Error: ${err.message}`);
+      }
+      process.exit(err.exitCode);
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    if (isJson(flags)) {
+      process.stdout.write(
+        JSON.stringify({ success: false, error: { code: 'INTERNAL', message } }, null, 2) + '\n',
+      );
+    } else {
+      emitError(`Error: ${message}`);
+    }
+    process.exit(EXIT.ERROR);
+  }
+}
+
+export function ageString(iso: string | null): string {
+  if (!iso) return '—';
+  const ms = Date.now() - new Date(iso).getTime();
+  if (Number.isNaN(ms)) return iso;
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 48) return `${hr}h ago`;
+  const days = Math.floor(hr / 24);
+  return `${days}d ago`;
+}
+
+export function shortId(id: string): string {
+  return id.slice(0, 8);
+}

--- a/cli/src/output.ts
+++ b/cli/src/output.ts
@@ -12,7 +12,7 @@ export const EXIT = {
 export type GlobalFlags = {
   json?: boolean;
   quiet?: boolean;
-  url?: string;
+  serverUrl?: string;
   token?: string;
 };
 

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -1,0 +1,126 @@
+// Mirrors of the server DTOs the CLI consumes. Kept narrow on purpose — the
+// CLI only renders/forwards a subset, so we don't pull the full server type.
+
+export type ApiError = { code: string; message: string; details?: unknown };
+
+export type ApiResponse<T> =
+  | { success: true; data: T; error: null }
+  | { success: false; data: null; error: ApiError };
+
+export type Provider = 'openai' | 'anthropic' | 'openrouter';
+export type ScrapeMethod = 'auto' | 'playwright' | 'cheerio';
+export type SetupMethod = 'ai' | 'manual';
+export type NotifyChannel = 'email' | 'telegram';
+export type RunStatus =
+  | 'pending'
+  | 'scraping'
+  | 'extracting'
+  | 'exporting'
+  | 'completed'
+  | 'failed';
+
+export type NotificationRule =
+  | { type: 'any_change'; message?: string }
+  | { type: 'new_items'; message?: string }
+  | { type: 'removed_items'; message?: string }
+  | {
+      type: 'field_threshold';
+      field: string;
+      operator:
+        | 'less_than'
+        | 'greater_than'
+        | 'equals'
+        | 'not_equals'
+        | 'less_than_or_equal'
+        | 'greater_than_or_equal';
+      value: number | string;
+      message?: string;
+    }
+  | { type: 'field_change'; field: string; message?: string };
+
+export type JobDTO = {
+  id: string;
+  user_id: string;
+  name: string;
+  urls: string[];
+  extraction_prompt: string;
+  extraction_schema: Record<string, 'string' | 'number' | 'boolean' | 'array' | 'object'> | null;
+  scrape_method: ScrapeMethod;
+  schedule: string | null;
+  enabled: boolean;
+  notification_rules: NotificationRule[];
+  notify_channels: NotifyChannel[];
+  comparison_key: string | null;
+  ai_provider: Provider;
+  ai_model: string;
+  google_sheet_id: string | null;
+  sheet_tab_name: string | null;
+  setup_method: SetupMethod;
+  respect_robots_txt: boolean;
+  last_run_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type JobListItem = JobDTO & {
+  last_run_status: string | null;
+  last_run_items: number | null;
+};
+
+export type RunDTO = {
+  id: string;
+  job_id: string;
+  status: RunStatus;
+  urls_scraped: number;
+  items_extracted: number;
+  tokens_used: number;
+  error_message: string | null;
+  export_error: string | null;
+  started_at: string;
+  completed_at: string | null;
+};
+
+export type ExtractedDataDTO = {
+  id: string;
+  run_id: string;
+  job_id: string;
+  source_url: string;
+  data: Record<string, unknown>;
+  data_hash: string;
+  created_at: string;
+};
+
+export type DiffResult = {
+  current_run: { id: string; started_at: string };
+  previous_run: { id: string; started_at: string } | null;
+  added: Record<string, unknown>[];
+  removed: Record<string, unknown>[];
+  changed: {
+    key: string | null;
+    before: Record<string, unknown>;
+    after: Record<string, unknown>;
+    field_diffs: { field: string; old: unknown; new: unknown }[];
+  }[];
+  comparison_key: string | null;
+};
+
+export type ProviderRow = {
+  provider: Provider;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DashboardStats = {
+  active_jobs: number;
+  runs_today: number;
+  items_tracked: number;
+  changes_this_week: number;
+};
+
+export type UserPublic = {
+  id: string;
+  email: string;
+  name: string | null;
+  email_verified: boolean;
+  telegram_chat_id: string | null;
+};

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "declaration": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "workspaces": [
         "server",
-        "client"
+        "client",
+        "cli"
       ],
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
@@ -25,6 +26,35 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "cli": {
+      "name": "@smartscrape/cli",
+      "version": "0.9.0",
+      "dependencies": {
+        "cli-table3": "^0.6.5",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "smartscrape": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.5",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.3",
+        "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "cli/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "client": {
@@ -392,6 +422,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1677,6 +1717,10 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@smartscrape/cli": {
+      "resolved": "cli",
+      "link": true
     },
     "node_modules/@smartscrape/client": {
       "resolved": "client",
@@ -3012,6 +3056,21 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "workspaces": [
     "server",
-    "client"
+    "client",
+    "cli"
   ],
   "scripts": {
     "dev": "npm-run-all --parallel dev:server dev:client",


### PR DESCRIPTION
Closes #96.

## Summary

Adds a `cli/` workspace exposing the SmartScrape REST API as a `smartscrape` binary so cron jobs, scripts, and external agents can drive the system without the React UI.

## What's in

- New workspace `@smartscrape/cli` (TypeScript, native `fetch`, `commander`, `cli-table3`)
- `bin: smartscrape` so the CLI is publish-ready
- Token storage at `~/.smartscrape/config.json` (POSIX `0600`/`0700`)
- Cookie-only refresh flow that mirrors the post-#89 server behavior — login response `Set-Cookie` is captured and replayed verbatim against `/api/auth/refresh`, with the new pair persisted on success
- `SMARTSCRAPE_URL` / `SMARTSCRAPE_TOKEN` env overrides for headless use
- Commands:
  - `auth login | logout | whoami`
  - `jobs list | show | create | edit | toggle | delete | run` (`--wait` polls until terminal)
  - `runs list | show | data | diff`
  - `results <jobId>` (latest completed run)
  - `export <jobId> --csv | --json | --sheets`
  - `providers list | set | test | delete`
  - `settings show | set`
  - `notifications test {email|telegram}`
  - `dashboard stats`
- Universal flags: `--json`, `--quiet`, `--server-url`, `--token`
- Exit codes: `0` ok, `1` generic, `2` auth, `3` not found, `4` validation
- Errors emit `{success:false,error:{code,message}}` on `--json`

## Notes for reviewers

- Global override is `--server-url` (not `--url`) so it doesn't collide with `jobs create --url <pages...>`.
- Job creation goes through `POST /api/jobs`; the AI-assisted 3-step wizard stays UI-only.
- Diff is per-run on the server (`/api/runs/:id/diff`); `runs diff <id>` reflects that and `results` resolves the latest completed run id automatically.
- AI provider keys live at `/api/providers`, distinct from the per-user free-form `/api/settings` bag.

## Verification

```
$ npm run typecheck     # server + client + cli — clean
$ npm run lint          # eslint — clean
$ npm run format:check  # prettier — clean
```

### Live test plan against a dev stack (Docker compose Postgres + Redis, dev server, registered + verified user)

- [x] `smartscrape auth login` persists `url`, `accessToken`, `refreshCookie`, `refreshExpiresAt`, `email` to `~/.smartscrape/config.json`
- [x] `smartscrape jobs list --json` byte-identical to `GET /api/jobs` `.data`
- [x] `smartscrape jobs run <id> --wait` polls and reports the terminal status (verified by triggering a run that fails server-side with `NO_PROVIDER_KEY`; CLI correctly stopped at `failed`)
- [x] `smartscrape export <id> --csv` byte-identical to `GET /api/jobs/:id/export/csv` (both empty in this run because no provider key → no extracted rows; non-trivial CSV needs a real AI key — leaving end-to-end happy-path verification to a follow-up)
- [x] Auto-refresh: hand-tampered access token, single `whoami` call succeeds and rotates the token via cookie-replay refresh