### PR TITLE
feat(access-tokens): personal access tokens for headless authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ node cli/dist/index.js results <job-id> --json
 node cli/dist/index.js export <job-id> --csv > out.csv
 ```
 
-Every command supports `--json`, `--quiet`, `--server-url`, `--token`. Exit codes: `0` success, `1` generic, `2` auth, `3` not found, `4` validation. See [cli/README.md](cli/README.md) for the full command list.
+Every command supports `--json`, `--quiet`, `--server-url`, `--token`, `--api-key`. Exit codes: `0` success, `1` generic, `2` auth, `3` not found, `4` validation. See [cli/README.md](cli/README.md) for the full command list.
+
+Long-running automation should use a personal access token over JWT: `smartscrape auth tokens create --name ci-runner` mints one, plaintext is shown once, send it on every request via `SMARTSCRAPE_API_KEY` env or the `X-API-Key` header. Revoke any token from Settings or via `smartscrape auth tokens revoke <id>`.
 
 ## How a run works
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -22,16 +22,21 @@ falls back to `~/.smartscrape/config.json` written by `auth login`.
 # Interactive login (writes config + refresh cookie)
 smartscrape auth login --url http://localhost:3000 --email you@example.com --password '...'
 
-# Non-interactive — env-only (preferred for cron/agents)
+# Personal access token — preferred for cron/agents, never expires until revoked
+smartscrape auth tokens create --name "ci-runner" > /run/secrets/smartscrape-token
 export SMARTSCRAPE_URL=http://localhost:3000
-export SMARTSCRAPE_TOKEN=eyJhbGciOiJIUzI1NiIs...
+export SMARTSCRAPE_API_KEY=$(cat /run/secrets/smartscrape-token)
 smartscrape jobs list --json
+
+# JWT — works too, but cron needs to handle the refresh cookie
+export SMARTSCRAPE_TOKEN=eyJhbGciOiJIUzI1NiIs...
 ```
 
 ## Commands
 
 ```
 auth login | logout | whoami
+auth tokens list | create --name <n> | revoke <id>
 jobs list | show <id> | create | edit <id> | delete <id> | toggle <id> | run <id>
 runs show <id> | data <id> | diff <id>
 results <job-id>            # latest run's data
@@ -43,6 +48,6 @@ dashboard stats
 ```
 
 Every command supports `--json` (raw JSON to stdout) and `--quiet` (suppress
-non-error output), plus `--server-url` and `--token` for per-invocation
-overrides. Exit codes: `0` success, `1` generic error, `2` auth failure,
-`3` not found, `4` validation error.
+non-error output), plus `--server-url`, `--token`, and `--api-key` for
+per-invocation overrides. Exit codes: `0` success, `1` generic error, `2` auth
+failure, `3` not found, `4` validation error.

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -100,7 +100,11 @@ export function extractRefreshCookie(setCookieHeader: string): string | null {
   return match ? match[0] : null;
 }
 
-export function createClient(overrides?: { url?: string; token?: string }): ApiClient {
+export function createClient(overrides?: {
+  url?: string;
+  token?: string;
+  apiKey?: string;
+}): ApiClient {
   const session = resolveSession(overrides);
 
   async function doFetch(
@@ -113,7 +117,10 @@ export function createClient(overrides?: { url?: string; token?: string }): ApiC
       accept: 'application/json',
       ...(opts.headers ?? {}),
     };
-    if (token) headers['authorization'] = `Bearer ${token}`;
+    // API key wins over JWT — headless callers configure SMARTSCRAPE_API_KEY
+    // precisely to avoid the refresh dance, so we honor it whenever it's set.
+    if (session.apiKey) headers['x-api-key'] = session.apiKey;
+    else if (token) headers['authorization'] = `Bearer ${token}`;
     let body: string | undefined;
     if (opts.body !== undefined) {
       headers['content-type'] = 'application/json';
@@ -125,7 +132,9 @@ export function createClient(overrides?: { url?: string; token?: string }): ApiC
   async function requestRaw(path: string, opts: RequestOpts = {}): Promise<Response> {
     let token = session.token;
     let res = await doFetch(path, opts, token);
-    if (res.status === 401 && !opts.noAutoRefresh && session.refreshCookie) {
+    // Don't refresh when authenticating via API key — those are long-lived and
+    // either work or are revoked; there's no JWT to renew.
+    if (res.status === 401 && !opts.noAutoRefresh && !session.apiKey && session.refreshCookie) {
       const refreshed = await tryRefresh(session);
       if (refreshed) {
         token = refreshed;
@@ -170,9 +179,10 @@ export function createClient(overrides?: { url?: string; token?: string }): ApiC
 }
 
 export function requireToken(client: ApiClient): void {
+  if (client.session.apiKey) return;
   if (!client.session.token) {
     throw new CliError(
-      "Not signed in. Run 'smartscrape auth login' or set SMARTSCRAPE_TOKEN.",
+      "Not signed in. Run 'smartscrape auth login', or set SMARTSCRAPE_API_KEY / SMARTSCRAPE_TOKEN.",
       EXIT.AUTH,
       'NO_TOKEN',
     );

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -1,8 +1,17 @@
 import { Command } from 'commander';
 import { createClient, extractRefreshCookie } from '../api.js';
 import { clearConfig, configFilePath, loadConfig, saveConfig } from '../config.js';
-import { CliError, EXIT, emitJson, emitText, runCommand, type GlobalFlags } from '../output.js';
-import type { ApiResponse, UserPublic } from '../types.js';
+import {
+  CliError,
+  EXIT,
+  ageString,
+  emitJson,
+  emitText,
+  renderTable,
+  runCommand,
+  type GlobalFlags,
+} from '../output.js';
+import type { AccessToken, ApiResponse, UserPublic } from '../types.js';
 
 type LoginResponse = {
   user: UserPublic;
@@ -95,10 +104,14 @@ export function authCommand(getFlags: () => GlobalFlags): Command {
     .action(async () => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
-        if (!client.session.token) {
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
+        if (!client.session.token && !client.session.apiKey) {
           throw new CliError(
-            "Not signed in. Run 'smartscrape auth login' or set SMARTSCRAPE_TOKEN.",
+            "Not signed in. Run 'smartscrape auth login', or set SMARTSCRAPE_API_KEY / SMARTSCRAPE_TOKEN.",
             EXIT.AUTH,
             'NO_TOKEN',
           );
@@ -112,6 +125,131 @@ export function authCommand(getFlags: () => GlobalFlags): Command {
             flags,
           );
         }
+      });
+    });
+
+  const tokens = auth
+    .command('tokens')
+    .description('Manage personal access tokens (PATs) for headless authentication');
+
+  tokens
+    .command('list')
+    .description('List access tokens for the authenticated user (plaintexts are never shown)')
+    .action(async () => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
+        if (!client.session.token && !client.session.apiKey) {
+          throw new CliError(
+            "Not signed in. Run 'smartscrape auth login' first.",
+            EXIT.AUTH,
+            'NO_TOKEN',
+          );
+        }
+        const data = await client.request<{ tokens: AccessToken[] }>('/api/auth/access-tokens');
+        if (flags.json) {
+          emitJson(data.tokens, flags);
+          return;
+        }
+        if (data.tokens.length === 0) {
+          emitText('(no access tokens — create one with `auth tokens create`)', flags);
+          return;
+        }
+        emitText(
+          renderTable({
+            head: ['ID', 'Name', 'Prefix', 'Last used', 'Created', 'Revoked'],
+            rows: data.tokens.map((t) => [
+              t.id.slice(0, 8),
+              t.name,
+              t.prefix,
+              ageString(t.last_used_at),
+              ageString(t.created_at),
+              t.revoked_at ? ageString(t.revoked_at) : '—',
+            ]),
+          }),
+          flags,
+        );
+      });
+    });
+
+  tokens
+    .command('create')
+    .description('Mint a new access token. Plaintext is shown once — capture it now.')
+    .requiredOption('--name <name>', 'Human-readable label (e.g. "ci-runner", "homelab")')
+    .action(async (opts: { name: string }) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
+        if (!client.session.token && !client.session.apiKey) {
+          throw new CliError(
+            "Not signed in. Run 'smartscrape auth login' first.",
+            EXIT.AUTH,
+            'NO_TOKEN',
+          );
+        }
+        const data = await client.request<{ token: AccessToken & { plaintext: string } }>(
+          '/api/auth/access-tokens',
+          { method: 'POST', body: { name: opts.name } },
+        );
+        if (flags.json) {
+          emitJson(data.token, flags);
+          return;
+        }
+        // Plaintext goes to stdout so the user can pipe it into a secret store;
+        // status banner goes to stderr so they can `> token.txt` cleanly.
+        process.stderr.write(
+          `Created access token '${data.token.name}' (id=${data.token.id}). Plaintext shown ONCE on the next line:\n`,
+        );
+        process.stdout.write(data.token.plaintext + '\n');
+      });
+    });
+
+  tokens
+    .command('revoke <id>')
+    .description('Revoke an access token by id (or short id from `tokens list`)')
+    .action(async (id: string) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
+        if (!client.session.token && !client.session.apiKey) {
+          throw new CliError(
+            "Not signed in. Run 'smartscrape auth login' first.",
+            EXIT.AUTH,
+            'NO_TOKEN',
+          );
+        }
+        // Allow the short 8-char id from `tokens list` by resolving against
+        // the full list when the input isn't a UUID.
+        let fullId = id;
+        if (!/^[0-9a-f-]{36}$/i.test(id)) {
+          const list = await client.request<{ tokens: AccessToken[] }>('/api/auth/access-tokens');
+          const match = list.tokens.find((t) => t.id.startsWith(id));
+          if (!match) {
+            throw new CliError(
+              `No access token with id starting with '${id}'`,
+              EXIT.NOT_FOUND,
+              'TOKEN_NOT_FOUND',
+            );
+          }
+          fullId = match.id;
+        }
+        await client.request<{ revoked: boolean }>(`/api/auth/access-tokens/${fullId}`, {
+          method: 'DELETE',
+        });
+        if (flags.json) emitJson({ id: fullId, revoked: true }, flags);
+        else emitText(`Revoked ${fullId}`, flags);
       });
     });
 

--- a/cli/src/commands/dashboard.ts
+++ b/cli/src/commands/dashboard.ts
@@ -12,7 +12,11 @@ export function dashboardCommand(getFlags: () => GlobalFlags): Command {
     .action(async () => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<DashboardStats>('/api/dashboard/stats');
         if (flags.json) emitJson(data, flags);

--- a/cli/src/commands/export.ts
+++ b/cli/src/commands/export.ts
@@ -30,7 +30,11 @@ export function exportCommand(getFlags: () => GlobalFlags): Command {
               'BAD_TARGET',
             );
           }
-          const client = createClient({ url: flags.serverUrl, token: flags.token });
+          const client = createClient({
+            url: flags.serverUrl,
+            token: flags.token,
+            apiKey: flags.apiKey,
+          });
           requireToken(client);
 
           if (opts.sheets) {

--- a/cli/src/commands/jobs.ts
+++ b/cli/src/commands/jobs.ts
@@ -135,7 +135,11 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (opts: { filter: string; limit: number; offset: number }) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<{ items: JobListItem[]; total: number }>('/api/jobs', {
           query: { filter: opts.filter, limit: opts.limit, offset: opts.offset },
@@ -169,7 +173,11 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (id: string) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<{ job: JobDTO }>(`/api/jobs/${id}`);
         if (flags.json) {
@@ -221,7 +229,11 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     const flags = getFlags();
     await runCommand(flags, async () => {
       const body = buildCreateBody(opts);
-      const client = createClient({ url: flags.serverUrl, token: flags.token });
+      const client = createClient({
+        url: flags.serverUrl,
+        token: flags.token,
+        apiKey: flags.apiKey,
+      });
       requireToken(client);
       const data = await client.request<{ job: JobDTO }>('/api/jobs', {
         method: 'POST',
@@ -284,7 +296,11 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
             'NO_PATCH',
           );
         }
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<{ job: JobDTO }>(`/api/jobs/${id}`, {
           method: 'PATCH',
@@ -301,7 +317,11 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (id: string) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<{ job: JobDTO }>(`/api/jobs/${id}/toggle`, {
           method: 'PATCH',
@@ -325,7 +345,11 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
             'CONFIRM_REQUIRED',
           );
         }
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<{ removed: boolean }>(`/api/jobs/${id}`, {
           method: 'DELETE',
@@ -343,7 +367,11 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (id: string, opts: { wait?: boolean; timeout: number }) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const triggered = await client.request<{ run: RunDTO }>(`/api/jobs/${id}/run`, {
           method: 'POST',

--- a/cli/src/commands/notifications.ts
+++ b/cli/src/commands/notifications.ts
@@ -18,7 +18,11 @@ export function notificationsCommand(getFlags: () => GlobalFlags): Command {
             'BAD_CHANNEL',
           );
         }
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<unknown>(`/api/notifications/test/${channel}`, {
           method: 'POST',

--- a/cli/src/commands/providers.ts
+++ b/cli/src/commands/providers.ts
@@ -35,7 +35,11 @@ export function providersCommand(getFlags: () => GlobalFlags): Command {
     .action(async () => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<{ providers: ProviderRow[] }>('/api/providers');
         if (flags.json) emitJson(data.providers, flags);
@@ -59,7 +63,11 @@ export function providersCommand(getFlags: () => GlobalFlags): Command {
       const flags = getFlags();
       await runCommand(flags, async () => {
         const provider = asProvider(opts.provider);
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<{ provider: ProviderRow }>('/api/providers', {
           method: 'POST',
@@ -77,7 +85,11 @@ export function providersCommand(getFlags: () => GlobalFlags): Command {
       const flags = getFlags();
       await runCommand(flags, async () => {
         const p = asProvider(provider);
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<unknown>(`/api/providers/${p}/test`, { method: 'POST' });
         if (flags.json) emitJson(data, flags);
@@ -92,7 +104,11 @@ export function providersCommand(getFlags: () => GlobalFlags): Command {
       const flags = getFlags();
       await runCommand(flags, async () => {
         const p = asProvider(provider);
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<{ provider: string; removed: boolean }>(
           `/api/providers/${p}`,

--- a/cli/src/commands/results.ts
+++ b/cli/src/commands/results.ts
@@ -25,7 +25,11 @@ export function resultsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (jobId: string, opts: { runId?: string; format: string }) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         let runId = opts.runId;
         if (!runId) {

--- a/cli/src/commands/runs.ts
+++ b/cli/src/commands/runs.ts
@@ -20,7 +20,11 @@ export function runsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (jobId: string) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<{ runs: RunDTO[] }>(`/api/jobs/${jobId}/runs`);
         if (flags.json) {
@@ -50,7 +54,11 @@ export function runsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (id: string) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<{ run: RunDTO }>(`/api/runs/${id}`);
         if (flags.json) {
@@ -84,7 +92,11 @@ export function runsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (id: string) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<{ data: ExtractedDataDTO[] }>(`/api/runs/${id}/data`);
         if (flags.json) {
@@ -119,7 +131,11 @@ export function runsCommand(getFlags: () => GlobalFlags): Command {
     .action(async (id: string) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<{ diff: DiffResult }>(`/api/runs/${id}/diff`);
         if (flags.json) {

--- a/cli/src/commands/settings.ts
+++ b/cli/src/commands/settings.ts
@@ -23,7 +23,11 @@ export function settingsCommand(getFlags: () => GlobalFlags): Command {
     .action(async () => {
       const flags = getFlags();
       await runCommand(flags, async () => {
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<SettingsResponse>('/api/settings');
         if (flags.json) emitJson(data.settings, flags);
@@ -51,7 +55,11 @@ export function settingsCommand(getFlags: () => GlobalFlags): Command {
             throw new CliError(`Bad pair '${p}' — use key=value`, EXIT.VALIDATION, 'BAD_PAIR');
           patch[p.slice(0, idx)] = p.slice(idx + 1);
         }
-        const client = createClient({ url: flags.serverUrl, token: flags.token });
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
         requireToken(client);
         const data = await client.request<SettingsResponse>('/api/settings', {
           method: 'PATCH',

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -53,24 +53,35 @@ export function clearConfig(): void {
 
 export type ResolvedSession = {
   url: string;
+  /** A short-lived JWT, when one is available. Null when authenticating via PAT. */
   token: string | null;
   refreshCookie: string | null;
   email: string | null;
+  /** A personal access token (`sst_…`), used in `X-API-Key`. Wins over JWT when present. */
+  apiKey: string | null;
 };
 
 /**
  * Layer env vars on top of the stored config. Env wins so cron jobs and agents
- * can override without touching ~/.smartscrape/config.json.
+ * can override without touching ~/.smartscrape/config.json. The API-key path
+ * has its own env var (SMARTSCRAPE_API_KEY) so headless callers can avoid the
+ * JWT refresh dance entirely.
  */
-export function resolveSession(overrides?: { url?: string; token?: string }): ResolvedSession {
+export function resolveSession(overrides?: {
+  url?: string;
+  token?: string;
+  apiKey?: string;
+}): ResolvedSession {
   const stored = loadConfig();
   const url = overrides?.url ?? process.env.SMARTSCRAPE_URL ?? stored.url;
   const token = overrides?.token ?? process.env.SMARTSCRAPE_TOKEN ?? stored.accessToken;
+  const apiKey = overrides?.apiKey ?? process.env.SMARTSCRAPE_API_KEY ?? null;
   return {
     url: url.replace(/\/$/, ''),
     token: token ?? null,
     refreshCookie: stored.refreshCookie,
     email: stored.email,
+    apiKey,
   };
 }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -19,7 +19,11 @@ program
   .option('--json', 'Emit JSON instead of formatted tables')
   .option('--quiet', 'Suppress non-error output (data still goes to stdout)')
   .option('--server-url <url>', 'Override the SmartScrape server URL (also: SMARTSCRAPE_URL env)')
-  .option('--token <token>', 'Override the access token (also: SMARTSCRAPE_TOKEN env)');
+  .option('--token <token>', 'Override the JWT access token (also: SMARTSCRAPE_TOKEN env)')
+  .option(
+    '--api-key <key>',
+    'Use a personal access token instead of a JWT (also: SMARTSCRAPE_API_KEY env)',
+  );
 
 // Commands read flags via a getter so children resolve them after parsing.
 const getFlags = (): GlobalFlags => program.opts<GlobalFlags>();

--- a/cli/src/output.ts
+++ b/cli/src/output.ts
@@ -14,6 +14,7 @@ export type GlobalFlags = {
   quiet?: boolean;
   serverUrl?: string;
   token?: string;
+  apiKey?: string;
 };
 
 export class CliError extends Error {

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -124,3 +124,12 @@ export type UserPublic = {
   email_verified: boolean;
   telegram_chat_id: string | null;
 };
+
+export type AccessToken = {
+  id: string;
+  name: string;
+  prefix: string;
+  last_used_at: string | null;
+  created_at: string;
+  revoked_at: string | null;
+};

--- a/server/migrations/20260510193700_personal_access_tokens.js
+++ b/server/migrations/20260510193700_personal_access_tokens.js
@@ -1,0 +1,28 @@
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+
+export const up = (pgm) => {
+  pgm.sql(`
+    CREATE TABLE personal_access_tokens (
+      id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id       UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      name          TEXT        NOT NULL CHECK (char_length(name) BETWEEN 1 AND 80),
+      token_hash    TEXT        NOT NULL UNIQUE,
+      prefix        TEXT        NOT NULL,
+      last_used_at  TIMESTAMPTZ,
+      created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+      revoked_at    TIMESTAMPTZ
+    );
+
+    CREATE INDEX personal_access_tokens_user_id_idx
+      ON personal_access_tokens (user_id);
+
+    -- Filter index that only covers live tokens — auth path is hottest.
+    CREATE INDEX personal_access_tokens_active_hash_idx
+      ON personal_access_tokens (token_hash)
+      WHERE revoked_at IS NULL;
+  `);
+};
+
+export const down = (pgm) => {
+  pgm.sql(`DROP TABLE IF EXISTS personal_access_tokens;`);
+};

--- a/server/src/db/personalAccessTokens.ts
+++ b/server/src/db/personalAccessTokens.ts
@@ -1,0 +1,88 @@
+import { getPool } from '../config/database.js';
+
+export type PersonalAccessTokenRow = {
+  id: string;
+  user_id: string;
+  name: string;
+  token_hash: string;
+  prefix: string;
+  last_used_at: Date | null;
+  created_at: Date;
+  revoked_at: Date | null;
+};
+
+export type PersonalAccessTokenDTO = {
+  id: string;
+  name: string;
+  prefix: string;
+  last_used_at: string | null;
+  created_at: string;
+  revoked_at: string | null;
+};
+
+export function toDTO(row: PersonalAccessTokenRow): PersonalAccessTokenDTO {
+  return {
+    id: row.id,
+    name: row.name,
+    prefix: row.prefix,
+    last_used_at: row.last_used_at?.toISOString() ?? null,
+    created_at: row.created_at.toISOString(),
+    revoked_at: row.revoked_at?.toISOString() ?? null,
+  };
+}
+
+export async function createToken(args: {
+  userId: string;
+  name: string;
+  tokenHash: string;
+  prefix: string;
+}): Promise<PersonalAccessTokenRow> {
+  const { rows } = await getPool().query<PersonalAccessTokenRow>(
+    `INSERT INTO personal_access_tokens (user_id, name, token_hash, prefix)
+     VALUES ($1, $2, $3, $4)
+     RETURNING *`,
+    [args.userId, args.name, args.tokenHash, args.prefix],
+  );
+  return rows[0]!;
+}
+
+export async function listForUser(userId: string): Promise<PersonalAccessTokenRow[]> {
+  const { rows } = await getPool().query<PersonalAccessTokenRow>(
+    `SELECT * FROM personal_access_tokens
+      WHERE user_id = $1
+      ORDER BY revoked_at IS NULL DESC, created_at DESC`,
+    [userId],
+  );
+  return rows;
+}
+
+/**
+ * Lookup by hash for the auth-middleware hot path. Filters out revoked tokens
+ * so a leaked revoked token can never be replayed. The partial index on
+ * `token_hash WHERE revoked_at IS NULL` keeps this O(log N).
+ */
+export async function findActiveByHash(tokenHash: string): Promise<PersonalAccessTokenRow | null> {
+  const { rows } = await getPool().query<PersonalAccessTokenRow>(
+    `SELECT * FROM personal_access_tokens
+      WHERE token_hash = $1 AND revoked_at IS NULL
+      LIMIT 1`,
+    [tokenHash],
+  );
+  return rows[0] ?? null;
+}
+
+export async function revoke(userId: string, id: string): Promise<boolean> {
+  const { rowCount } = await getPool().query(
+    `UPDATE personal_access_tokens
+        SET revoked_at = now()
+      WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL`,
+    [id, userId],
+  );
+  return (rowCount ?? 0) > 0;
+}
+
+export async function touchLastUsed(id: string): Promise<void> {
+  await getPool().query(`UPDATE personal_access_tokens SET last_used_at = now() WHERE id = $1`, [
+    id,
+  ]);
+}

--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
+
+// Mocks for the DB + JWT dependencies the middleware imports. Vitest hoists
+// vi.mock to the top of the file, so these apply to the SUT below.
+vi.mock('../db/personalAccessTokens.js', () => ({
+  findActiveByHash: vi.fn(),
+  touchLastUsed: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../db/users.js', () => ({
+  findUserById: vi.fn(),
+}));
+vi.mock('../lib/jwt.js', () => ({
+  verifyAccessToken: vi.fn(),
+}));
+
+import { findActiveByHash, touchLastUsed } from '../db/personalAccessTokens.js';
+import { findUserById } from '../db/users.js';
+import { verifyAccessToken } from '../lib/jwt.js';
+
+type ExecResult = {
+  statusCode: number | null;
+  jsonBody: unknown;
+  calledNext: boolean;
+  user: { id: string; email: string } | undefined;
+};
+
+function makeReq(headers: Record<string, string>): Request {
+  return {
+    header(name: string) {
+      return headers[name.toLowerCase()];
+    },
+  } as unknown as Request;
+}
+
+/**
+ * The auth module keeps an in-memory debounce cache as module-level state. To
+ * test cleanly each case re-imports the SUT after `vi.resetModules()`, which
+ * also re-binds the mocked deps below to fresh `vi.fn()` instances.
+ */
+async function freshExec(
+  headers: Record<string, string>,
+): Promise<ExecResult & { mod: typeof import('./auth.js') }> {
+  vi.resetModules();
+  // Re-declare mocks against the reset module registry — without this the
+  // re-imported SUT would resolve to the real modules.
+  vi.doMock('../db/personalAccessTokens.js', () => ({
+    findActiveByHash,
+    touchLastUsed,
+  }));
+  vi.doMock('../db/users.js', () => ({ findUserById }));
+  vi.doMock('../lib/jwt.js', () => ({ verifyAccessToken }));
+  const mod = await import('./auth.js');
+  const req = makeReq(headers);
+  const out: ExecResult = { statusCode: null, jsonBody: null, calledNext: false, user: undefined };
+  const res = {
+    status(n: number) {
+      out.statusCode = n;
+      return this;
+    },
+    json(payload: unknown) {
+      out.jsonBody = payload;
+      return this;
+    },
+  } as unknown as Response;
+  const next: NextFunction = () => {
+    out.calledNext = true;
+  };
+  await mod.requireAuth(req, res, next);
+  out.user = (req as unknown as { user?: { id: string; email: string } }).user;
+  return { ...out, mod };
+}
+
+const fakeUserRow = {
+  id: 'u-1',
+  email: 'alice@example.com',
+  password_hash: '',
+  name: null,
+  email_verified: true,
+  verification_token: null,
+  reset_token: null,
+  reset_token_expires: null,
+  telegram_chat_id: null,
+  created_at: new Date(),
+  updated_at: new Date(),
+};
+
+const fakePatRow = {
+  id: 'pat-1',
+  user_id: 'u-1',
+  name: 'ci',
+  token_hash: 'hash',
+  prefix: 'sst_xxxxxxxx',
+  last_used_at: null,
+  created_at: new Date(),
+  revoked_at: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default success returns; individual tests override.
+  vi.mocked(touchLastUsed).mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('requireAuth — PAT path', () => {
+  it('authenticates an active PAT presented via X-API-Key', async () => {
+    vi.mocked(findActiveByHash).mockResolvedValueOnce(fakePatRow);
+    vi.mocked(findUserById).mockResolvedValueOnce(fakeUserRow);
+    const out = await freshExec({ 'x-api-key': 'sst_abc' });
+    expect(out.calledNext).toBe(true);
+    expect(out.user).toEqual({ id: 'u-1', email: 'alice@example.com' });
+  });
+
+  it('also accepts a PAT in Authorization: Bearer (sst_ prefix)', async () => {
+    vi.mocked(findActiveByHash).mockResolvedValueOnce(fakePatRow);
+    vi.mocked(findUserById).mockResolvedValueOnce(fakeUserRow);
+    const out = await freshExec({ authorization: 'Bearer sst_abc' });
+    expect(out.calledNext).toBe(true);
+    expect(out.user?.id).toBe('u-1');
+    // Crucially: when prefix is sst_, we never fall through to JWT verify.
+    expect(verifyAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects 401 when the PAT does not match an active row', async () => {
+    vi.mocked(findActiveByHash).mockResolvedValueOnce(null);
+    const out = await freshExec({ 'x-api-key': 'sst_bad' });
+    expect(out.calledNext).toBe(false);
+    expect(out.statusCode).toBe(401);
+    expect(out.jsonBody).toMatchObject({
+      success: false,
+      error: { code: 'UNAUTHORIZED' },
+    });
+  });
+
+  it('rejects 401 when the PAT row points at a deleted user', async () => {
+    vi.mocked(findActiveByHash).mockResolvedValueOnce(fakePatRow);
+    vi.mocked(findUserById).mockResolvedValueOnce(null);
+    const out = await freshExec({ 'x-api-key': 'sst_abc' });
+    expect(out.calledNext).toBe(false);
+    expect(out.statusCode).toBe(401);
+  });
+
+  it('debounces last_used_at: first call writes, immediate second does not', async () => {
+    vi.mocked(findActiveByHash).mockResolvedValue(fakePatRow);
+    vi.mocked(findUserById).mockResolvedValue(fakeUserRow);
+    vi.resetModules();
+    vi.doMock('../db/personalAccessTokens.js', () => ({
+      findActiveByHash,
+      touchLastUsed,
+    }));
+    vi.doMock('../db/users.js', () => ({ findUserById }));
+    vi.doMock('../lib/jwt.js', () => ({ verifyAccessToken }));
+    const mod = await import('./auth.js');
+    const req1 = makeReq({ 'x-api-key': 'sst_abc' });
+    const noopRes = { status: () => noopRes, json: () => noopRes } as unknown as Response;
+    await mod.requireAuth(req1, noopRes, () => {});
+    expect(touchLastUsed).toHaveBeenCalledTimes(1);
+    const req2 = makeReq({ 'x-api-key': 'sst_abc' });
+    await mod.requireAuth(req2, noopRes, () => {});
+    // Still 1 — the second hit is inside the 60s debounce window. Same SUT
+    // instance, so the in-memory cache persists across the two calls.
+    expect(touchLastUsed).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('requireAuth — JWT path', () => {
+  it('authenticates a valid Bearer JWT', async () => {
+    vi.mocked(verifyAccessToken).mockReturnValueOnce({
+      sub: 'u-2',
+      email: 'bob@example.com',
+    } as ReturnType<typeof verifyAccessToken>);
+    const out = await freshExec({ authorization: 'Bearer eyJhbGciOi...' });
+    expect(out.calledNext).toBe(true);
+    expect(out.user).toEqual({ id: 'u-2', email: 'bob@example.com' });
+  });
+
+  it('rejects 401 when the JWT fails verification', async () => {
+    vi.mocked(verifyAccessToken).mockImplementationOnce(() => {
+      throw new Error('expired');
+    });
+    const out = await freshExec({ authorization: 'Bearer eyJ.bad' });
+    expect(out.calledNext).toBe(false);
+    expect(out.statusCode).toBe(401);
+  });
+
+  it('rejects 401 when no auth header is present', async () => {
+    const out = await freshExec({});
+    expect(out.calledNext).toBe(false);
+    expect(out.statusCode).toBe(401);
+  });
+
+  it('rejects 401 when Authorization header is malformed', async () => {
+    const out = await freshExec({ authorization: 'NotBearer foo' });
+    expect(out.calledNext).toBe(false);
+    expect(out.statusCode).toBe(401);
+  });
+
+  it('X-API-Key wins when both headers are present', async () => {
+    vi.mocked(findActiveByHash).mockResolvedValueOnce(fakePatRow);
+    vi.mocked(findUserById).mockResolvedValueOnce(fakeUserRow);
+    const out = await freshExec({
+      'x-api-key': 'sst_abc',
+      authorization: 'Bearer eyJ.something',
+    });
+    expect(out.calledNext).toBe(true);
+    expect(out.user?.id).toBe('u-1');
+    expect(verifyAccessToken).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,6 +1,11 @@
 import type { Request, Response, NextFunction } from 'express';
 import { verifyAccessToken } from '../lib/jwt.js';
 import { fail } from '../lib/response.js';
+import { hashToken } from '../lib/tokens.js';
+import { findActiveByHash, touchLastUsed } from '../db/personalAccessTokens.js';
+import { findUserById } from '../db/users.js';
+
+export const PAT_PREFIX = 'sst_';
 
 export type AuthenticatedUser = {
   id: string;
@@ -16,18 +21,80 @@ declare global {
   }
 }
 
-export function requireAuth(req: Request, res: Response, next: NextFunction): void {
+/**
+ * In-memory debounce for last_used_at writes. The auth middleware fires on
+ * every request, so without a guard we'd write per-request — which both
+ * thrashes the row and serialises behind the UPDATE. A 60s window is good
+ * enough for "when was this token last used" without paying that cost.
+ */
+const LAST_USED_DEBOUNCE_MS = 60_000;
+const lastTouchedAt = new Map<string, number>();
+
+async function authenticatePat(token: string): Promise<AuthenticatedUser | null> {
+  const row = await findActiveByHash(hashToken(token));
+  if (!row) return null;
+  const user = await findUserById(row.user_id);
+  if (!user) return null;
+  const now = Date.now();
+  const previous = lastTouchedAt.get(row.id) ?? 0;
+  if (now - previous >= LAST_USED_DEBOUNCE_MS) {
+    lastTouchedAt.set(row.id, now);
+    // Fire-and-forget: the user is already authenticated; failing this write
+    // shouldn't fail the request.
+    void touchLastUsed(row.id).catch(() => {});
+  }
+  return { id: user.id, email: user.email };
+}
+
+function authenticateJwt(token: string): AuthenticatedUser | null {
+  try {
+    const payload = verifyAccessToken(token);
+    return { id: payload.sub, email: payload.email };
+  } catch {
+    return null;
+  }
+}
+
+export async function requireAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
+  // Personal access tokens win when present — X-API-Key is the documented
+  // header for automation, and it's the only way to send a PAT without
+  // pretending to be a JWT.
+  const apiKeyHeader = req.header('x-api-key');
+  if (apiKeyHeader) {
+    const user = await authenticatePat(apiKeyHeader);
+    if (user) {
+      req.user = user;
+      next();
+      return;
+    }
+    res.status(401).json(fail('UNAUTHORIZED', 'Invalid or revoked API key'));
+    return;
+  }
+
   const header = req.header('authorization') ?? '';
   const match = header.match(/^Bearer\s+(.+)$/i);
   if (!match) {
     res.status(401).json(fail('UNAUTHORIZED', 'Missing or malformed Authorization header'));
     return;
   }
-  try {
-    const payload = verifyAccessToken(match[1]!);
-    req.user = { id: payload.sub, email: payload.email };
-    next();
-  } catch {
-    res.status(401).json(fail('UNAUTHORIZED', 'Invalid or expired access token'));
+  const presented = match[1]!;
+  // Authorization: Bearer sst_... is also accepted, so the same token works
+  // from both header forms.
+  if (presented.startsWith(PAT_PREFIX)) {
+    const user = await authenticatePat(presented);
+    if (user) {
+      req.user = user;
+      next();
+      return;
+    }
+    res.status(401).json(fail('UNAUTHORIZED', 'Invalid or revoked API key'));
+    return;
   }
+  const user = authenticateJwt(presented);
+  if (!user) {
+    res.status(401).json(fail('UNAUTHORIZED', 'Invalid or expired access token'));
+    return;
+  }
+  req.user = user;
+  next();
 }

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -22,6 +22,13 @@ import {
   revokeAllForUser,
   revokeById,
 } from '../db/refreshTokens.js';
+import {
+  createToken as createPat,
+  listForUser as listPats,
+  revoke as revokePat,
+  toDTO as toPatDTO,
+} from '../db/personalAccessTokens.js';
+import { PAT_PREFIX } from '../middleware/auth.js';
 import { hashPassword, verifyPassword } from '../lib/password.js';
 import { signAccessToken, REFRESH_TTL_MS } from '../lib/jwt.js';
 import { generateToken, hashToken } from '../lib/tokens.js';
@@ -297,3 +304,60 @@ authRouter.delete('/me', requireAuth, userGeneralLimiter, async (req, res) => {
   await deleteUser(req.user!.id);
   res.status(200).json(ok({ deleted: true }));
 });
+
+// ---------- personal access tokens ----------
+
+const createPatSchema = z.object({
+  name: z.string().trim().min(1).max(80),
+});
+
+const patIdParam = z.object({ id: z.string().uuid() });
+
+/**
+ * Format: `sst_<base64url-22chars>`. Prefix makes the token grep-able in logs
+ * and obviously different from JWTs (which look like `eyJ…`). 22 chars of
+ * base64url = 132 bits of entropy, well past brute-force territory.
+ */
+function newAccessToken(): { plaintext: string; hash: string; prefix: string } {
+  const { token } = generateToken(16);
+  const plaintext = `${PAT_PREFIX}${token}`;
+  // Hash the *prefixed* plaintext so the auth-middleware lookup hashes the
+  // exact same string the client sends.
+  return { plaintext, hash: hashToken(plaintext), prefix: plaintext.slice(0, 12) };
+}
+
+authRouter.get('/access-tokens', requireAuth, userGeneralLimiter, async (req, res) => {
+  const rows = await listPats(req.user!.id);
+  res.status(200).json(ok({ tokens: rows.map(toPatDTO) }));
+});
+
+authRouter.post(
+  '/access-tokens',
+  requireAuth,
+  userGeneralLimiter,
+  validate(createPatSchema),
+  async (req, res) => {
+    const { name } = req.body as z.infer<typeof createPatSchema>;
+    const { plaintext, hash, prefix } = newAccessToken();
+    const row = await createPat({ userId: req.user!.id, name, tokenHash: hash, prefix });
+    // Plaintext is returned exactly once — clients must persist it now or
+    // mint a new token.
+    res.status(201).json(ok({ token: { ...toPatDTO(row), plaintext } }));
+  },
+);
+
+authRouter.delete(
+  '/access-tokens/:id',
+  requireAuth,
+  userGeneralLimiter,
+  validate(patIdParam, 'params'),
+  async (req, res) => {
+    const { id } = req.params as unknown as z.infer<typeof patIdParam>;
+    const ok_ = await revokePat(req.user!.id, id);
+    if (!ok_) {
+      res.status(404).json(fail('NOT_FOUND', 'Access token not found'));
+      return;
+    }
+    res.status(200).json(ok({ revoked: true }));
+  },
+);


### PR DESCRIPTION
Closes #98.

## Summary

Personal access tokens (PATs) — long-lived, revocable, surfaced on every request via `X-API-Key` or `Authorization: Bearer sst_…`. The motivating use case is cron jobs and external agents: today they either babysit a JWT refresh cookie or re-login every invocation, neither of which is great.

## What's in

### Server

- Migration `20260510193700_personal_access_tokens.js`: `personal_access_tokens` table (uuid pk, sha256 `token_hash` UNIQUE, `prefix` for UI display, `last_used_at`, `revoked_at`), plus a partial index on `token_hash WHERE revoked_at IS NULL` so the auth-middleware lookup hits an index that only contains live tokens.
- `requireAuth` extended: `X-API-Key` wins, then `Authorization: Bearer sst_…` (same token, second header form), then JWT. JWT path is unchanged for callers that don't opt in.
- `last_used_at` writes are debounced to **once per token per minute** in-process, fire-and-forget — auth path fires on every request, so the alternative was a write per request.
- Routes under `/api/auth/access-tokens`: `GET` list (no plaintext, just prefix), `POST` create (plaintext returned **once**), `DELETE /:id` revoke.
- Auth middleware tests: 11 vitest cases covering both header forms, deleted-user guard, revoked-row guard, debounce, X-API-Key precedence over Bearer JWT.

### CLI

- `smartscrape auth tokens list | create --name <n> | revoke <id>` (short id resolution against the live list, so `revoke 6bdb1e23` works).
- New global flag `--api-key` and env `SMARTSCRAPE_API_KEY`, both routed through `createClient` to `ResolvedSession.apiKey`.
- API-key path skips the JWT refresh dance — PATs are either active or revoked; there's no short-lived token to renew.
- On `create`, plaintext goes to stdout (pipe-into-secret-store friendly); status banner to stderr.

## Naming

The existing `api_keys` table holds *third-party* (OpenAI/Anthropic/OpenRouter) credentials. To avoid that collision, the new table is `personal_access_tokens` (GitHub's naming convention) and the CLI/UI surface is "access tokens" / "PAT". Plaintext format is `sst_<base64url-22>` so tokens are grep-able in logs and obviously different from JWTs (which start with `eyJ`).

## Out of scope (deferred)

- Settings UI for managing tokens — separate follow-up (or rolled into a wider Settings polish PR).
- Per-token scopes — every token currently has the same access as the user. Worth a follow-up if anyone wants "read-only" or "jobs-only" tokens.

## Verification

```
$ npm run typecheck     # server + client + cli — clean
$ npm run lint          # eslint — clean
$ npm run format:check  # prettier — clean
$ npm run -w server test
  Test Files  9 passed (9)
       Tests  119 passed (119)
```

### Live end-to-end against a dev stack

- [x] `POST /api/auth/access-tokens` returns `{ id, name, prefix, plaintext }` once
- [x] `X-API-Key: sst_…` authenticates against `/api/auth/me`
- [x] `Authorization: Bearer sst_…` also authenticates (same token, second form)
- [x] `last_used_at` advances on use
- [x] `DELETE /api/auth/access-tokens/:id` succeeds
- [x] Re-using a revoked token returns 401 + `{ code: 'UNAUTHORIZED' }`
- [x] CLI `auth tokens create` → plaintext on stdout, banner on stderr
- [x] CLI `--api-key` / `SMARTSCRAPE_API_KEY` works for all subcommands
- [x] CLI `auth tokens revoke <shortid>` resolves to full uuid

## Test plan

All items run before requesting review:

- [x] **CI passes** — all 5 checks green on commit 4da9aa2 (verify, audit, docker, migrations, e2e). 119 tests including the 11 new auth-middleware cases.
- [x] **Migration round-trip on a live DB** — `migrate:down` drops the table + pgmigrations row; `migrate:up` restores it with all 4 indexes (pk, unique token_hash, user_id, partial active_hash). Both directions clean against an existing populated database.
- [x] **PAT lifecycle against real job-API endpoints** — minted a PAT, drove 6 distinct authenticated endpoints (`auth whoami`, `jobs list`, `dashboard stats`, `providers list`, `settings show`, `auth tokens list`) using only `SMARTSCRAPE_API_KEY`, revoked it, confirmed both `X-API-Key` and `Bearer sst_…` forms return 401 + `UNAUTHORIZED` afterward.
- [x] **JWT path regression** — `auth login` + `jobs list` succeed unchanged; tampered access token forces a 401 → CLI replays the refresh cookie → server issues a new pair → CLI persists it → command succeeds. Identical to the pre-change behavior verified in #97.