### PR TITLE
feat(runs): typed failure reasons + auto-pause on repeated failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Every command supports `--json`, `--quiet`, `--server-url`, `--token`, `--api-ke
 
 Long-running automation should use a personal access token over JWT: `smartscrape auth tokens create --name ci-runner` mints one, plaintext is shown once, send it on every request via `SMARTSCRAPE_API_KEY` env or the `X-API-Key` header. Revoke any token from Settings or via `smartscrape auth tokens revoke <id>`.
 
+## Failure classification + auto-pause
+
+Failed runs are classified into one of seven buckets — `timeout`, `blocked`, `parse_error`, `ai_error`, `network_error`, `quota_error`, `unknown` — and the type lands on the run row (`error_type`), the jobs list (`last_run_error_type`), and any webhook payload. After three consecutive failures, a job is auto-paused (`enabled=false`) and a `job_failed` notification fires on the user's configured channels. Re-enable with the toggle endpoint or `smartscrape jobs toggle <id>`.
+
 ## Webhooks
 
 Configure a webhook on a job and SmartScrape POSTs the run results to that URL after every terminal run (completed or failed). Set the URL on create or edit:

--- a/cli/src/commands/jobs.ts
+++ b/cli/src/commands/jobs.ts
@@ -122,7 +122,9 @@ function buildCreateBody(
 
 function statusBadge(job: JobListItem): string {
   if (!job.enabled) return 'paused';
-  if (job.last_run_status === 'failed') return 'failed';
+  if (job.last_run_status === 'failed') {
+    return job.last_run_error_type ? `failed (${job.last_run_error_type})` : 'failed';
+  }
   if (job.last_run_status) return `active (${job.last_run_status})`;
   return 'active';
 }

--- a/cli/src/commands/runs.ts
+++ b/cli/src/commands/runs.ts
@@ -76,6 +76,7 @@ export function runsCommand(getFlags: () => GlobalFlags): Command {
             `Tokens:      ${r.tokens_used}`,
             `Started:     ${r.started_at}`,
             `Completed:   ${r.completed_at ?? '—'}`,
+            r.error_type ? `Error type:  ${r.error_type}` : '',
             r.error_message ? `Error:       ${r.error_message}` : '',
             r.export_error ? `ExportErr:   ${r.export_error}` : '',
           ]

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -19,6 +19,15 @@ export type RunStatus =
   | 'completed'
   | 'failed';
 
+export type ErrorType =
+  | 'timeout'
+  | 'blocked'
+  | 'parse_error'
+  | 'ai_error'
+  | 'network_error'
+  | 'quota_error'
+  | 'unknown';
+
 export type NotificationRule =
   | { type: 'any_change'; message?: string }
   | { type: 'new_items'; message?: string }
@@ -67,6 +76,7 @@ export type JobDTO = {
 export type JobListItem = JobDTO & {
   last_run_status: string | null;
   last_run_items: number | null;
+  last_run_error_type: ErrorType | null;
 };
 
 export type RunDTO = {
@@ -77,6 +87,7 @@ export type RunDTO = {
   items_extracted: number;
   tokens_used: number;
   error_message: string | null;
+  error_type: ErrorType | null;
   export_error: string | null;
   started_at: string;
   completed_at: string | null;

--- a/server/migrations/20260510210000_run_error_type.js
+++ b/server/migrations/20260510210000_run_error_type.js
@@ -1,0 +1,33 @@
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+
+export const up = (pgm) => {
+  pgm.sql(`
+    ALTER TABLE scrape_runs
+      ADD COLUMN error_type TEXT
+        CHECK (
+          error_type IS NULL
+          OR error_type IN (
+            'timeout',
+            'blocked',
+            'parse_error',
+            'ai_error',
+            'network_error',
+            'quota_error',
+            'unknown'
+          )
+        );
+
+    -- Index just the failed runs so the "rolling failure window per job"
+    -- lookup is O(log N) regardless of how many successful runs sit on the table.
+    CREATE INDEX scrape_runs_failed_by_job_idx
+      ON scrape_runs (job_id, started_at DESC)
+      WHERE status = 'failed';
+  `);
+};
+
+export const down = (pgm) => {
+  pgm.sql(`
+    DROP INDEX IF EXISTS scrape_runs_failed_by_job_idx;
+    ALTER TABLE scrape_runs DROP COLUMN IF EXISTS error_type;
+  `);
+};

--- a/server/src/db/jobs.ts
+++ b/server/src/db/jobs.ts
@@ -146,6 +146,7 @@ export type ListOpts = {
 export type JobListItem = JobDTO & {
   last_run_status: string | null;
   last_run_items: number | null;
+  last_run_error_type: string | null;
 };
 
 export async function listJobs(
@@ -162,10 +163,13 @@ export async function listJobs(
   // "failed" is evaluated after the LATERAL join so we add it below.
 
   const sql = `
-    SELECT j.*, lr.status AS last_run_status, lr.items_extracted AS last_run_items
+    SELECT j.*,
+           lr.status AS last_run_status,
+           lr.items_extracted AS last_run_items,
+           lr.error_type AS last_run_error_type
       FROM scrape_jobs j
       LEFT JOIN LATERAL (
-        SELECT status, items_extracted
+        SELECT status, items_extracted, error_type
           FROM scrape_runs
          WHERE job_id = j.id
          ORDER BY started_at DESC
@@ -176,12 +180,17 @@ export async function listJobs(
       ORDER BY j.created_at DESC
       LIMIT ${limit} OFFSET ${offset}`;
   const { rows } = await getPool().query<
-    JobRow & { last_run_status: string | null; last_run_items: number | null }
+    JobRow & {
+      last_run_status: string | null;
+      last_run_items: number | null;
+      last_run_error_type: string | null;
+    }
   >(sql, vals);
   const items = rows.map((r) => ({
     ...toDTO(r),
     last_run_status: r.last_run_status,
     last_run_items: r.last_run_items,
+    last_run_error_type: r.last_run_error_type,
   }));
 
   const countSql = `

--- a/server/src/db/runs.ts
+++ b/server/src/db/runs.ts
@@ -1,4 +1,5 @@
 import { getPool } from '../config/database.js';
+import type { ErrorType } from '../lib/error-classifier.js';
 
 export type RunStatus =
   | 'pending'
@@ -16,6 +17,7 @@ export type RunRow = {
   items_extracted: number;
   tokens_used: number;
   error_message: string | null;
+  error_type: ErrorType | null;
   export_error: string | null;
   started_at: Date;
   completed_at: Date | null;
@@ -100,6 +102,7 @@ export async function updateRun(
       | 'items_extracted'
       | 'tokens_used'
       | 'error_message'
+      | 'error_type'
       | 'export_error'
       | 'completed_at'
       | 'webhook_status'
@@ -120,6 +123,7 @@ export async function updateRun(
   if (patch.items_extracted !== undefined) push('items_extracted', patch.items_extracted);
   if (patch.tokens_used !== undefined) push('tokens_used', patch.tokens_used);
   if (patch.error_message !== undefined) push('error_message', patch.error_message);
+  if (patch.error_type !== undefined) push('error_type', patch.error_type);
   if (patch.export_error !== undefined) push('export_error', patch.export_error);
   if (patch.completed_at !== undefined) push('completed_at', patch.completed_at);
   if (patch.webhook_status !== undefined) push('webhook_status', patch.webhook_status);

--- a/server/src/lib/error-classifier.test.ts
+++ b/server/src/lib/error-classifier.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { classifyError } from './error-classifier.js';
+
+describe('classifyError', () => {
+  it.each([
+    ['Daily run quota reached (100/24h). Run skipped.', 'quota_error'],
+    ['HTTP 429 Too Many Requests', 'quota_error'],
+    ['No openrouter API key configured', 'ai_error'],
+    ['No openai API key configured', 'ai_error'],
+    ['Stored provider key could not be decrypted', 'ai_error'],
+    ['Extraction failed for https://example.com: invalid output', 'ai_error'],
+    ['HTTP 403 Forbidden', 'blocked'],
+    ['Cloudflare challenge presented', 'blocked'],
+    ['Captcha required', 'blocked'],
+    ['Disallowed by robots.txt', 'blocked'],
+    ['Invalid JSON returned from model', 'parse_error'],
+    ['Schema validation failed', 'parse_error'],
+    ['Page exceeded 5242880 bytes', 'parse_error'],
+    ['Empty response body', 'parse_error'],
+    ['Navigation timeout of 30000ms exceeded', 'timeout'],
+    ['ETIMEDOUT', 'timeout'],
+    ['Request aborted', 'timeout'],
+    ['fetch failed: ECONNRESET', 'network_error'],
+    ['getaddrinfo ENOTFOUND example.com', 'network_error'],
+    ['socket hang up', 'network_error'],
+    ['something we have never seen', 'unknown'],
+    [null, 'unknown'],
+    [undefined, 'unknown'],
+    ['', 'unknown'],
+  ])('classifies %j as %s', (message, expected) => {
+    expect(classifyError(message)).toBe(expected);
+  });
+
+  it('quota_error wins over generic 429-network signal (order matters)', () => {
+    // Even though "fetch failed" matches network_error, the 429 + "quota"
+    // signal must take precedence so users see the real cause.
+    expect(classifyError('fetch failed: HTTP 429 quota exceeded')).toBe('quota_error');
+  });
+
+  it('blocked wins over generic "fetch failed" wrapping', () => {
+    expect(classifyError('Cheerio fetch failed for url: HTTP 403 Forbidden')).toBe('blocked');
+  });
+});

--- a/server/src/lib/error-classifier.ts
+++ b/server/src/lib/error-classifier.ts
@@ -1,0 +1,76 @@
+/**
+ * Classify a run failure into one of the seven buckets surfaced on the run
+ * row + webhook payload. The runner concentrates errors into string messages
+ * at every failure site, so a regex-based classifier is the least invasive
+ * way to retrofit typed failures — turning a `throw new Error("Page exceeded
+ * 5242880 bytes")` into `'parse_error'` without rewriting the call sites.
+ *
+ * Order matters: more specific patterns first. `quota_error` and `ai_error`
+ * are checked before generic network/timeout patterns because some upstream
+ * SDKs throw "request failed" on rate-limit and we don't want to demote a
+ * known-quota failure to `network_error`.
+ */
+
+export const ERROR_TYPES = [
+  'timeout',
+  'blocked',
+  'parse_error',
+  'ai_error',
+  'network_error',
+  'quota_error',
+  'unknown',
+] as const;
+
+export type ErrorType = (typeof ERROR_TYPES)[number];
+
+type Rule = { type: ErrorType; pattern: RegExp };
+
+// Each rule tests against the lowercased message. Keep the patterns short
+// and explicit — a one-line comment justifies any non-obvious string.
+const RULES: Rule[] = [
+  // Daily quota: emitted by the runner directly, plus 429 from any HTTP path.
+  { type: 'quota_error', pattern: /daily run quota|quota_exceeded|too many requests|\b429\b/ },
+
+  // AI provider misconfig + SDK-level failures. "no <provider> api key configured"
+  // is the runner's own pre-flight message.
+  {
+    type: 'ai_error',
+    pattern:
+      /no \w+ api key configured|provider key|stored provider key|extraction failed|model returned|openai|anthropic|openrouter|insufficient_quota|context_length/,
+  },
+
+  // Anti-bot signals from the scraper / playwright path.
+  {
+    type: 'blocked',
+    pattern: /\b403\b|forbidden|captcha|cloudflare|access denied|blocked by|robots\.txt|disallow/,
+  },
+
+  // Validation / structure errors from the AI extractor or page parser.
+  {
+    type: 'parse_error',
+    pattern:
+      /invalid json|fence|schema|exceeded \d+ bytes|too large|html parse|cheerio|empty response body/,
+  },
+
+  // Timeouts: native fetch, Playwright nav timeout, AbortController.
+  {
+    type: 'timeout',
+    pattern: /\btimeout\b|timed? out|etimedout|aborted|deadline|navigation timeout/,
+  },
+
+  // Network: DNS, connection, transport.
+  {
+    type: 'network_error',
+    pattern:
+      /econnrefused|enotfound|econnreset|epipe|fetch failed|getaddrinfo|socket hang up|err_http2|tls|certificate/,
+  },
+];
+
+export function classifyError(message: string | null | undefined): ErrorType {
+  if (!message) return 'unknown';
+  const lower = message.toLowerCase();
+  for (const rule of RULES) {
+    if (rule.pattern.test(lower)) return rule.type;
+  }
+  return 'unknown';
+}

--- a/server/src/services/auto-pause.test.ts
+++ b/server/src/services/auto-pause.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config/database.js', () => ({
+  getPool: vi.fn(),
+}));
+vi.mock('../db/jobs.js', () => ({
+  findJob: vi.fn(),
+  updateJob: vi.fn(),
+}));
+vi.mock('./job-queue.js', () => ({
+  syncSchedule: vi.fn(),
+}));
+vi.mock('./notification-service.js', () => ({
+  dispatch: vi.fn(),
+}));
+
+import {
+  AUTO_PAUSE_THRESHOLD,
+  isInFailureStreak,
+  maybeAutoPause,
+  rollingFailureRate,
+} from './auto-pause.js';
+import { getPool } from '../config/database.js';
+import { findJob, updateJob } from '../db/jobs.js';
+import { syncSchedule } from './job-queue.js';
+import { dispatch } from './notification-service.js';
+
+type FakePool = { query: ReturnType<typeof vi.fn> };
+
+function poolReturning(rows: { status: string }[]): FakePool {
+  return { query: vi.fn().mockResolvedValue({ rows }) };
+}
+
+const baseJob = {
+  id: 'job-1',
+  user_id: 'user-1',
+  name: 'Test job',
+  urls: [],
+  extraction_prompt: '',
+  extraction_schema: null,
+  scrape_method: 'auto',
+  schedule: null,
+  enabled: true,
+  notification_rules: [],
+  notify_channels: [],
+  comparison_key: null,
+  ai_provider: 'openrouter',
+  ai_model: 'openai/gpt-4o-mini',
+  google_sheet_id: null,
+  sheet_tab_name: null,
+  setup_method: 'manual',
+  respect_robots_txt: true,
+  webhook_url: null,
+  webhook_secret_encrypted: null,
+  last_run_at: null,
+  created_at: new Date(),
+  updated_at: new Date(),
+} as unknown as Awaited<ReturnType<typeof findJob>>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('isInFailureStreak', () => {
+  it('returns false when there are fewer than threshold terminal runs', async () => {
+    vi.mocked(getPool).mockReturnValue(poolReturning([{ status: 'failed' }]) as never);
+    expect(await isInFailureStreak('job-1')).toBe(false);
+  });
+
+  it('returns true when the last N runs are all failed', async () => {
+    vi.mocked(getPool).mockReturnValue(
+      poolReturning(Array(AUTO_PAUSE_THRESHOLD).fill({ status: 'failed' })) as never,
+    );
+    expect(await isInFailureStreak('job-1')).toBe(true);
+  });
+
+  it('returns false when at least one recent run completed', async () => {
+    vi.mocked(getPool).mockReturnValue(
+      poolReturning([{ status: 'failed' }, { status: 'completed' }, { status: 'failed' }]) as never,
+    );
+    expect(await isInFailureStreak('job-1')).toBe(false);
+  });
+});
+
+describe('rollingFailureRate', () => {
+  it('returns 0 when there are no terminal runs yet', async () => {
+    vi.mocked(getPool).mockReturnValue(poolReturning([]) as never);
+    expect(await rollingFailureRate('job-1')).toBe(0);
+  });
+
+  it('returns the proportion of failed in the window', async () => {
+    vi.mocked(getPool).mockReturnValue(
+      poolReturning([
+        { status: 'failed' },
+        { status: 'failed' },
+        { status: 'failed' },
+        { status: 'completed' },
+      ]) as never,
+    );
+    expect(await rollingFailureRate('job-1')).toBe(0.75);
+  });
+});
+
+describe('maybeAutoPause', () => {
+  it('does nothing when streak threshold is not met', async () => {
+    vi.mocked(getPool).mockReturnValue(poolReturning([{ status: 'failed' }]) as never);
+    const result = await maybeAutoPause({
+      jobId: 'job-1',
+      userId: 'user-1',
+      runId: 'run-1',
+      errorType: 'blocked',
+      errorMessage: '403',
+    });
+    expect(result).toBeNull();
+    expect(updateJob).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('disables the job, syncs the schedule, and dispatches a notification on streak', async () => {
+    vi.mocked(getPool).mockReturnValue(
+      poolReturning(Array(AUTO_PAUSE_THRESHOLD).fill({ status: 'failed' })) as never,
+    );
+    vi.mocked(findJob).mockResolvedValueOnce(baseJob);
+    vi.mocked(updateJob).mockResolvedValueOnce({ ...baseJob, enabled: false } as never);
+
+    const result = await maybeAutoPause({
+      jobId: 'job-1',
+      userId: 'user-1',
+      runId: 'run-1',
+      errorType: 'blocked',
+      errorMessage: 'HTTP 403 Forbidden',
+    });
+
+    expect(result).not.toBeNull();
+    expect(updateJob).toHaveBeenCalledWith('user-1', 'job-1', { enabled: false });
+    expect(syncSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: 'job-1', enabled: false }),
+    );
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const [, runIdArg, notifs] = vi.mocked(dispatch).mock.calls[0]!;
+    expect(runIdArg).toBe('run-1');
+    expect(notifs).toEqual([
+      {
+        type: 'job_failed',
+        message: expect.stringContaining('Job auto-paused after 3 consecutive failures (blocked)'),
+      },
+    ]);
+  });
+
+  it('short-circuits when the job is already disabled (idempotent)', async () => {
+    vi.mocked(getPool).mockReturnValue(
+      poolReturning(Array(AUTO_PAUSE_THRESHOLD).fill({ status: 'failed' })) as never,
+    );
+    vi.mocked(findJob).mockResolvedValueOnce({ ...baseJob, enabled: false } as never);
+
+    const result = await maybeAutoPause({
+      jobId: 'job-1',
+      userId: 'user-1',
+      runId: 'run-1',
+      errorType: 'blocked',
+      errorMessage: '403',
+    });
+    expect(result).toBeNull();
+    expect(updateJob).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/auto-pause.ts
+++ b/server/src/services/auto-pause.ts
@@ -1,0 +1,106 @@
+import { getPool } from '../config/database.js';
+import { findJob, updateJob, type JobRow } from '../db/jobs.js';
+import { syncSchedule } from './job-queue.js';
+import { dispatch } from './notification-service.js';
+import type { ErrorType } from '../lib/error-classifier.js';
+
+/**
+ * Number of consecutive failures (most-recent runs, in order) that triggers
+ * auto-pause. Three is the threshold listed in the spec — generous enough to
+ * survive transient blips but tight enough to stop a job that's permanently
+ * broken (auth revoked, target redesigned) before it burns a 24h quota.
+ */
+export const AUTO_PAUSE_THRESHOLD = 3;
+
+/**
+ * Return whether the latest `AUTO_PAUSE_THRESHOLD` runs for a job are all
+ * 'failed'. Considers only terminal runs (completed | failed) — a still-in-
+ * flight run (pending/scraping/extracting) doesn't break the streak.
+ */
+export async function isInFailureStreak(jobId: string): Promise<boolean> {
+  const { rows } = await getPool().query<{ status: string }>(
+    `SELECT status
+       FROM scrape_runs
+      WHERE job_id = $1 AND status IN ('completed', 'failed')
+      ORDER BY started_at DESC
+      LIMIT $2`,
+    [jobId, AUTO_PAUSE_THRESHOLD],
+  );
+  if (rows.length < AUTO_PAUSE_THRESHOLD) return false;
+  return rows.every((r) => r.status === 'failed');
+}
+
+/**
+ * Compute the rolling failure rate over the last `windowSize` terminal runs,
+ * expressed as a fraction in [0, 1]. Returns 0 when there are no terminal runs
+ * yet (vs. NaN), so callers can render it without a null check.
+ */
+export async function rollingFailureRate(jobId: string, windowSize = 10): Promise<number> {
+  const { rows } = await getPool().query<{ status: string }>(
+    `SELECT status
+       FROM scrape_runs
+      WHERE job_id = $1 AND status IN ('completed', 'failed')
+      ORDER BY started_at DESC
+      LIMIT $2`,
+    [jobId, windowSize],
+  );
+  if (rows.length === 0) return 0;
+  const failed = rows.filter((r) => r.status === 'failed').length;
+  return failed / rows.length;
+}
+
+/**
+ * If the job has hit the failure threshold, disable it, tear down its
+ * scheduled BullMQ entry, and dispatch a `job_failed` notification. Idempotent
+ * — already-paused jobs short-circuit.
+ *
+ * Returns the post-action JobRow when a pause happened, or null otherwise.
+ */
+export async function maybeAutoPause(args: {
+  jobId: string;
+  userId: string;
+  runId: string;
+  errorType: ErrorType;
+  errorMessage: string;
+}): Promise<JobRow | null> {
+  if (!(await isInFailureStreak(args.jobId))) return null;
+
+  const job = await findJob(args.userId, args.jobId);
+  if (!job) return null;
+  if (!job.enabled) return null; // already paused — no need to re-notify
+
+  const updated = await updateJob(args.userId, args.jobId, { enabled: false });
+  if (!updated) return null;
+
+  // Drop the repeatable so a cron-scheduled job stops firing immediately.
+  try {
+    await syncSchedule({
+      jobId: updated.id,
+      userId: updated.user_id,
+      enabled: false,
+      schedule: updated.schedule,
+    });
+  } catch (err) {
+    // Schedule sync failing shouldn't block the pause — the job is already
+    // marked disabled, the worker checks `enabled` before each run.
+    console.error('[auto-pause] syncSchedule failed', err);
+  }
+
+  // Surface to the user via whatever notification channels they have set up.
+  // Telemetry-only if they haven't configured any.
+  try {
+    await dispatch(updated, args.runId, [
+      {
+        type: 'job_failed',
+        message: `Job auto-paused after ${AUTO_PAUSE_THRESHOLD} consecutive failures (${args.errorType}): ${args.errorMessage}`,
+      },
+    ]);
+  } catch (err) {
+    console.error('[auto-pause] notification dispatch failed', err);
+  }
+
+  console.warn(
+    `[auto-pause] job=${args.jobId} disabled after ${AUTO_PAUSE_THRESHOLD} consecutive failures (${args.errorType})`,
+  );
+  return updated;
+}

--- a/server/src/services/job-runner.ts
+++ b/server/src/services/job-runner.ts
@@ -10,6 +10,8 @@ import { dispatch, evaluateRules } from './notification-service.js';
 import { pushRows } from './google-sheets.js';
 import { findConnection } from '../db/googleConnections.js';
 import { findUserById } from '../db/users.js';
+import { classifyError, type ErrorType } from '../lib/error-classifier.js';
+import { maybeAutoPause } from './auto-pause.js';
 
 export type RunSummary = {
   runId: string;
@@ -18,7 +20,53 @@ export type RunSummary = {
   itemsExtracted: number;
   tokensUsed: number;
   error?: string;
+  errorType?: ErrorType;
 };
+
+/**
+ * Finalize a failed run with a classified error_type, then check whether the
+ * job has hit the consecutive-failure threshold and auto-pause if so. Wraps
+ * the existing per-failure-site boilerplate so every exit path classifies
+ * and considers auto-pause uniformly.
+ */
+async function failAndMaybePause(args: {
+  runId: string;
+  jobId: string;
+  userId: string;
+  message: string;
+  partial?: { urlsScraped?: number; itemsExtracted?: number; tokensUsed?: number };
+}): Promise<RunSummary> {
+  const errorType = classifyError(args.message);
+  await updateRun(args.runId, {
+    status: 'failed',
+    error_message: args.message,
+    error_type: errorType,
+    urls_scraped: args.partial?.urlsScraped,
+    items_extracted: args.partial?.itemsExtracted,
+    tokens_used: args.partial?.tokensUsed,
+    completed_at: new Date(),
+  });
+  // Fire-and-forget the auto-pause check — its own failures are logged and
+  // shouldn't keep the run from returning to the worker.
+  void maybeAutoPause({
+    jobId: args.jobId,
+    userId: args.userId,
+    runId: args.runId,
+    errorType,
+    errorMessage: args.message,
+  }).catch((err) => {
+    console.error('[runner] auto-pause check failed', err);
+  });
+  return {
+    runId: args.runId,
+    jobId: args.jobId,
+    status: 'failed',
+    itemsExtracted: args.partial?.itemsExtracted ?? 0,
+    tokensUsed: args.partial?.tokensUsed ?? 0,
+    error: args.message,
+    errorType,
+  };
+}
 
 /**
  * Execute a full run for a job:
@@ -37,46 +85,34 @@ export async function runJob(job: JobRow, existingRunId?: string): Promise<RunSu
   // We subtract 1 because the row above is already counted.
   const recent = await countRunsLast24h(job.user_id);
   if (recent - 1 >= DAILY_RUN_QUOTA) {
-    const err = `Daily run quota reached (${DAILY_RUN_QUOTA}/24h). Run skipped.`;
-    await updateRun(run.id, { status: 'failed', error_message: err, completed_at: new Date() });
-    return {
+    return failAndMaybePause({
       runId: run.id,
       jobId: job.id,
-      status: 'failed',
-      itemsExtracted: 0,
-      tokensUsed: 0,
-      error: err,
-    };
+      userId: job.user_id,
+      message: `Daily run quota reached (${DAILY_RUN_QUOTA}/24h). Run skipped.`,
+    });
   }
 
   const provider = job.ai_provider;
   const keyRow = await findApiKey(job.user_id, provider);
   if (!keyRow) {
-    const err = `No ${provider} API key configured`;
-    await updateRun(run.id, { status: 'failed', error_message: err, completed_at: new Date() });
-    return {
+    return failAndMaybePause({
       runId: run.id,
       jobId: job.id,
-      status: 'failed',
-      itemsExtracted: 0,
-      tokensUsed: 0,
-      error: err,
-    };
+      userId: job.user_id,
+      message: `No ${provider} API key configured`,
+    });
   }
   let apiKey: string;
   try {
     apiKey = decrypt(keyRow.api_key_encrypted);
   } catch {
-    const err = 'Stored provider key could not be decrypted';
-    await updateRun(run.id, { status: 'failed', error_message: err, completed_at: new Date() });
-    return {
+    return failAndMaybePause({
       runId: run.id,
       jobId: job.id,
-      status: 'failed',
-      itemsExtracted: 0,
-      tokensUsed: 0,
-      error: err,
-    };
+      userId: job.user_id,
+      message: 'Stored provider key could not be decrypted',
+    });
   }
 
   // Build the leak-guard lists once per run. Split by type so the API-key
@@ -191,21 +227,12 @@ export async function runJob(job: JobRow, existingRunId?: string): Promise<RunSu
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    await updateRun(run.id, {
-      status: 'failed',
-      urls_scraped: urlsScraped,
-      items_extracted: itemsExtracted,
-      tokens_used: tokensUsed,
-      error_message: message,
-      completed_at: new Date(),
-    });
-    return {
+    return failAndMaybePause({
       runId: run.id,
       jobId: job.id,
-      status: 'failed',
-      itemsExtracted,
-      tokensUsed,
-      error: message,
-    };
+      userId: job.user_id,
+      message,
+      partial: { urlsScraped, itemsExtracted, tokensUsed },
+    });
   }
 }

--- a/server/src/services/webhooks.test.ts
+++ b/server/src/services/webhooks.test.ts
@@ -25,6 +25,7 @@ function fakePayload(): WebhookPayload {
     urls_scraped: 1,
     tokens_used: 100,
     error_message: null,
+    error_type: null,
     started_at: '2026-05-10T20:00:00.000Z',
     completed_at: '2026-05-10T20:00:05.000Z',
     changes: { added: 1, removed: 0, changed: 1 },

--- a/server/src/services/webhooks.ts
+++ b/server/src/services/webhooks.ts
@@ -4,6 +4,7 @@ import type { JobRow } from '../db/jobs.js';
 import { listDataForRun, updateRun, type RunRow } from '../db/runs.js';
 import { diffRun, type DiffResult } from './change-detector.js';
 import { assertSafeUrl } from '../lib/ssrf.js';
+import type { ErrorType } from '../lib/error-classifier.js';
 
 /**
  * Shape of the body POSTed to a job's webhook_url after each terminal run.
@@ -19,6 +20,8 @@ export type WebhookPayload = {
   urls_scraped: number;
   tokens_used: number;
   error_message: string | null;
+  /** Classified failure bucket; null on completed runs and the test payload. */
+  error_type: ErrorType | null;
   started_at: string | null;
   completed_at: string | null;
   changes: {
@@ -134,6 +137,7 @@ export async function deliverForRun(args: {
   userId: string;
   run: Pick<RunRow, 'id' | 'status' | 'items_extracted' | 'urls_scraped' | 'tokens_used'> & {
     error_message: string | null;
+    error_type: ErrorType | null;
     started_at: Date | string;
     completed_at: Date | string | null;
   };
@@ -180,6 +184,7 @@ export async function deliverForRun(args: {
     urls_scraped: args.run.urls_scraped,
     tokens_used: args.run.tokens_used,
     error_message: args.run.error_message,
+    error_type: args.run.error_type,
     started_at: startedAt,
     completed_at: completedAt,
     changes: diff
@@ -221,6 +226,7 @@ export function buildTestPayload(job: JobRow): WebhookPayload {
     urls_scraped: 0,
     tokens_used: 0,
     error_message: null,
+    error_type: null,
     started_at: new Date().toISOString(),
     completed_at: new Date().toISOString(),
     changes: { added: 0, removed: 0, changed: 0 },


### PR DESCRIPTION
Closes #101.

## Summary

Failed runs are now classified into seven structured `error_type` buckets (`timeout`, `blocked`, `parse_error`, `ai_error`, `network_error`, `quota_error`, `unknown`) and surfaced on the run row, the jobs list, and the webhook payload. After **3 consecutive failures** the job is auto-paused (`enabled=false`) and a `job_failed` notification fires on the user's configured channels. Re-enabling is the usual toggle endpoint.

Purely additive — existing `error_message` strings are unchanged; `error_type` is derived from them by a regex-based classifier.

## What's in

### Server

- Migration `20260510210000_run_error_type.js`:
  - `scrape_runs.error_type` (CHECK-constrained text)
  - Partial index on `(job_id, started_at DESC) WHERE status='failed'` so the streak lookup is O(log N) regardless of total run history
- `server/src/lib/error-classifier.ts`: order-sensitive regex matcher. Pattern precedence matters — `quota_error` and `ai_error` win over generic `network_error`/`timeout` patterns so a 429-shaped quota failure doesn't get demoted to "network error".
- `server/src/services/auto-pause.ts`:
  - `isInFailureStreak(jobId)` — last 3 terminal runs are all `failed`
  - `rollingFailureRate(jobId, window=10)` — failed/total over the rolling window (exposed for future UI)
  - `maybeAutoPause(...)` — disables job, tears down its repeatable BullMQ entry, dispatches a `job_failed` notification with the classified type and message. Idempotent: already-paused jobs short-circuit (no re-notify).
- Runner: every failure exit is funneled through `failAndMaybePause()`. Classifies the message, persists `error_type` alongside `error_message`, fires the auto-pause check fire-and-forget so the worker never blocks on it.
- Webhook payload gains `error_type: ErrorType | null` (null on completed runs and on the `webhook.test` payload).
- `listJobs` returns `last_run_error_type` on each item (one extra column on the existing LATERAL join — no extra query).

### CLI

- `jobs list` status badge: `failed (blocked)` instead of plain `failed` when an error_type is set.
- `runs show` prints `Error type: <bucket>` above the existing error message line.
- Types module gains an `ErrorType` union mirroring the server.

### Tests

- 26 cases in `error-classifier.test.ts` covering every bucket and the precedence rules (e.g. "quota wins over fetch failed").
- 10 cases in `auto-pause.test.ts` covering streak detection, the rolling rate, the disable+sync+notify side-effect chain, and the "already paused" short-circuit.
- Suite now: **12 files / 160 tests passing** (vs 119 before this PR).

## Out of scope (deferred)

- UI badge / rolling-rate widget on the job detail page — backend exposes the data via the jobs DTO; the React surface is a separate small PR.
- An auto-resume policy (e.g. retry after 24h with a single probe run) — for now users re-enable manually.

## Notes for reviewers

- Auto-pause notifications only deliver to channels the user has set up. Users without `notify_channels` still see the paused state in the UI / CLI; the notification surface is opt-in.
- The classifier is intentionally regex-only (no typed exceptions from the runner). Lowest-touch retrofit; if we want richer signals later we can attach a code to the thrown error and have the classifier prefer it.

## Verification

```
$ npm run typecheck     # server + client + cli — clean
$ npm run lint          # eslint — clean
$ npm run format:check  # prettier — clean
$ npm run -w server test
  Test Files  12 passed (12)
       Tests  160 passed (160)
```

## Test plan

All items executed before requesting review:

- [x] **CI passes** — 5/5 green on commit `3076f46` (verify, audit, docker, migrations, e2e).
- [x] **Migration round-trip on a live DB** — `migrate:down` drops the column and the partial index; `migrate:up` restores both. Existing run rows untouched (the new column is NULL on pre-migration rows).
- [x] **Classification on real failures** — triggered 3 runs against a user with no provider key configured. Each one persists `error_type='ai_error'` ("No openrouter API key configured" → `ai_error` per the regex precedence rules).
- [x] **Auto-pause threshold** — after run 1: job still `enabled=true`. After run 2: still `enabled=true`. After run 3: `enabled=false`.
- [x] **jobs list surfaces last_run_error_type** — `GET /api/jobs` returns `last_run_error_type: 'ai_error'` on the failing job's list item.
- [x] **Idempotent re-pause** — re-enabled the job via toggle, triggered a 4th run, confirmed auto-pause re-disables without exception. The unit test "short-circuits when already disabled" complements this (no duplicate notifications).
- [x] **Webhook payload carries error_type** — `WebhookPayload.error_type` field added; webhook unit tests updated.