### PR TITLE
chore: purge stale 9ny4 references

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question / discussion
-    url: https://github.com/9ny4/smartscrape/discussions
+    url: https://github.com/sekkedev/smartscrape/discussions
     about: For open-ended questions, ideas, or showing off how you're using SmartScrape.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for considering a contribution. This guide is short on purpose; if someth
 Prereqs: Node 20.19+ or 22.12+ (required by the Vite 7 toolchain), Docker Desktop (or compatible), npm 10+.
 
 ```bash
-git clone https://github.com/9ny4/smartscrape.git
+git clone https://github.com/sekkedev/smartscrape.git
 cd smartscrape
 npm install
 npx playwright install chromium

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 9ny4
+Copyright (c) 2026 Fredrik André (sekkedev)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SmartScrape
 
-[![CI](https://github.com/9ny4/smartscrape/actions/workflows/ci.yml/badge.svg)](https://github.com/9ny4/smartscrape/actions/workflows/ci.yml)
+[![CI](https://github.com/sekkedev/smartscrape/actions/workflows/ci.yml/badge.svg)](https://github.com/sekkedev/smartscrape/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 ![Node](https://img.shields.io/badge/node-%3E%3D20-339933?logo=node.js&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)
@@ -66,7 +66,7 @@ Prereqs: Docker (or Node 20.19+ / 22.12+ for the dev path — the Vite 7 toolcha
 ### Self-host (Docker, recommended)
 
 ```bash
-git clone https://github.com/9ny4/smartscrape.git
+git clone https://github.com/sekkedev/smartscrape.git
 cd smartscrape
 cp .env.example .env
 # Fill in the three required secrets — generation snippets are inside .env.example.
@@ -79,7 +79,7 @@ Open <http://localhost:3000>. Migrations run on container start; the API also se
 ### Develop
 
 ```bash
-git clone https://github.com/9ny4/smartscrape.git
+git clone https://github.com/sekkedev/smartscrape.git
 cd smartscrape
 npm install
 npx playwright install chromium

--- a/server/src/services/scraper.ts
+++ b/server/src/services/scraper.ts
@@ -7,7 +7,7 @@ import { isAllowedByRobots } from './robots.js';
 import { pickUserAgent } from '../lib/user-agents.js';
 import { STEALTH_INIT_SCRIPT } from '../lib/stealth.js';
 
-const USER_AGENT = 'SmartScrapeBot/0.1 (+https://github.com/9ny4/smartscrape)';
+const USER_AGENT = 'SmartScrapeBot/0.1 (+https://github.com/sekkedev/smartscrape)';
 // A realistic Chrome UA used on the Playwright fallback path where we want to
 // look as close to a real browser as possible. The bot UA above is kept for
 // static fetches so well-behaved sites can identify us.


### PR DESCRIPTION
Mechanical swap of the owner's old GitHub username `9ny4` to `sekkedev` after the account rename. A case-insensitive repo-wide grep (excluding `.git` and `node_modules`) found exactly these references; no others exist.

## Changed references

| File:line | Change |
|---|---|
| `README.md:3` | CI badge image + link URLs `github.com/9ny4/smartscrape/actions/...` -> `github.com/sekkedev/smartscrape/actions/...` |
| `README.md:69` | clone URL -> `https://github.com/sekkedev/smartscrape.git` |
| `README.md:82` | clone URL -> `https://github.com/sekkedev/smartscrape.git` |
| `CONTRIBUTING.md:10` | clone URL -> `https://github.com/sekkedev/smartscrape.git` |
| `.github/ISSUE_TEMPLATE/config.yml:4` | discussions link -> `https://github.com/sekkedev/smartscrape/discussions` |
| `LICENSE:3` | `Copyright (c) 2026 9ny4` -> `Copyright (c) 2026 Fredrik André (sekkedev)` |
| `server/src/services/scraper.ts:10` | bot User-Agent URL -> `+https://github.com/sekkedev/smartscrape` |

## Validation

- `grep -ri 9ny4` (excluding `.git`, `node_modules`): no matches after the change
- `npx prettier --check` on the four Prettier-covered changed files: clean
- `npm run typecheck`: passes across all workspaces

Closes #111
