### PR TITLE
feat(scraper): anti-bot resilience — stealth, proxy, UA rotation, pacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ Every command supports `--json`, `--quiet`, `--server-url`, `--token`, `--api-ke
 
 Long-running automation should use a personal access token over JWT: `smartscrape auth tokens create --name ci-runner` mints one, plaintext is shown once, send it on every request via `SMARTSCRAPE_API_KEY` env or the `X-API-Key` header. Revoke any token from Settings or via `smartscrape auth tokens revoke <id>`.
 
+## Anti-bot resilience
+
+Each job has four knobs that help against targets with active bot detection:
+
+- **`stealth_mode`** — turns on UA rotation (a small pool of recent real-browser UAs, deterministic per job id so the target sees a stable identity across runs) and injects a minimal Playwright stealth init script (hides `navigator.webdriver`, plausibly populates `plugins`/`languages`, fixes the headless-Chrome `permissions.query` quirk).
+- **`proxy_url`** — per-job `http(s)://[user:pass@]host:port`. Applies to both the static (Cheerio) and rendered (Playwright) paths.
+- **`pacing_min_ms` / `pacing_max_ms`** — uniform-random sleep between successive URLs in a multi-URL job. The existing per-host throttle still runs underneath.
+- **Process-wide `HTTPS_PROXY` / `HTTP_PROXY` env** — when set at server start, every outbound fetch (scraper, AI SDKs, webhook delivery) routes through the configured proxy. Per-job `proxy_url` overrides on the scrape path.
+
+```bash
+smartscrape jobs edit <job-id> --stealth --proxy-url http://user:pass@proxy:3128 --pacing-min 500 --pacing-max 1500
+```
+
 ## Failure classification + auto-pause
 
 Failed runs are classified into one of seven buckets — `timeout`, `blocked`, `parse_error`, `ai_error`, `network_error`, `quota_error`, `unknown` — and the type lands on the run row (`error_type`), the jobs list (`last_run_error_type`), and any webhook payload. After three consecutive failures, a job is auto-paused (`enabled=false`) and a `job_failed` notification fires on the user's configured channels. Re-enable with the toggle endpoint or `smartscrape jobs toggle <id>`.

--- a/cli/README.md
+++ b/cli/README.md
@@ -52,6 +52,11 @@ Pass `--webhook-url <url>` and `--webhook-secret <secret>` on `jobs create` /
 `jobs edit` to receive POSTed run results. On `jobs edit`, an empty string
 (e.g. `--webhook-url ""`) clears the field.
 
+`--stealth`, `--proxy-url`, `--pacing-min`, and `--pacing-max` configure the
+anti-bot knobs (UA rotation + Playwright stealth, per-job proxy, jitter
+between URLs). On `jobs edit`, `--no-stealth` turns it off, `--proxy-url ""`
+clears the proxy, and `--pacing-min -1` / `--pacing-max -1` clear the bounds.
+
 Every command supports `--json` (raw JSON to stdout) and `--quiet` (suppress
 non-error output), plus `--server-url`, `--token`, and `--api-key` for
 per-invocation overrides. Exit codes: `0` success, `1` generic error, `2` auth

--- a/cli/src/commands/jobs.ts
+++ b/cli/src/commands/jobs.ts
@@ -41,6 +41,10 @@ type CreateInput = {
   respect_robots_txt?: boolean;
   webhook_url?: string | null;
   webhook_secret?: string | null;
+  stealth_mode?: boolean;
+  proxy_url?: string | null;
+  pacing_min_ms?: number | null;
+  pacing_max_ms?: number | null;
 };
 
 function readJsonFromOpt(value: string | undefined, label: string): unknown {
@@ -117,6 +121,10 @@ function buildCreateBody(
   if (opts.respectRobots !== undefined) body.respect_robots_txt = Boolean(opts.respectRobots);
   if (opts.webhookUrl !== undefined) body.webhook_url = String(opts.webhookUrl);
   if (opts.webhookSecret !== undefined) body.webhook_secret = String(opts.webhookSecret);
+  if (opts.stealth === true) body.stealth_mode = true;
+  if (opts.proxyUrl !== undefined) body.proxy_url = String(opts.proxyUrl);
+  if (opts.pacingMin !== undefined) body.pacing_min_ms = Number(opts.pacingMin);
+  if (opts.pacingMax !== undefined) body.pacing_max_ms = Number(opts.pacingMax);
   return body;
 }
 
@@ -205,6 +213,13 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
             `Compare key:  ${j.comparison_key ?? '(data hash)'}`,
             `Channels:     ${j.notify_channels.join(', ') || '(none)'}`,
             `Rules:        ${j.notification_rules.length}`,
+            `Stealth:      ${j.stealth_mode ? 'on' : 'off'}`,
+            `Proxy:        ${j.proxy_url ?? '(none)'}`,
+            `Pacing:       ${
+              j.pacing_min_ms === null && j.pacing_max_ms === null
+                ? '(default throttle)'
+                : `${j.pacing_min_ms ?? '?'}–${j.pacing_max_ms ?? '?'} ms`
+            }`,
             `Webhook URL:  ${j.webhook_url ?? '(none)'}`,
             `Webhook sec:  ${j.webhook_secret_configured ? 'configured' : '(none)'}`,
             `Last run:     ${j.last_run_at ?? 'never'}`,
@@ -237,6 +252,17 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     .option(
       '--webhook-secret <secret>',
       'Optional HMAC secret. When set, payloads include X-Webhook-Signature',
+    )
+    .option('--stealth', 'Enable stealth_mode (rotating UA + Playwright fingerprint patches)')
+    .option(
+      '--proxy-url <url>',
+      'Route scrape requests through this proxy (http(s)://[user:pass@]host:port)',
+    )
+    .option('--pacing-min <ms>', 'Min ms to sleep between URLs in a multi-URL job', (v) =>
+      parseInt(v, 10),
+    )
+    .option('--pacing-max <ms>', 'Max ms to sleep between URLs in a multi-URL job', (v) =>
+      parseInt(v, 10),
     );
   create.action(async (opts: Record<string, string | string[] | boolean | undefined>) => {
     const flags = getFlags();
@@ -274,6 +300,11 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
     .option('--sheet-tab <name>', 'Tab name within the sheet')
     .option('--webhook-url <url>', 'POST run results to this URL (pass empty string to clear)')
     .option('--webhook-secret <secret>', 'HMAC secret (pass empty string to clear)')
+    .option('--stealth', 'Turn stealth_mode ON for this job')
+    .option('--no-stealth', 'Turn stealth_mode OFF for this job')
+    .option('--proxy-url <url>', 'Set proxy URL (pass empty string to clear)')
+    .option('--pacing-min <ms>', 'Min ms between URLs (-1 to clear)', (v) => parseInt(v, 10))
+    .option('--pacing-max <ms>', 'Max ms between URLs (-1 to clear)', (v) => parseInt(v, 10))
     .action(async (id: string, opts: Record<string, string | boolean | undefined>) => {
       const flags = getFlags();
       await runCommand(flags, async () => {
@@ -309,6 +340,19 @@ export function jobsCommand(getFlags: () => GlobalFlags): Command {
         }
         if (opts.webhookSecret !== undefined) {
           patch.webhook_secret = opts.webhookSecret === '' ? null : String(opts.webhookSecret);
+        }
+        // commander turns --stealth / --no-stealth into stealth=true/false
+        if (typeof opts.stealth === 'boolean') patch.stealth_mode = opts.stealth;
+        if (opts.proxyUrl !== undefined) {
+          patch.proxy_url = opts.proxyUrl === '' ? null : String(opts.proxyUrl);
+        }
+        if (opts.pacingMin !== undefined) {
+          const n = Number(opts.pacingMin);
+          patch.pacing_min_ms = n < 0 ? null : n;
+        }
+        if (opts.pacingMax !== undefined) {
+          const n = Number(opts.pacingMax);
+          patch.pacing_max_ms = n < 0 ? null : n;
         }
 
         if (Object.keys(patch).length === 0) {

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -66,6 +66,10 @@ export type JobDTO = {
   sheet_tab_name: string | null;
   setup_method: SetupMethod;
   respect_robots_txt: boolean;
+  stealth_mode: boolean;
+  proxy_url: string | null;
+  pacing_min_ms: number | null;
+  pacing_max_ms: number | null;
   webhook_url: string | null;
   webhook_secret_configured: boolean;
   last_run_at: string | null;

--- a/server/migrations/20260510220000_anti_bot.js
+++ b/server/migrations/20260510220000_anti_bot.js
@@ -1,0 +1,30 @@
+/** @type {import('node-pg-migrate').MigrationBuilder} */
+
+export const up = (pgm) => {
+  pgm.sql(`
+    ALTER TABLE scrape_jobs
+      ADD COLUMN stealth_mode    BOOLEAN NOT NULL DEFAULT false,
+      ADD COLUMN proxy_url       TEXT,
+      ADD COLUMN pacing_min_ms   INTEGER
+        CHECK (pacing_min_ms IS NULL OR pacing_min_ms BETWEEN 0 AND 600000),
+      ADD COLUMN pacing_max_ms   INTEGER
+        CHECK (pacing_max_ms IS NULL OR pacing_max_ms BETWEEN 0 AND 600000),
+      ADD CONSTRAINT scrape_jobs_pacing_order
+        CHECK (
+          pacing_min_ms IS NULL
+          OR pacing_max_ms IS NULL
+          OR pacing_min_ms <= pacing_max_ms
+        );
+  `);
+};
+
+export const down = (pgm) => {
+  pgm.sql(`
+    ALTER TABLE scrape_jobs
+      DROP CONSTRAINT IF EXISTS scrape_jobs_pacing_order,
+      DROP COLUMN IF EXISTS pacing_max_ms,
+      DROP COLUMN IF EXISTS pacing_min_ms,
+      DROP COLUMN IF EXISTS proxy_url,
+      DROP COLUMN IF EXISTS stealth_mode;
+  `);
+};

--- a/server/src/db/jobs.ts
+++ b/server/src/db/jobs.ts
@@ -44,6 +44,10 @@ export type JobRow = {
   sheet_tab_name: string | null;
   setup_method: SetupMethod;
   respect_robots_txt: boolean;
+  stealth_mode: boolean;
+  proxy_url: string | null;
+  pacing_min_ms: number | null;
+  pacing_max_ms: number | null;
   webhook_url: string | null;
   /**
    * AES-256-GCM ciphertext of the user-supplied HMAC secret, or null. The
@@ -98,6 +102,10 @@ export type CreateJobArgs = {
   sheet_tab_name?: string | null;
   setup_method?: SetupMethod;
   respect_robots_txt?: boolean;
+  stealth_mode?: boolean;
+  proxy_url?: string | null;
+  pacing_min_ms?: number | null;
+  pacing_max_ms?: number | null;
   webhook_url?: string | null;
   webhook_secret_encrypted?: string | null;
 };
@@ -108,9 +116,11 @@ export async function createJob(userId: string, args: CreateJobArgs): Promise<Jo
        user_id, name, urls, extraction_prompt, extraction_schema,
        scrape_method, schedule, enabled, notification_rules, notify_channels,
        comparison_key, ai_provider, ai_model, google_sheet_id, sheet_tab_name, setup_method,
-       respect_robots_txt, webhook_url, webhook_secret_encrypted
+       respect_robots_txt, stealth_mode, proxy_url, pacing_min_ms, pacing_max_ms,
+       webhook_url, webhook_secret_encrypted
      )
-     VALUES ($1,$2,$3::jsonb,$4,$5::jsonb,$6,$7,$8,$9::jsonb,$10::jsonb,$11,$12,$13,$14,$15,$16,$17,$18,$19)
+     VALUES ($1,$2,$3::jsonb,$4,$5::jsonb,$6,$7,$8,$9::jsonb,$10::jsonb,$11,$12,$13,$14,$15,$16,
+             $17,$18,$19,$20,$21,$22,$23)
      RETURNING *`,
     [
       userId,
@@ -130,6 +140,10 @@ export async function createJob(userId: string, args: CreateJobArgs): Promise<Jo
       args.sheet_tab_name ?? null,
       args.setup_method ?? 'manual',
       args.respect_robots_txt ?? true,
+      args.stealth_mode ?? false,
+      args.proxy_url ?? null,
+      args.pacing_min_ms ?? null,
+      args.pacing_max_ms ?? null,
       args.webhook_url ?? null,
       args.webhook_secret_encrypted ?? null,
     ],
@@ -249,6 +263,10 @@ export async function updateJob(
   if (args.google_sheet_id !== undefined) push('google_sheet_id', args.google_sheet_id);
   if (args.sheet_tab_name !== undefined) push('sheet_tab_name', args.sheet_tab_name);
   if (args.respect_robots_txt !== undefined) push('respect_robots_txt', args.respect_robots_txt);
+  if (args.stealth_mode !== undefined) push('stealth_mode', args.stealth_mode);
+  if (args.proxy_url !== undefined) push('proxy_url', args.proxy_url);
+  if (args.pacing_min_ms !== undefined) push('pacing_min_ms', args.pacing_min_ms);
+  if (args.pacing_max_ms !== undefined) push('pacing_max_ms', args.pacing_max_ms);
   if (args.webhook_url !== undefined) push('webhook_url', args.webhook_url);
   if (args.webhook_secret_encrypted !== undefined)
     push('webhook_secret_encrypted', args.webhook_secret_encrypted);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import cookieParser from 'cookie-parser';
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { ProxyAgent, setGlobalDispatcher } from 'undici';
 import { env, requireSecrets } from './config/env.js';
 import { closeDatabase } from './config/database.js';
 import { closeRedis } from './config/redis.js';
@@ -25,6 +26,26 @@ import { fail } from './lib/response.js';
 
 // Fail fast if any runtime secret is missing or a placeholder.
 requireSecrets();
+
+// Honor HTTPS_PROXY / HTTP_PROXY at the process level so every outbound fetch
+// (cheerio scrape path, AI provider SDKs, webhook delivery, Google Sheets)
+// routes through the configured proxy by default. Per-job `proxy_url` still
+// overrides this on the scrape path. Lowercase variants are also recognised.
+{
+  const proxyEnv =
+    process.env.HTTPS_PROXY ??
+    process.env.https_proxy ??
+    process.env.HTTP_PROXY ??
+    process.env.http_proxy;
+  if (proxyEnv) {
+    try {
+      setGlobalDispatcher(new ProxyAgent(proxyEnv));
+      console.log(`[proxy] global dispatcher → ${proxyEnv.replace(/\/\/[^@]*@/, '//****@')}`);
+    } catch (err) {
+      console.error('[proxy] failed to install global dispatcher', err);
+    }
+  }
+}
 
 const app = express();
 

--- a/server/src/lib/stealth.ts
+++ b/server/src/lib/stealth.ts
@@ -1,0 +1,54 @@
+/**
+ * Init script injected into every Playwright page when `stealth_mode` is on.
+ *
+ * This is the minimum set of fingerprint patches that defeat the cheapest
+ * bot checks (CreepJS-style "is this Puppeteer?" detection): hide the
+ * webdriver flag (the Chromium launch flag already covers most of this, but
+ * belt-and-suspenders), report a plausible-looking `plugins` array, set
+ * `languages`, define `window.chrome`, fix the WebGL vendor string, and
+ * suppress the "Permissions" API quirk that returns "denied" for
+ * notifications on headless Chromium.
+ *
+ * We intentionally don't pull in `playwright-extra` + the puppeteer-extra
+ * stealth plugin. The full plugin set is much heavier (~50 patches) and
+ * solves a problem we don't have — we're a self-hosted scraper, not a
+ * scraping-as-a-service. Users with hostile targets can layer their own
+ * proxy / stealth tooling on top via the `proxy_url` field.
+ */
+export const STEALTH_INIT_SCRIPT = String.raw`
+(() => {
+  try {
+    Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+  } catch {}
+  try {
+    Object.defineProperty(navigator, 'plugins', {
+      get: () => [1, 2, 3, 4, 5].map((i) => ({ name: 'Plugin ' + i, filename: 'plugin' + i + '.dll' })),
+    });
+  } catch {}
+  try {
+    Object.defineProperty(navigator, 'languages', { get: () => ['en-US', 'en'] });
+  } catch {}
+  try {
+    // Headless Chrome lacks the chrome.runtime shim that real Chrome has.
+    if (typeof window !== 'undefined' && !window.chrome) {
+      // @ts-ignore
+      window.chrome = { runtime: {} };
+    }
+  } catch {}
+  try {
+    const origQuery = window.navigator.permissions && window.navigator.permissions.query;
+    if (origQuery) {
+      // Headless reports 'denied' for notifications even when Notification.permission is 'default'.
+      window.navigator.permissions.query = (params) =>
+        params && params.name === 'notifications'
+          ? Promise.resolve({ state: Notification.permission })
+          : origQuery.call(window.navigator.permissions, params);
+    }
+  } catch {}
+  try {
+    // Spoof a non-empty hardwareConcurrency. Headless reports the host's CPU count anyway,
+    // but some checks assert >= 4.
+    Object.defineProperty(navigator, 'hardwareConcurrency', { get: () => Math.max(4, navigator.hardwareConcurrency || 4) });
+  } catch {}
+})();
+`;

--- a/server/src/lib/user-agents.test.ts
+++ b/server/src/lib/user-agents.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { STEALTH_USER_AGENTS, pickUserAgent } from './user-agents.js';
+
+describe('pickUserAgent', () => {
+  it('returns a UA from the pool', () => {
+    const ua = pickUserAgent('job-1');
+    expect(STEALTH_USER_AGENTS).toContain(ua);
+  });
+
+  it('is deterministic for the same seed', () => {
+    expect(pickUserAgent('job-1')).toBe(pickUserAgent('job-1'));
+    expect(pickUserAgent('abcdef')).toBe(pickUserAgent('abcdef'));
+  });
+
+  it('produces different UAs for different seeds (over a reasonable sample)', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 200; i += 1) {
+      seen.add(pickUserAgent(`job-${i}`));
+    }
+    // We have 8 UAs; with 200 random-ish seeds we should land on at least half.
+    expect(seen.size).toBeGreaterThanOrEqual(4);
+  });
+
+  it('distribution is roughly even across the pool', () => {
+    const counts = new Map<string, number>();
+    const N = 2000;
+    for (let i = 0; i < N; i += 1) {
+      const ua = pickUserAgent(`seed-${i}`);
+      counts.set(ua, (counts.get(ua) ?? 0) + 1);
+    }
+    const expected = N / STEALTH_USER_AGENTS.length;
+    // Allow ±35% per bucket — SHA-256 mod 8 should be much tighter than this
+    // in practice, but pick a forgiving threshold to keep the test stable.
+    for (const ua of STEALTH_USER_AGENTS) {
+      const c = counts.get(ua) ?? 0;
+      expect(c, `UA "${ua.slice(0, 40)}…"`).toBeGreaterThan(expected * 0.65);
+      expect(c).toBeLessThan(expected * 1.35);
+    }
+  });
+});

--- a/server/src/lib/user-agents.ts
+++ b/server/src/lib/user-agents.ts
@@ -1,0 +1,41 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * A small pool of recent real-browser UAs. We rotate among these when a job
+ * has stealth_mode enabled. The pool is intentionally short: enough variety
+ * to avoid one-UA fingerprinting, but stable enough that a target site sees
+ * the same UA for a given job across runs (deterministic by job id).
+ *
+ * Keep entries roughly current. Old strings still work but raise eyebrows.
+ */
+export const STEALTH_USER_AGENTS = [
+  // Chrome 132 / Windows 10
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36',
+  // Chrome 132 / macOS 14
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36',
+  // Firefox 134 / Windows 10
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0',
+  // Firefox 134 / macOS
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:134.0) Gecko/20100101 Firefox/134.0',
+  // Safari 18 / macOS Sequoia
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15',
+  // Edge 132 / Windows 11
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36 Edg/132.0.0.0',
+  // Chrome 131 / Windows 11
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+  // Chrome 131 / Linux
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+] as const;
+
+/**
+ * Pick a UA from the pool deterministically given a seed string. The same
+ * seed always returns the same UA — used so a given job presents a stable
+ * identity across runs (server-side caches, A/B cookies, and per-IP heuristics
+ * all benefit from stability over randomness).
+ */
+export function pickUserAgent(seed: string): string {
+  const digest = createHash('sha256').update(seed).digest();
+  // First byte of the hash → modulo pool length. Cheap and uniform enough.
+  const idx = digest[0]! % STEALTH_USER_AGENTS.length;
+  return STEALTH_USER_AGENTS[idx]!;
+}

--- a/server/src/routes/jobs.ts
+++ b/server/src/routes/jobs.ts
@@ -73,7 +73,24 @@ const notificationRule = z.discriminatedUnion('type', [
 
 const extractionSchema = z.record(z.enum(['string', 'number', 'boolean', 'array', 'object']));
 
-const createBody = z.object({
+// The pacing order constraint runs as a refinement, but createBody is also
+// reused via `.partial()` for updates and `.extend()` for the AI-setup confirm
+// flow. ZodEffects (the result of `.refine`) doesn't support partial/extend,
+// so we factor the raw object out and apply the refinement at the use sites.
+function applyPacingRefinement<S extends z.ZodTypeAny>(schema: S): S {
+  return schema.refine(
+    (v: { pacing_min_ms?: number | null; pacing_max_ms?: number | null }) =>
+      v.pacing_min_ms === undefined ||
+      v.pacing_max_ms === undefined ||
+      v.pacing_min_ms === null ||
+      v.pacing_max_ms === null ||
+      v.pacing_min_ms <= v.pacing_max_ms,
+    { message: 'pacing_min_ms must be <= pacing_max_ms', path: ['pacing_max_ms'] },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) as any;
+}
+
+const createBodyInner = z.object({
   name: z.string().trim().min(1).max(200),
   urls: z.array(z.string().url()).min(1).max(10),
   extraction_prompt: z.string().trim().min(5).max(5000),
@@ -105,13 +122,26 @@ const createBody = z.object({
   sheet_tab_name: z.string().nullable().optional(),
   setup_method: setupMethodEnum.optional(),
   respect_robots_txt: z.boolean().optional(),
+  // Anti-bot resilience knobs.
+  stealth_mode: z.boolean().optional(),
+  proxy_url: z
+    .string()
+    .url()
+    .max(2048)
+    .regex(/^https?:\/\//i, 'proxy_url must be http:// or https://')
+    .nullable()
+    .optional(),
+  pacing_min_ms: z.number().int().min(0).max(600_000).nullable().optional(),
+  pacing_max_ms: z.number().int().min(0).max(600_000).nullable().optional(),
   // Webhooks. Pass `null` to clear; omit to leave as-is. webhook_secret is
   // encrypted server-side before storage and never returned in the read API.
   webhook_url: z.string().url().max(2048).nullable().optional(),
   webhook_secret: z.string().min(8).max(256).nullable().optional(),
 });
 
-const updateBody = createBody.partial();
+const createBody = applyPacingRefinement(createBodyInner);
+
+const updateBody = applyPacingRefinement(createBodyInner.partial());
 
 const idParam = z.object({ id: z.string().uuid() });
 
@@ -183,10 +213,12 @@ const aiPreviewBody = z.object({
   ai_model: z.string().min(1).max(120).optional(),
 });
 
-const aiConfirmBody = createBody.extend({
-  user_goal: z.string().trim().min(1).max(2000),
-  ai_suggestion: z.record(z.unknown()),
-});
+const aiConfirmBody = applyPacingRefinement(
+  createBodyInner.extend({
+    user_goal: z.string().trim().min(1).max(2000),
+    ai_suggestion: z.record(z.unknown()),
+  }),
+);
 
 async function resolveProviderKey(
   userId: string,

--- a/server/src/services/job-runner.ts
+++ b/server/src/services/job-runner.ts
@@ -138,10 +138,26 @@ export async function runJob(job: JobRow, existingRunId?: string): Promise<RunSu
   let tokensUsed = 0;
   const allBatches: { source_url: string; data: Record<string, unknown>; data_hash: string }[] = [];
 
+  // Pacing between successive URLs in the same job. When pacing_max_ms is
+  // unset we leave it to the per-host throttle in the scraper. When both are
+  // set, sleep a uniform-random ms in [min, max] before each URL after the
+  // first.
+  const pacingMin = job.pacing_min_ms ?? null;
+  const pacingMax = job.pacing_max_ms ?? null;
+
   try {
+    let urlIndex = 0;
     for (const url of job.urls) {
+      if (urlIndex > 0 && pacingMin !== null && pacingMax !== null) {
+        const delay = Math.floor(pacingMin + Math.random() * (pacingMax - pacingMin + 1));
+        if (delay > 0) await new Promise((r) => setTimeout(r, delay));
+      }
+      urlIndex += 1;
       const page = await scrape(url, job.scrape_method, {
         respectRobotsTxt: job.respect_robots_txt,
+        stealth: job.stealth_mode,
+        stealthSeed: job.id,
+        proxyUrl: job.proxy_url,
       });
       urlsScraped += 1;
 

--- a/server/src/services/scraper.test.ts
+++ b/server/src/services/scraper.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { parseProxy } from './scraper.js';
+
+describe('parseProxy', () => {
+  it('returns null for blank / nullish input', () => {
+    expect(parseProxy(null)).toBeNull();
+    expect(parseProxy(undefined)).toBeNull();
+    expect(parseProxy('')).toBeNull();
+  });
+
+  it('parses bare http://host:port', () => {
+    expect(parseProxy('http://proxy.example.com:3128')).toEqual({
+      server: 'http://proxy.example.com:3128',
+    });
+  });
+
+  it('extracts username/password from the URL userinfo', () => {
+    expect(parseProxy('http://alice:s3cret@proxy.example.com:3128')).toEqual({
+      server: 'http://proxy.example.com:3128',
+      username: 'alice',
+      password: 's3cret',
+    });
+  });
+
+  it('URL-decodes credentials so reserved characters survive the round-trip', () => {
+    expect(parseProxy('http://us%40er:p%2Fass@proxy:8080')).toEqual({
+      server: 'http://proxy:8080',
+      username: 'us@er',
+      password: 'p/ass',
+    });
+  });
+
+  it('returns null for malformed URLs rather than throwing', () => {
+    expect(parseProxy('not a url')).toBeNull();
+  });
+});

--- a/server/src/services/scraper.ts
+++ b/server/src/services/scraper.ts
@@ -1,8 +1,11 @@
 import { chromium, type Browser } from 'playwright';
+import { ProxyAgent, type Dispatcher } from 'undici';
 import { cleanHtml, visibleTextLength } from './html-cleaner.js';
 import { assertSafeUrl } from '../lib/ssrf.js';
 import { createSemaphore } from '../lib/semaphore.js';
 import { isAllowedByRobots } from './robots.js';
+import { pickUserAgent } from '../lib/user-agents.js';
+import { STEALTH_INIT_SCRIPT } from '../lib/stealth.js';
 
 const USER_AGENT = 'SmartScrapeBot/0.1 (+https://github.com/9ny4/smartscrape)';
 // A realistic Chrome UA used on the Playwright fallback path where we want to
@@ -10,6 +13,30 @@ const USER_AGENT = 'SmartScrapeBot/0.1 (+https://github.com/9ny4/smartscrape)';
 // static fetches so well-behaved sites can identify us.
 const BROWSER_UA =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36';
+
+/**
+ * Parse a Playwright-shaped proxy config out of an http(s)://user:pass@host
+ * URL. Returns null when the input is blank so callers can fall straight
+ * through to a normal launch.
+ */
+export function parseProxy(proxyUrl: string | null | undefined): {
+  server: string;
+  username?: string;
+  password?: string;
+} | null {
+  if (!proxyUrl) return null;
+  let u: URL;
+  try {
+    u = new URL(proxyUrl);
+  } catch {
+    return null;
+  }
+  const server = `${u.protocol}//${u.host}`;
+  const out: { server: string; username?: string; password?: string } = { server };
+  if (u.username) out.username = decodeURIComponent(u.username);
+  if (u.password) out.password = decodeURIComponent(u.password);
+  return out;
+}
 
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
 const MIN_VISIBLE_TEXT = 200; // below this, fall back to Playwright
@@ -70,12 +97,25 @@ function describeError(err: unknown): string {
   return parts.filter(Boolean).join(' \u2014 ');
 }
 
+type FetchOpts = {
+  userAgent?: string;
+  proxyUrl?: string | null;
+};
+
 async function fetchWithCap(
   url: string,
   signal?: AbortSignal,
+  opts: FetchOpts = {},
 ): Promise<{ status: number; body: string; finalUrl: string }> {
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(new Error('Request timeout after 15s')), 15_000);
+  // Per-request proxy via undici. Without `dispatcher`, fetch uses the global
+  // dispatcher (which honors HTTP_PROXY when set at process start).
+  let dispatcher: Dispatcher | undefined;
+  if (opts.proxyUrl) {
+    dispatcher = new ProxyAgent(opts.proxyUrl);
+  }
+  const userAgent = opts.userAgent ?? USER_AGENT;
   try {
     // Manual redirect handling so each hop is re-validated by the SSRF guard.
     // `redirect: 'follow'` would cheerfully chase a 302 to http://169.254.169.254
@@ -86,9 +126,13 @@ async function fetchWithCap(
       const safety = await assertSafeUrl(currentUrl);
       if (!safety.ok) throw new Error(`Refused redirect to ${currentUrl}: ${safety.reason}`);
       res = await fetch(currentUrl, {
-        headers: { 'user-agent': USER_AGENT, accept: 'text/html,application/xhtml+xml' },
+        headers: { 'user-agent': userAgent, accept: 'text/html,application/xhtml+xml' },
         redirect: 'manual',
         signal: signal ?? ac.signal,
+        // The `dispatcher` field is a non-standard fetch option recognised by
+        // Node's bundled undici. Cast keeps TS happy without polluting the
+        // global RequestInit type.
+        ...(dispatcher ? ({ dispatcher } as unknown as RequestInit) : {}),
       });
       if (res.status >= 300 && res.status < 400) {
         const next = res.headers.get('location');
@@ -123,6 +167,9 @@ async function fetchWithCap(
     return { status: res.status, body: buf.toString('utf8'), finalUrl: res.url };
   } finally {
     clearTimeout(timer);
+    // ProxyAgent holds connections open; closing is fire-and-forget so a slow
+    // proxy doesn't drag the run worker.
+    if (dispatcher) void dispatcher.close().catch(() => undefined);
   }
 }
 
@@ -180,14 +227,22 @@ function isHttp2Error(err: unknown): boolean {
   return err instanceof Error && /ERR_HTTP2_PROTOCOL_ERROR/.test(err.message);
 }
 
+type PlaywrightOpts = {
+  userAgent?: string;
+  proxyUrl?: string | null;
+  stealth?: boolean;
+};
+
 async function fetchViaPlaywright(
   url: string,
   http1Only = false,
+  opts: PlaywrightOpts = {},
 ): Promise<{ status: number; body: string; finalUrl: string }> {
   const release = await playwrightSlots.acquire();
   const b = await browser(http1Only);
+  const proxy = parseProxy(opts.proxyUrl);
   const ctx = await b.newContext({
-    userAgent: BROWSER_UA,
+    userAgent: opts.userAgent ?? BROWSER_UA,
     viewport: { width: 1280, height: 800 },
     locale: 'en-US',
     extraHTTPHeaders: {
@@ -197,9 +252,15 @@ async function fetchViaPlaywright(
       'Sec-Fetch-Mode': 'navigate',
       'Sec-Fetch-Site': 'none',
     },
+    ...(proxy ? { proxy } : {}),
   });
   try {
     await attachSsrfRouteGuard(ctx);
+    if (opts.stealth) {
+      // Inject our minimal stealth init script before any page script runs.
+      // See server/src/lib/stealth.ts for what it patches and why.
+      await ctx.addInitScript(STEALTH_INIT_SCRIPT);
+    }
     const page = await ctx.newPage();
     // `domcontentloaded` is more forgiving than `networkidle` on pages with
     // persistent XHR/websocket activity (analytics etc).
@@ -220,12 +281,13 @@ async function fetchViaPlaywright(
 /** Playwright with one retry when the site rejects HTTP/2 (some bot walls do). */
 async function fetchViaPlaywrightWithRetry(
   url: string,
+  opts: PlaywrightOpts = {},
 ): Promise<{ status: number; body: string; finalUrl: string }> {
   try {
-    return await fetchViaPlaywright(url, false);
+    return await fetchViaPlaywright(url, false, opts);
   } catch (err) {
     if (isHttp2Error(err)) {
-      return await fetchViaPlaywright(url, true);
+      return await fetchViaPlaywright(url, true, opts);
     }
     throw err;
   }
@@ -234,6 +296,19 @@ async function fetchViaPlaywrightWithRetry(
 export type ScrapeOptions = {
   /** When true (default) we honor robots.txt for the configured user-agent. */
   respectRobotsTxt?: boolean;
+  /**
+   * When true, switch the Cheerio + Playwright paths to a rotating real-browser
+   * UA (deterministic per `stealthSeed`) and inject the Playwright stealth init
+   * script. Per-job toggle from `scrape_jobs.stealth_mode`.
+   */
+  stealth?: boolean;
+  /**
+   * Stable seed for the UA picker — usually the job id. Same seed → same UA
+   * across runs, which keeps target-site caching/cookies coherent.
+   */
+  stealthSeed?: string;
+  /** Per-job proxy (http(s)://[user:pass@]host:port). Overrides process env. */
+  proxyUrl?: string | null;
 };
 
 export async function scrape(
@@ -257,16 +332,31 @@ export async function scrape(
   const host = new URL(url).hostname;
   await throttle(host);
 
+  // When stealth_mode is on, pick a rotating real-browser UA seeded by the
+  // job id. Otherwise stick with our identifiable bot UA on the static path
+  // and the fixed Chrome UA on the Playwright path.
+  const stealthUa = opts.stealth && opts.stealthSeed ? pickUserAgent(opts.stealthSeed) : null;
+  const cheerioUa = stealthUa ?? USER_AGENT;
+  const playwrightOpts: PlaywrightOpts = {
+    userAgent: stealthUa ?? BROWSER_UA,
+    proxyUrl: opts.proxyUrl ?? null,
+    stealth: Boolean(opts.stealth),
+  };
+  const fetchOpts: FetchOpts = {
+    userAgent: cheerioUa,
+    proxyUrl: opts.proxyUrl ?? null,
+  };
+
   let primary: { status: number; body: string; finalUrl: string };
   let usedMethod: 'cheerio' | 'playwright';
 
   if (method === 'playwright') {
-    primary = await fetchViaPlaywrightWithRetry(url);
+    primary = await fetchViaPlaywrightWithRetry(url, playwrightOpts);
     usedMethod = 'playwright';
   } else {
     let cheerioErr: unknown = null;
     try {
-      primary = await fetchWithCap(url);
+      primary = await fetchWithCap(url, undefined, fetchOpts);
       usedMethod = 'cheerio';
     } catch (err) {
       cheerioErr = err;
@@ -276,7 +366,7 @@ export async function scrape(
       // Auto mode: fall back to Playwright on fetch failure.
       await throttle(host);
       try {
-        primary = await fetchViaPlaywrightWithRetry(url);
+        primary = await fetchViaPlaywrightWithRetry(url, playwrightOpts);
         usedMethod = 'playwright';
       } catch (pwErr) {
         throw new Error(
@@ -292,7 +382,7 @@ export async function scrape(
     ) {
       await throttle(host);
       try {
-        primary = await fetchViaPlaywrightWithRetry(url);
+        primary = await fetchViaPlaywrightWithRetry(url, playwrightOpts);
         usedMethod = 'playwright';
       } catch {
         // Keep the static result rather than failing outright.


### PR DESCRIPTION
Closes #100. Last sub-issue under #102.

## Summary

Four new per-job knobs (and one process-wide hook) for jobs targeting sites with active bot detection. All opt-in: existing jobs default to off and behave identically to before this PR.

## What's in

### Server

- Migration `20260510220000_anti_bot.js`:
  - `scrape_jobs.stealth_mode` (bool, default false)
  - `scrape_jobs.proxy_url` (text, nullable)
  - `scrape_jobs.pacing_min_ms` / `pacing_max_ms` (int, nullable) with CHECK constraints (0..600_000 and `min <= max`)
- `lib/user-agents.ts`: pool of 8 recent real-browser UAs (Chrome 131/132, Firefox 134, Safari 18, Edge 132 across Windows/macOS/Linux). `pickUserAgent(seed)` is a SHA-256-based deterministic picker — same seed → same UA across runs, so a given job presents a stable identity (target-site caches and per-IP heuristics stay coherent).
- `lib/stealth.ts`: minimal Playwright init script. Hides `navigator.webdriver`, populates `plugins`/`languages`, defines `window.chrome`, fixes the headless-Chrome `permissions.query` quirk, and floors `hardwareConcurrency` at 4. **Intentionally not pulling in `playwright-extra`** — the full stealth plugin is ~50 patches and we don't need scraping-as-a-service-grade evasion; users with hostile targets can layer their own via `proxy_url`.
- `scraper.ts`: \`ScrapeOptions\` gains `{ stealth, stealthSeed, proxyUrl }`. Cheerio path threads user-agent + per-request `undici.ProxyAgent`. Playwright path threads user-agent + per-context `proxy` + `addInitScript(STEALTH_INIT_SCRIPT)` when stealth is on. Exposes `parseProxy()` for unit testing (decodes URL credentials, returns null for malformed input).
- `index.ts`: at startup, `HTTPS_PROXY` / `HTTP_PROXY` (and lowercase variants) install a global undici dispatcher so all outbound fetches (scraper, AI SDKs, webhook delivery, Google Sheets) route through the configured proxy by default. Per-job `proxy_url` overrides on the scrape path. Logs with masked credentials.
- `job-runner.ts`: passes stealth/stealthSeed/proxyUrl from `JobRow` to `scrape()`; sleeps a uniform-random ms in `[pacing_min_ms, pacing_max_ms]` between successive URLs in a multi-URL job when both bounds are set. Existing per-host throttle still runs.

### Routes

- `createBody` gains `stealth_mode` (bool), `proxy_url` (URL + http(s) regex, nullable), `pacing_min_ms` / `pacing_max_ms` (int, 0..600_000, nullable). Pacing order constraint (`min <= max`) lives on a refinement helper because `ZodEffects` doesn't support `.partial()`/`.extend()` directly — extracted `createBodyInner` and apply the refinement at each use site (`createBody`, `updateBody`, `aiConfirmBody`).

### CLI

- `jobs create`: `--stealth`, `--proxy-url`, `--pacing-min`, `--pacing-max`.
- `jobs edit`: same plus `--no-stealth`. Empty-string clears `--proxy-url`; `-1` clears `--pacing-min` / `--pacing-max`.
- `jobs show` prints all four anti-bot fields.

### Tests

- 4 cases for `pickUserAgent` — pool membership, determinism, spread across seeds, roughly-even distribution over 2000 samples.
- 5 cases for `parseProxy` — null/empty input, bare URL, credentials extraction, URL-decoded creds, malformed input.
- Suite now: **14 files / 169 tests passing** (was 12/160 before this PR).

## Out of scope (deferred)

- UI surfaces for the new fields (job edit form checkbox + inputs) — backend exposes everything via the DTO; the React form is a small follow-on.
- Heavier stealth via `playwright-extra` + `puppeteer-extra-plugin-stealth` — explicitly *not* in this PR; we picked the minimum that defeats the cheapest checks without 50 patches of dependency surface. Easy to layer in later if needed.
- External commercial-proxy provider integration — users can wire any standard `http://user:pass@host:port` URL into `proxy_url` already.

## Verification

```
$ npm run typecheck     # server + client + cli — clean
$ npm run lint          # eslint — clean
$ npm run format:check  # prettier — clean
$ npm run -w server test
  Test Files  14 passed (14)
       Tests  169 passed (169)
```

## Test plan

All items executed before requesting review:

- [x] **Migration round-trip on a live DB** — `migrate:down` drops all four columns + the order constraint, `migrate:up` restores them. Existing rows untouched (new columns get their defaults / NULL).
- [x] **Create job with all four fields** — `POST /api/jobs` accepts `stealth_mode=true`, `proxy_url=http://proxy:3128`, `pacing_min_ms=200`, `pacing_max_ms=600`. DTO returns the values verbatim.
- [x] **Pacing order validation** — `PATCH {pacing_min_ms: 1000, pacing_max_ms: 200}` → 400 `VALIDATION_ERROR`. Existing job state unchanged.
- [x] **Proxy URL scheme validation** — `PATCH {proxy_url: 'socks5://localhost:1080'}` → 400 `VALIDATION_ERROR` (regex enforces http/https).
- [x] **Pacing upper bound** — `PATCH {pacing_min_ms: 700_000}` → 400 (the 600_000 ms cap fires).
- [x] **Clearing** — `PATCH {stealth_mode:false, proxy_url:null, pacing_min_ms:null, pacing_max_ms:null}` → 200; subsequent GET shows all four cleared.
- [x] **Runner still works with stealth on** — triggered a real run on a job with `stealth_mode=true`. Run reaches terminal `failed` status with `error_type='ai_error'` (no provider key configured for this test user). No exception in the scraper path, no regression in the runner's failure handling.
- [x] **Unit tests** — UA picker determinism, pool spread, distribution; parseProxy null/bare/credentialed/decoded/malformed.