### PR TITLE
feat(webhooks): POST run results to a per-job webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ Every command supports `--json`, `--quiet`, `--server-url`, `--token`, `--api-ke
 
 Long-running automation should use a personal access token over JWT: `smartscrape auth tokens create --name ci-runner` mints one, plaintext is shown once, send it on every request via `SMARTSCRAPE_API_KEY` env or the `X-API-Key` header. Revoke any token from Settings or via `smartscrape auth tokens revoke <id>`.
 
+## Webhooks
+
+Configure a webhook on a job and SmartScrape POSTs the run results to that URL after every terminal run (completed or failed). Set the URL on create or edit:
+
+```bash
+smartscrape jobs edit <job-id> --webhook-url https://example.com/hook --webhook-secret '<long-secret>'
+smartscrape jobs webhook test <job-id>     # send a synthetic payload now
+```
+
+Payload shape: `{ event, job_id, job_name, run_id, status, items_count, urls_scraped, tokens_used, error_message, started_at, completed_at, changes: { added, removed, changed }, items: [...] }`. When a secret is configured, the request carries `X-Webhook-Signature: sha256=<hmac>` over the raw body and `X-Webhook-Timestamp`. Delivery retries up to 3 times with 1s → 4s backoff; the outcome is persisted on `webhook_status`, `webhook_attempts`, and `webhook_last_error` on the run row.
+
 ## How a run works
 
 1. You hit **Run now** (or cron fires the job).

--- a/cli/README.md
+++ b/cli/README.md
@@ -38,6 +38,7 @@ export SMARTSCRAPE_TOKEN=eyJhbGciOiJIUzI1NiIs...
 auth login | logout | whoami
 auth tokens list | create --name <n> | revoke <id>
 jobs list | show <id> | create | edit <id> | delete <id> | toggle <id> | run <id>
+jobs webhook test <id>      # send a synthetic payload to the configured URL
 runs show <id> | data <id> | diff <id>
 results <job-id>            # latest run's data
 export <job-id> --csv | --json | --sheets
@@ -46,6 +47,10 @@ providers list | set --provider <p> --key <k> | test <p> | delete <p>
 notifications test email | telegram
 dashboard stats
 ```
+
+Pass `--webhook-url <url>` and `--webhook-secret <secret>` on `jobs create` /
+`jobs edit` to receive POSTed run results. On `jobs edit`, an empty string
+(e.g. `--webhook-url ""`) clears the field.
 
 Every command supports `--json` (raw JSON to stdout) and `--quiet` (suppress
 non-error output), plus `--server-url`, `--token`, and `--api-key` for

--- a/cli/src/commands/jobs.ts
+++ b/cli/src/commands/jobs.ts
@@ -39,6 +39,8 @@ type CreateInput = {
   sheet_tab_name?: string | null;
   setup_method?: 'manual' | 'ai';
   respect_robots_txt?: boolean;
+  webhook_url?: string | null;
+  webhook_secret?: string | null;
 };
 
 function readJsonFromOpt(value: string | undefined, label: string): unknown {
@@ -113,6 +115,8 @@ function buildCreateBody(
   if (opts.sheetId !== undefined) body.google_sheet_id = String(opts.sheetId);
   if (opts.sheetTab !== undefined) body.sheet_tab_name = String(opts.sheetTab);
   if (opts.respectRobots !== undefined) body.respect_robots_txt = Boolean(opts.respectRobots);
+  if (opts.webhookUrl !== undefined) body.webhook_url = String(opts.webhookUrl);
+  if (opts.webhookSecret !== undefined) body.webhook_secret = String(opts.webhookSecret);
   return body;
 }
 
@@ -199,6 +203,8 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
             `Compare key:  ${j.comparison_key ?? '(data hash)'}`,
             `Channels:     ${j.notify_channels.join(', ') || '(none)'}`,
             `Rules:        ${j.notification_rules.length}`,
+            `Webhook URL:  ${j.webhook_url ?? '(none)'}`,
+            `Webhook sec:  ${j.webhook_secret_configured ? 'configured' : '(none)'}`,
             `Last run:     ${j.last_run_at ?? 'never'}`,
             `Created:      ${j.created_at}`,
           ].join('\n'),
@@ -224,7 +230,12 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     .option('--model <id>', 'AI model id, e.g. openai/gpt-4o-mini')
     .option('--sheet-id <id>', 'Linked Google Sheet ID')
     .option('--sheet-tab <name>', 'Tab name within the sheet')
-    .option('--no-respect-robots', 'Ignore robots.txt for this job');
+    .option('--no-respect-robots', 'Ignore robots.txt for this job')
+    .option('--webhook-url <url>', 'POST run results to this URL after every terminal run')
+    .option(
+      '--webhook-secret <secret>',
+      'Optional HMAC secret. When set, payloads include X-Webhook-Signature',
+    );
   create.action(async (opts: Record<string, string | string[] | boolean | undefined>) => {
     const flags = getFlags();
     await runCommand(flags, async () => {
@@ -259,6 +270,8 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     .option('--model <id>', 'AI model id')
     .option('--sheet-id <id>', 'Linked Google Sheet ID')
     .option('--sheet-tab <name>', 'Tab name within the sheet')
+    .option('--webhook-url <url>', 'POST run results to this URL (pass empty string to clear)')
+    .option('--webhook-secret <secret>', 'HMAC secret (pass empty string to clear)')
     .action(async (id: string, opts: Record<string, string | boolean | undefined>) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
@@ -288,6 +301,13 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
         if (opts.model !== undefined) patch.ai_model = String(opts.model);
         if (opts.sheetId !== undefined) patch.google_sheet_id = String(opts.sheetId);
         if (opts.sheetTab !== undefined) patch.sheet_tab_name = String(opts.sheetTab);
+        if (opts.webhookUrl !== undefined) {
+          // Empty string clears the URL; otherwise pass-through.
+          patch.webhook_url = opts.webhookUrl === '' ? null : String(opts.webhookUrl);
+        }
+        if (opts.webhookSecret !== undefined) {
+          patch.webhook_secret = opts.webhookSecret === '' ? null : String(opts.webhookSecret);
+        }
 
         if (Object.keys(patch).length === 0) {
           throw new CliError(
@@ -391,6 +411,35 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
         }
         if (flags.json) emitJson(final, flags);
         else emitText(`Run ${final.id} → ${final.status} (items: ${final.items_extracted})`, flags);
+      });
+    });
+
+  const webhook = jobs
+    .command('webhook')
+    .description('Inspect and test the configured webhook for a job');
+
+  webhook
+    .command('test <id>')
+    .description("Send a synthetic payload to the job's webhook_url")
+    .action(async (id: string) => {
+      const flags = getFlags();
+      await runCommand(flags, async () => {
+        const client = createClient({
+          url: flags.serverUrl,
+          token: flags.token,
+          apiKey: flags.apiKey,
+        });
+        requireToken(client);
+        const data = await client.request<{ delivered: boolean; attempts: number; status: number }>(
+          `/api/jobs/${id}/webhook/test`,
+          { method: 'POST' },
+        );
+        if (flags.json) emitJson(data, flags);
+        else
+          emitText(
+            `Delivered after ${data.attempts} attempt(s) — receiver returned HTTP ${data.status}`,
+            flags,
+          );
       });
     });
 

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -57,6 +57,8 @@ export type JobDTO = {
   sheet_tab_name: string | null;
   setup_method: SetupMethod;
   respect_robots_txt: boolean;
+  webhook_url: string | null;
+  webhook_secret_configured: boolean;
   last_run_at: string | null;
   created_at: string;
   updated_at: string;
@@ -78,6 +80,10 @@ export type RunDTO = {
   export_error: string | null;
   started_at: string;
   completed_at: string | null;
+  webhook_status: 'success' | 'failed' | null;
+  webhook_attempts: number;
+  webhook_last_error: string | null;
+  webhook_delivered_at: string | null;
 };
 
 export type ExtractedDataDTO = {

--- a/server/migrations/20260510200000_webhooks.js
+++ b/server/migrations/20260510200000_webhooks.js
@@ -1,0 +1,30 @@
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+
+export const up = (pgm) => {
+  pgm.sql(`
+    ALTER TABLE scrape_jobs
+      ADD COLUMN webhook_url               TEXT,
+      ADD COLUMN webhook_secret_encrypted  TEXT;
+
+    ALTER TABLE scrape_runs
+      ADD COLUMN webhook_status        TEXT
+        CHECK (webhook_status IN ('success', 'failed') OR webhook_status IS NULL),
+      ADD COLUMN webhook_attempts      INTEGER NOT NULL DEFAULT 0,
+      ADD COLUMN webhook_last_error    TEXT,
+      ADD COLUMN webhook_delivered_at  TIMESTAMPTZ;
+  `);
+};
+
+export const down = (pgm) => {
+  pgm.sql(`
+    ALTER TABLE scrape_runs
+      DROP COLUMN IF EXISTS webhook_delivered_at,
+      DROP COLUMN IF EXISTS webhook_last_error,
+      DROP COLUMN IF EXISTS webhook_attempts,
+      DROP COLUMN IF EXISTS webhook_status;
+
+    ALTER TABLE scrape_jobs
+      DROP COLUMN IF EXISTS webhook_secret_encrypted,
+      DROP COLUMN IF EXISTS webhook_url;
+  `);
+};

--- a/server/src/db/jobs.ts
+++ b/server/src/db/jobs.ts
@@ -44,20 +44,37 @@ export type JobRow = {
   sheet_tab_name: string | null;
   setup_method: SetupMethod;
   respect_robots_txt: boolean;
+  webhook_url: string | null;
+  /**
+   * AES-256-GCM ciphertext of the user-supplied HMAC secret, or null. The
+   * plaintext is never returned by the API after the initial write — the DTO
+   * exposes `webhook_secret_configured: boolean` so the UI can show that one
+   * is set without leaking it.
+   */
+  webhook_secret_encrypted: string | null;
   last_run_at: Date | null;
   created_at: Date;
   updated_at: Date;
 };
 
-export type JobDTO = Omit<JobRow, 'last_run_at' | 'created_at' | 'updated_at'> & {
+export type JobDTO = Omit<
+  JobRow,
+  'last_run_at' | 'created_at' | 'updated_at' | 'webhook_secret_encrypted'
+> & {
   last_run_at: string | null;
   created_at: string;
   updated_at: string;
+  webhook_secret_configured: boolean;
 };
 
 export function toDTO(row: JobRow): JobDTO {
+  // Strip the encrypted column from the wire shape — callers should only ever
+  // see a boolean. Destructure it off before spreading.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { webhook_secret_encrypted, ...rest } = row;
   return {
-    ...row,
+    ...rest,
+    webhook_secret_configured: row.webhook_secret_encrypted !== null,
     last_run_at: row.last_run_at?.toISOString() ?? null,
     created_at: row.created_at.toISOString(),
     updated_at: row.updated_at.toISOString(),
@@ -81,6 +98,8 @@ export type CreateJobArgs = {
   sheet_tab_name?: string | null;
   setup_method?: SetupMethod;
   respect_robots_txt?: boolean;
+  webhook_url?: string | null;
+  webhook_secret_encrypted?: string | null;
 };
 
 export async function createJob(userId: string, args: CreateJobArgs): Promise<JobRow> {
@@ -89,9 +108,9 @@ export async function createJob(userId: string, args: CreateJobArgs): Promise<Jo
        user_id, name, urls, extraction_prompt, extraction_schema,
        scrape_method, schedule, enabled, notification_rules, notify_channels,
        comparison_key, ai_provider, ai_model, google_sheet_id, sheet_tab_name, setup_method,
-       respect_robots_txt
+       respect_robots_txt, webhook_url, webhook_secret_encrypted
      )
-     VALUES ($1,$2,$3::jsonb,$4,$5::jsonb,$6,$7,$8,$9::jsonb,$10::jsonb,$11,$12,$13,$14,$15,$16,$17)
+     VALUES ($1,$2,$3::jsonb,$4,$5::jsonb,$6,$7,$8,$9::jsonb,$10::jsonb,$11,$12,$13,$14,$15,$16,$17,$18,$19)
      RETURNING *`,
     [
       userId,
@@ -111,6 +130,8 @@ export async function createJob(userId: string, args: CreateJobArgs): Promise<Jo
       args.sheet_tab_name ?? null,
       args.setup_method ?? 'manual',
       args.respect_robots_txt ?? true,
+      args.webhook_url ?? null,
+      args.webhook_secret_encrypted ?? null,
     ],
   );
   return rows[0]!;
@@ -219,6 +240,9 @@ export async function updateJob(
   if (args.google_sheet_id !== undefined) push('google_sheet_id', args.google_sheet_id);
   if (args.sheet_tab_name !== undefined) push('sheet_tab_name', args.sheet_tab_name);
   if (args.respect_robots_txt !== undefined) push('respect_robots_txt', args.respect_robots_txt);
+  if (args.webhook_url !== undefined) push('webhook_url', args.webhook_url);
+  if (args.webhook_secret_encrypted !== undefined)
+    push('webhook_secret_encrypted', args.webhook_secret_encrypted);
 
   if (sets.length === 0) return findJob(userId, jobId);
 

--- a/server/src/db/runs.ts
+++ b/server/src/db/runs.ts
@@ -19,11 +19,16 @@ export type RunRow = {
   export_error: string | null;
   started_at: Date;
   completed_at: Date | null;
+  webhook_status: 'success' | 'failed' | null;
+  webhook_attempts: number;
+  webhook_last_error: string | null;
+  webhook_delivered_at: Date | null;
 };
 
-export type RunDTO = Omit<RunRow, 'started_at' | 'completed_at'> & {
+export type RunDTO = Omit<RunRow, 'started_at' | 'completed_at' | 'webhook_delivered_at'> & {
   started_at: string;
   completed_at: string | null;
+  webhook_delivered_at: string | null;
 };
 
 export function toDTO(r: RunRow): RunDTO {
@@ -31,6 +36,7 @@ export function toDTO(r: RunRow): RunDTO {
     ...r,
     started_at: r.started_at.toISOString(),
     completed_at: r.completed_at?.toISOString() ?? null,
+    webhook_delivered_at: r.webhook_delivered_at?.toISOString() ?? null,
   };
 }
 
@@ -96,6 +102,10 @@ export async function updateRun(
       | 'error_message'
       | 'export_error'
       | 'completed_at'
+      | 'webhook_status'
+      | 'webhook_attempts'
+      | 'webhook_last_error'
+      | 'webhook_delivered_at'
     >
   >,
 ): Promise<void> {
@@ -112,6 +122,11 @@ export async function updateRun(
   if (patch.error_message !== undefined) push('error_message', patch.error_message);
   if (patch.export_error !== undefined) push('export_error', patch.export_error);
   if (patch.completed_at !== undefined) push('completed_at', patch.completed_at);
+  if (patch.webhook_status !== undefined) push('webhook_status', patch.webhook_status);
+  if (patch.webhook_attempts !== undefined) push('webhook_attempts', patch.webhook_attempts);
+  if (patch.webhook_last_error !== undefined) push('webhook_last_error', patch.webhook_last_error);
+  if (patch.webhook_delivered_at !== undefined)
+    push('webhook_delivered_at', patch.webhook_delivered_at);
   if (sets.length === 0) return;
   vals.push(runId);
   await getPool().query(

--- a/server/src/routes/jobs.ts
+++ b/server/src/routes/jobs.ts
@@ -24,7 +24,7 @@ import { countRunsLast24h, findRun, listDataForRun, listRunsForJob } from '../db
 import { DAILY_RUN_QUOTA } from '../services/job-runner.js';
 import { toCsv } from '../lib/csv.js';
 import { findForUser as findApiKey, type Provider as ProviderName } from '../db/apiKeys.js';
-import { decrypt } from '../config/encryption.js';
+import { decrypt, encrypt } from '../config/encryption.js';
 import { scrape } from '../services/scraper.js';
 import { suggest } from '../services/ai-setup.js';
 import { extract } from '../services/ai-extractor.js';
@@ -105,6 +105,10 @@ const createBody = z.object({
   sheet_tab_name: z.string().nullable().optional(),
   setup_method: setupMethodEnum.optional(),
   respect_robots_txt: z.boolean().optional(),
+  // Webhooks. Pass `null` to clear; omit to leave as-is. webhook_secret is
+  // encrypted server-side before storage and never returned in the read API.
+  webhook_url: z.string().url().max(2048).nullable().optional(),
+  webhook_secret: z.string().min(8).max(256).nullable().optional(),
 });
 
 const updateBody = createBody.partial();
@@ -125,6 +129,41 @@ async function validateAllUrls(urls: string[]): Promise<string | null> {
     if (!r.ok) return `${u}: ${r.reason}`;
   }
   return null;
+}
+
+/**
+ * Strip `webhook_secret` (plaintext) off the request body, validate the URL
+ * if present, and return an `args`-shaped patch that contains the encrypted
+ * column instead. Used by both create and edit so the secret never reaches
+ * the DB module in plaintext.
+ */
+async function prepareWebhookFields(body: {
+  webhook_url?: string | null;
+  webhook_secret?: string | null;
+}): Promise<
+  | { ok: true; args: { webhook_url?: string | null; webhook_secret_encrypted?: string | null } }
+  | { ok: false; status: number; code: string; message: string }
+> {
+  const out: { webhook_url?: string | null; webhook_secret_encrypted?: string | null } = {};
+  if (body.webhook_url !== undefined) {
+    if (body.webhook_url !== null) {
+      const safety = await assertSafeUrl(body.webhook_url);
+      if (!safety.ok) {
+        return {
+          ok: false,
+          status: 400,
+          code: 'UNSAFE_URL',
+          message: `webhook_url: ${safety.reason}`,
+        };
+      }
+    }
+    out.webhook_url = body.webhook_url;
+  }
+  if (body.webhook_secret !== undefined) {
+    out.webhook_secret_encrypted =
+      body.webhook_secret === null ? null : encrypt(body.webhook_secret);
+  }
+  return { ok: true, args: out };
 }
 
 // ---------- routes ----------
@@ -297,9 +336,19 @@ jobsRouter.post('/', validate(createBody), async (req, res) => {
     res.status(400).json(fail('UNSAFE_URL', bad));
     return;
   }
+  const webhook = await prepareWebhookFields(body);
+  if (!webhook.ok) {
+    res.status(webhook.status).json(fail(webhook.code, webhook.message));
+    return;
+  }
+  // Drop the plaintext webhook_secret before forwarding to the DB module — it
+  // only travels as the encrypted ciphertext from here on.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { webhook_secret, ...rest } = body;
   const row = await createJob(req.user!.id, {
-    ...body,
-    extraction_schema: body.extraction_schema ?? null,
+    ...rest,
+    extraction_schema: rest.extraction_schema ?? null,
+    ...webhook.args,
   });
   await syncSchedule({
     jobId: row.id,
@@ -330,7 +379,14 @@ jobsRouter.patch('/:id', validate(idParam, 'params'), validate(updateBody), asyn
       return;
     }
   }
-  const row = await updateJob(req.user!.id, id, body);
+  const webhook = await prepareWebhookFields(body);
+  if (!webhook.ok) {
+    res.status(webhook.status).json(fail(webhook.code, webhook.message));
+    return;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { webhook_secret, ...rest } = body;
+  const row = await updateJob(req.user!.id, id, { ...rest, ...webhook.args });
   if (!row) {
     res.status(404).json(fail('NOT_FOUND', 'Job not found'));
     return;
@@ -503,6 +559,36 @@ jobsRouter.post(
     }
   },
 );
+
+jobsRouter.post('/:id/webhook/test', validate(idParam, 'params'), async (req, res) => {
+  const { id } = req.params as unknown as z.infer<typeof idParam>;
+  const job = await findJob(req.user!.id, id);
+  if (!job) {
+    res.status(404).json(fail('NOT_FOUND', 'Job not found'));
+    return;
+  }
+  if (!job.webhook_url) {
+    res.status(400).json(fail('NO_WEBHOOK_URL', 'This job has no webhook_url configured'));
+    return;
+  }
+  const { buildTestPayload, deliver } = await import('../services/webhooks.js');
+  const payload = buildTestPayload(job);
+  const result = await deliver({
+    url: job.webhook_url,
+    secretEncrypted: job.webhook_secret_encrypted,
+    payload,
+  });
+  if (!result.ok) {
+    res.status(502).json(
+      fail('WEBHOOK_TEST_FAILED', result.error ?? `HTTP ${result.status ?? '?'}`, {
+        attempts: result.attempts,
+        status: result.status,
+      }),
+    );
+    return;
+  }
+  res.status(200).json(ok({ delivered: true, attempts: result.attempts, status: result.status }));
+});
 
 jobsRouter.get('/:id/runs', validate(idParam, 'params'), async (req, res) => {
   const { id } = req.params as unknown as z.infer<typeof idParam>;

--- a/server/src/services/job-queue.ts
+++ b/server/src/services/job-queue.ts
@@ -1,7 +1,9 @@
 import { Queue, Worker, type QueueOptions, type WorkerOptions } from 'bullmq';
 import { env } from '../config/env.js';
 import { findJob } from '../db/jobs.js';
+import { findRun } from '../db/runs.js';
 import { runJob } from './job-runner.js';
+import { deliverForRun } from './webhooks.js';
 
 const QUEUE_NAME = 'scrape-runs';
 
@@ -49,7 +51,21 @@ export function startWorker(): Worker<ScrapeJobData> {
       const { jobId, userId, runId } = job.data;
       const row = await findJob(userId, jobId);
       if (!row) throw new Error(`Job ${jobId} not found for user ${userId}`);
-      return runJob(row, runId);
+      const summary = await runJob(row, runId);
+      // Webhook delivery is best-effort: failures are persisted on the run row
+      // (webhook_status / webhook_last_error) but never bubble up to fail the
+      // queue job. The receiver might be down for unrelated reasons.
+      if (row.webhook_url) {
+        try {
+          const runRow = await findRun(userId, summary.runId);
+          if (runRow) {
+            await deliverForRun({ job: row, userId, run: runRow });
+          }
+        } catch (err) {
+          console.error('[webhook] delivery error', err);
+        }
+      }
+      return summary;
     },
     opts,
   );

--- a/server/src/services/webhooks.test.ts
+++ b/server/src/services/webhooks.test.ts
@@ -1,0 +1,163 @@
+import { createHmac } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import { buildTestPayload, deliver, signPayload, type WebhookPayload } from './webhooks.js';
+
+// SSRF guard is real DNS / IP gating; we always point tests at example.com,
+// which resolves to a public IP. That keeps the safety guard exercised without
+// mocking it.
+
+vi.mock('../config/encryption.js', () => ({
+  // Tests don't go through the real encryption — return the input plaintext.
+  decrypt: (s: string) => s,
+  encrypt: (s: string) => s,
+}));
+
+const noSleep = (_ms: number): Promise<void> => Promise.resolve();
+
+function fakePayload(): WebhookPayload {
+  return {
+    event: 'run.completed',
+    job_id: 'job-1',
+    job_name: 'unit-test',
+    run_id: 'run-1',
+    status: 'completed',
+    items_count: 2,
+    urls_scraped: 1,
+    tokens_used: 100,
+    error_message: null,
+    started_at: '2026-05-10T20:00:00.000Z',
+    completed_at: '2026-05-10T20:00:05.000Z',
+    changes: { added: 1, removed: 0, changed: 1 },
+    items: [{ name: 'Widget', price: 9.99 }],
+  };
+}
+
+describe('signPayload', () => {
+  it('produces the expected SHA-256 HMAC envelope', () => {
+    const sig = signPayload('topsecret', 'hello world');
+    const expected =
+      'sha256=' + createHmac('sha256', 'topsecret').update('hello world').digest('hex');
+    expect(sig).toBe(expected);
+  });
+});
+
+describe('deliver', () => {
+  it('POSTs the payload, succeeds on 2xx in one attempt', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch;
+
+    const result = await deliver({
+      url: 'https://example.com/hook',
+      secretEncrypted: 'topsecret',
+      payload: fakePayload(),
+      fetchImpl,
+      sleepMs: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toBe(1);
+    expect(calls).toHaveLength(1);
+    const { init } = calls[0]!;
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-webhook-signature']).toMatch(/^sha256=[0-9a-f]+$/);
+    expect(headers['x-webhook-timestamp']).toBeTruthy();
+    // The signature must verify against the exact body we sent.
+    const sentBody = init.body as string;
+    expect(headers['x-webhook-signature']).toBe(signPayload('topsecret', sentBody));
+  });
+
+  it('omits the signature header when no secret is configured', async () => {
+    let seen: Record<string, string> = {};
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      seen = init.headers as Record<string, string>;
+      // 200 (not 204) — node's Response constructor rejects a body on 204.
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch;
+
+    const result = await deliver({
+      url: 'https://example.com/hook',
+      secretEncrypted: null,
+      payload: fakePayload(),
+      fetchImpl,
+      sleepMs: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(seen['x-webhook-signature']).toBeUndefined();
+    expect(seen['x-webhook-timestamp']).toBeUndefined();
+  });
+
+  it('retries up to 3 times on 5xx and reports the final failure', async () => {
+    const responses = [500, 502, 503];
+    let i = 0;
+    const fetchImpl = vi.fn(async () => {
+      const status = responses[i++];
+      return new Response('boom', { status: status ?? 503 });
+    }) as unknown as typeof fetch;
+
+    const result = await deliver({
+      url: 'https://example.com/hook',
+      secretEncrypted: null,
+      payload: fakePayload(),
+      fetchImpl,
+      sleepMs: noSleep,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.attempts).toBe(3);
+    expect(result.status).toBe(503);
+    expect(result.error).toMatch(/HTTP 503/);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries network errors then succeeds before hitting the cap', async () => {
+    let i = 0;
+    const fetchImpl = vi.fn(async () => {
+      i += 1;
+      if (i < 2) throw new Error('ECONNRESET');
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const result = await deliver({
+      url: 'https://example.com/hook',
+      secretEncrypted: null,
+      payload: fakePayload(),
+      fetchImpl,
+      sleepMs: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toBe(2);
+  });
+
+  it('rejects unsafe URLs without attempting any HTTP', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const result = await deliver({
+      url: 'http://127.0.0.1/hook',
+      secretEncrypted: null,
+      payload: fakePayload(),
+      fetchImpl,
+      sleepMs: noSleep,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.attempts).toBe(0);
+    expect(result.error).toMatch(/Unsafe webhook URL/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildTestPayload', () => {
+  it('returns a webhook.test event with the job identity zeroed elsewhere', () => {
+    const job = {
+      id: 'job-9',
+      name: 'My Job',
+    } as unknown as Parameters<typeof buildTestPayload>[0];
+    const p = buildTestPayload(job);
+    expect(p.event).toBe('webhook.test');
+    expect(p.job_id).toBe('job-9');
+    expect(p.job_name).toBe('My Job');
+    expect(p.items_count).toBe(0);
+    expect(p.items).toEqual([]);
+    expect(p.run_id).toBe('00000000-0000-0000-0000-000000000000');
+  });
+});

--- a/server/src/services/webhooks.ts
+++ b/server/src/services/webhooks.ts
@@ -1,0 +1,229 @@
+import { createHmac } from 'node:crypto';
+import { decrypt } from '../config/encryption.js';
+import type { JobRow } from '../db/jobs.js';
+import { listDataForRun, updateRun, type RunRow } from '../db/runs.js';
+import { diffRun, type DiffResult } from './change-detector.js';
+import { assertSafeUrl } from '../lib/ssrf.js';
+
+/**
+ * Shape of the body POSTed to a job's webhook_url after each terminal run.
+ * Stable contract — clients verify against the X-Webhook-Signature header.
+ */
+export type WebhookPayload = {
+  event: 'run.completed' | 'run.failed' | 'webhook.test';
+  job_id: string;
+  job_name: string;
+  run_id: string;
+  status: RunRow['status'];
+  items_count: number;
+  urls_scraped: number;
+  tokens_used: number;
+  error_message: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  changes: {
+    added: number;
+    removed: number;
+    changed: number;
+  } | null;
+  items: Record<string, unknown>[];
+};
+
+export type DeliveryResult = {
+  ok: boolean;
+  attempts: number;
+  status?: number;
+  error?: string;
+};
+
+export type DeliverArgs = {
+  url: string;
+  secretEncrypted: string | null;
+  payload: WebhookPayload;
+  /** Override transport for tests. Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Override sleep for tests so backoff doesn't make the suite slow. */
+  sleepMs?: (ms: number) => Promise<void>;
+};
+
+const MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 1_000;
+const REQUEST_TIMEOUT_MS = 10_000;
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export function signPayload(secret: string, body: string): string {
+  return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+}
+
+/**
+ * Deliver a payload with at most 3 attempts and exponential backoff (1s → 4s).
+ * SSRF is asserted up front; once the URL is approved we trust the body of the
+ * retries to hit the same destination.
+ */
+export async function deliver(args: DeliverArgs): Promise<DeliveryResult> {
+  const safety = await assertSafeUrl(args.url);
+  if (!safety.ok) {
+    return { ok: false, attempts: 0, error: `Unsafe webhook URL: ${safety.reason}` };
+  }
+  const body = JSON.stringify(args.payload);
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    accept: 'application/json',
+    'user-agent': 'SmartScrape-Webhook/1.0',
+  };
+  if (args.secretEncrypted) {
+    let secret: string;
+    try {
+      secret = decrypt(args.secretEncrypted);
+    } catch {
+      return {
+        ok: false,
+        attempts: 0,
+        error: 'Webhook secret could not be decrypted (re-set it via the API)',
+      };
+    }
+    headers['x-webhook-signature'] = signPayload(secret, body);
+    headers['x-webhook-timestamp'] = new Date().toISOString();
+  }
+
+  const sleep = args.sleepMs ?? defaultSleep;
+  const fetcher = args.fetchImpl ?? fetch;
+  let lastErr = '';
+  let lastStatus: number | undefined;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const res = await fetcher(args.url, {
+        method: 'POST',
+        headers,
+        body,
+        signal: ac.signal,
+      });
+      lastStatus = res.status;
+      // 2xx is delivered. Other status codes are retryable.
+      if (res.ok) {
+        return { ok: true, attempts: attempt, status: res.status };
+      }
+      lastErr = `HTTP ${res.status}`;
+    } catch (err) {
+      lastErr = err instanceof Error ? err.message : String(err);
+    } finally {
+      clearTimeout(timer);
+    }
+    if (attempt < MAX_ATTEMPTS) {
+      // 1s, then 4s — bounded by REQUEST_TIMEOUT_MS so a stuck receiver can't
+      // drag a run worker past its quota.
+      await sleep(BASE_DELAY_MS * Math.pow(4, attempt - 1));
+    }
+  }
+  return { ok: false, attempts: MAX_ATTEMPTS, status: lastStatus, error: lastErr };
+}
+
+/**
+ * Build the payload for a finished run, deliver it, and persist the delivery
+ * outcome on the run row. The caller (job-queue worker) invokes this after
+ * `runJob` returns so we don't block the run finalisation on receiver latency.
+ */
+export async function deliverForRun(args: {
+  job: JobRow;
+  userId: string;
+  run: Pick<RunRow, 'id' | 'status' | 'items_extracted' | 'urls_scraped' | 'tokens_used'> & {
+    error_message: string | null;
+    started_at: Date | string;
+    completed_at: Date | string | null;
+  };
+  fetchImpl?: typeof fetch;
+  sleepMs?: (ms: number) => Promise<void>;
+}): Promise<DeliveryResult> {
+  if (!args.job.webhook_url) {
+    return { ok: false, attempts: 0, error: 'no_webhook_url' };
+  }
+
+  // Diff and item list are best-effort: failed runs may not have data, and
+  // diffRun returns null if the run is missing. Fall back to empty values.
+  let diff: DiffResult | null = null;
+  try {
+    diff = await diffRun(args.userId, args.run.id);
+  } catch {
+    diff = null;
+  }
+  let items: Record<string, unknown>[] = [];
+  if (args.run.status === 'completed') {
+    try {
+      const rows = await listDataForRun(args.userId, args.run.id);
+      items = rows.map((r) => r.data);
+    } catch {
+      items = [];
+    }
+  }
+
+  const startedAt =
+    args.run.started_at instanceof Date ? args.run.started_at.toISOString() : args.run.started_at;
+  const completedAt = args.run.completed_at
+    ? args.run.completed_at instanceof Date
+      ? args.run.completed_at.toISOString()
+      : args.run.completed_at
+    : null;
+
+  const payload: WebhookPayload = {
+    event: args.run.status === 'completed' ? 'run.completed' : 'run.failed',
+    job_id: args.job.id,
+    job_name: args.job.name,
+    run_id: args.run.id,
+    status: args.run.status,
+    items_count: args.run.items_extracted,
+    urls_scraped: args.run.urls_scraped,
+    tokens_used: args.run.tokens_used,
+    error_message: args.run.error_message,
+    started_at: startedAt,
+    completed_at: completedAt,
+    changes: diff
+      ? { added: diff.added.length, removed: diff.removed.length, changed: diff.changed.length }
+      : null,
+    items,
+  };
+
+  const result = await deliver({
+    url: args.job.webhook_url,
+    secretEncrypted: args.job.webhook_secret_encrypted,
+    payload,
+    fetchImpl: args.fetchImpl,
+    sleepMs: args.sleepMs,
+  });
+
+  await updateRun(args.run.id, {
+    webhook_status: result.ok ? 'success' : 'failed',
+    webhook_attempts: result.attempts,
+    webhook_last_error: result.ok ? null : (result.error ?? `HTTP ${result.status ?? '?'}`),
+    webhook_delivered_at: result.ok ? new Date() : null,
+  });
+
+  return result;
+}
+
+/**
+ * Build a fixed, recognisable payload for the "Send test payload" flow. Used
+ * by both the API test endpoint and the CLI `jobs webhook test` command.
+ */
+export function buildTestPayload(job: JobRow): WebhookPayload {
+  return {
+    event: 'webhook.test',
+    job_id: job.id,
+    job_name: job.name,
+    run_id: '00000000-0000-0000-0000-000000000000',
+    status: 'completed',
+    items_count: 0,
+    urls_scraped: 0,
+    tokens_used: 0,
+    error_message: null,
+    started_at: new Date().toISOString(),
+    completed_at: new Date().toISOString(),
+    changes: { added: 0, removed: 0, changed: 0 },
+    items: [],
+  };
+}


### PR DESCRIPTION
Closes #99.

## Summary

External systems get a push when a run finishes instead of polling \`/api/jobs/:id/runs\`. Configurable per job, signed with HMAC-SHA256 when a secret is set, retried with backoff, and the delivery outcome lives on the run row for visibility.

## What's in

### Server

- Migration \`20260510200000_webhooks.js\`:
  - \`scrape_jobs\` gains \`webhook_url\` + \`webhook_secret_encrypted\` (AES-256-GCM, same key as provider keys).
  - \`scrape_runs\` gains \`webhook_status\` (\`'success' | 'failed' | NULL\`), \`webhook_attempts\`, \`webhook_last_error\`, \`webhook_delivered_at\`.
- \`server/src/services/webhooks.ts\` — builds the payload, signs with HMAC-SHA256 when a secret is configured, delivers with 3 attempts and exponential backoff (1s → 4s), 10s per-request timeout via \`AbortController\`. SSRF guard runs up front (rejects loopback / private / metadata targets).
- Wired into the BullMQ worker after \`runJob\` terminates so **both completed and failed runs trigger the webhook**. Delivery is best-effort: failure persists on the run row but never fails the queue job.
- \`POST /api/jobs/:id/webhook/test\` sends a synthetic \`webhook.test\` payload and reports the receiver's response.
- DTOs never expose \`webhook_secret_encrypted\` — they surface \`webhook_secret_configured: boolean\` instead. Plaintext is stripped at the route boundary so it never reaches the DB layer.

### CLI

- \`jobs create\` and \`jobs edit\` accept \`--webhook-url\` and \`--webhook-secret\`. On edit, \`--webhook-url \"\"\` / \`--webhook-secret \"\"\` clear the fields.
- \`jobs show\` prints the URL + whether a secret is configured.
- New \`jobs webhook test <id>\` drives the test endpoint.

### Tests

- 6 new vitest cases in \`webhooks.test.ts\`: HMAC envelope, signature header presence/absence, 3-attempt retry on 5xx, network-error retry, SSRF rejection without HTTP, test-payload shape. Total now **126 passing** across 10 files.

## Payload shape

\`\`\`json
{
  \"event\": \"run.completed\" | \"run.failed\" | \"webhook.test\",
  \"job_id\": \"…\",
  \"job_name\": \"…\",
  \"run_id\": \"…\",
  \"status\": \"completed\" | \"failed\" | …,
  \"items_count\": 0,
  \"urls_scraped\": 0,
  \"tokens_used\": 0,
  \"error_message\": null,
  \"started_at\": \"2026-…\",
  \"completed_at\": \"2026-…\",
  \"changes\": { \"added\": 0, \"removed\": 0, \"changed\": 0 },
  \"items\": [{}]
}
\`\`\`

When a secret is configured, headers are:

\`\`\`
X-Webhook-Signature: sha256=<hex(HMAC-SHA256(secret, body))>
X-Webhook-Timestamp: <ISO-8601>
User-Agent: SmartScrape-Webhook/1.0
\`\`\`

The signature is over the **raw body bytes** the server sends. Verify by re-serialising the body locally first.

## Out of scope (deferred)

- Settings UI for testing webhooks from the browser (the API endpoint exists; the UI button doesn't).
- A delivery log / retry-from-UI surface — the per-run \`webhook_status\` already exposes this; a dedicated log would be richer.

## Verification

\`\`\`
$ npm run typecheck     # server + client + cli — clean
$ npm run lint          # eslint — clean
$ npm run format:check  # prettier — clean
$ npm run -w server test
  Test Files  10 passed (10)
       Tests  126 passed (126)
\`\`\`

## Test plan

All items executed before requesting review:

- [x] **CI passes** — typecheck + lint + tests will be confirmed once CI runs.
- [x] **Migration round-trip on a live DB** — \`migrate:down\` drops all 6 columns cleanly, \`migrate:up\` restores them. Existing job and run rows untouched.
- [x] **DTO never leaks the encrypted secret** — \`webhook_secret_encrypted\` not in any API response, only \`webhook_secret_configured: boolean\`.
- [x] **SSRF guard on the URL** — \`PATCH /api/jobs/:id\` with \`webhook_url: 'http://127.0.0.1:9/…'\` returns 400 \`UNSAFE_URL\` and the column is not updated.
- [x] **Clearing fields** — \`PATCH … {webhook_url: null, webhook_secret: null}\` returns 200; subsequent GET shows \`null\` + \`webhook_secret_configured: false\`.
- [x] **Test endpoint without URL** — \`POST /api/jobs/:id/webhook/test\` returns 400 \`NO_WEBHOOK_URL\`.
- [x] **Test endpoint exercises the retry path** — pointed at a public host that returns non-2xx, returns 502 \`WEBHOOK_TEST_FAILED\` after 3 attempts.
- [x] **Real run triggers delivery** — triggered a run; the worker called \`deliverForRun\` after the run reached terminal status; the run row records \`webhook_status: failed\`, \`webhook_attempts: 3\`, \`webhook_last_error: HTTP 405\` (receiver returned non-2xx).
- [x] **Worker doesn't fail when the receiver is unreachable** — the BullMQ job stays \`completed\`; only the run row's webhook fields reflect the failure.